### PR TITLE
Cherry-picking from Stefano Martina's PR only the commit with the "good" fix

### DIFF
--- a/src/Materialway.cpp
+++ b/src/Materialway.cpp
@@ -749,7 +749,11 @@ namespace material {
 
         //if the module is in z plus
         if(module.maxZ() > 0) {
-          attachPoint = discretize(module.maxZ());
+          if(module.maxZ() <= currLayer_->maxZ()) {
+            attachPoint = discretize(module.maxZ());
+          } else {
+            attachPoint = discretize(currLayer_->maxZ());
+          }
           section = startLayer;
           while (section->maxZ() < attachPoint + sectionTolerance) {
             if(!section->hasNextSection()) {


### PR DESCRIPTION
The original commit says "Fix for correct material routing in case of barrel modules with maxZ greater than the one of the corresponding layer"
And this was tested by Gabrielle to be working as expected.