### PR TITLE
Adding detailed information on material budget for services

### DIFF
--- a/include/Squid.h
+++ b/include/Squid.h
@@ -97,7 +97,7 @@ namespace insur {
     bool reportBandwidthSite();
     bool reportTriggerProcessorsSite();
     bool reportPowerSite();
-    bool reportMaterialBudgetSite();
+    bool reportMaterialBudgetSite(bool debugServices);
     bool reportResolutionSite();
     bool reportTriggerPerformanceSite(bool extended);
     bool reportNeighbourGraphSite();

--- a/include/Vizard.h
+++ b/include/Vizard.h
@@ -162,8 +162,8 @@ namespace insur {
 
     // TODO: all these functions should check if the corresponding data is present
     // and return true or false, depending if they created the output or not
-    void histogramSummary(Analyzer& a, RootWSite& site);
-    void histogramSummary(Analyzer& a, RootWSite& site, std::string alternativeName);
+    void histogramSummary(Analyzer& a, MaterialBudget& materialBudget, bool debugServices, RootWSite& site);
+    void histogramSummary(Analyzer& a, MaterialBudget& materialBudget, bool debugServices, RootWSite& site, std::string alternativeName);
     void weigthSummart(Analyzer& a, WeightDistributionGrid& weightGrid, RootWSite& site, std::string alternativeName);
     bool geometrySummary(Analyzer& a, Tracker& tracker, SimParms& simparms, InactiveSurfaces* inactive, RootWSite& site, std::string alternativeName = "");
     bool bandwidthSummary(Analyzer& analyzer, Tracker& tracker, SimParms& simparms, RootWSite& site);
@@ -173,6 +173,7 @@ namespace insur {
     bool taggedErrorSummary(Analyzer& a, RootWSite& site);
     bool triggerSummary(Analyzer& a, Tracker& tracker, RootWSite& site, bool extended);
     bool neighbourGraphSummary(InactiveSurfaces& is, RootWSite& site); 
+    void drawInactiveSurfacesSummary(MaterialBudget& mb, RootWPage& page); 
     bool additionalInfoSite(const std::set<string>& includeSet, const std::string& settingsfile,
                             const std::string& matfile, const std::string& pixmatfile,
                             bool defaultMaterial, bool defaultPixelMaterial,

--- a/src/Analyzer.cpp
+++ b/src/Analyzer.cpp
@@ -737,7 +737,6 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 
 }
 
-
 void Analyzer::analyzePower(Tracker& tracker) {
   computeIrradiatedPowerConsumption(tracker);
   preparePowerHistograms();

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -608,11 +608,11 @@ namespace insur {
    * Produces the output of the analysis of the material budget analysis
    * @return True if there were no errors during processing, false otherwise
    */
-  bool Squid::reportMaterialBudgetSite() {
+  bool Squid::reportMaterialBudgetSite(bool debugServices) {
     if (mb) {
       startTaskClock("Creating material budget report");
-      v.histogramSummary(a, site, "outer");
-      if (pm) v.histogramSummary(pixelAnalyzer, site, "pixel");
+      v.histogramSummary(a, *mb, debugServices, site, "outer");
+      if (pm) v.histogramSummary(pixelAnalyzer, *pm, debugServices, site, "pixel");
       v.weigthSummart(a, weightDistributionTracker, site, "outer");
       stopTaskClock();
       return true;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -4591,33 +4591,40 @@ namespace insur {
 
   
   void Vizard::drawInactiveSurfacesSummary(MaterialBudget& materialBudget, RootWPage& myPage) {
+    Tracker& myTracker = materialBudget.getTracker();
+    std::string myTrackerName = myTracker.myid();
+
     RootWContent& myContent = myPage.addContent("Service detials");
 
     auto& barrelServices = materialBudget.getInactiveSurfaces().getBarrelServices();
     auto& endcapServices = materialBudget.getInactiveSurfaces().getEndcapServices();
     auto& supports = materialBudget.getInactiveSurfaces().getSupports();
 
+    // We put all services inside the same container
     std::vector<InactiveElement> allServices;
-
     allServices.reserve( barrelServices.size() + endcapServices.size() + supports.size() ); // preallocate memory
     allServices.insert( allServices.end(), barrelServices.begin(), barrelServices.end() );
     allServices.insert( allServices.end(), endcapServices.begin(), endcapServices.end() );
     allServices.insert( allServices.end(), supports.begin(), supports.end() );
 
+    // Counting services with an ad-hoc index
     int serviceId = 0;
     double z1, z2, r1, r2, length, il, rl;
     double mass;
     std::stringstream myStringStream;
 
     // Graphic representation of the services in the rz plane
-    TCanvas* servicesCanvas = new TCanvas("servicesCanvas", "servicesCanvas", 2400, 600); // TODO Factory for canvases?!
+    double maxR = myTracker.maxR()*1.2;
+    double maxZ = myTracker.maxZ()*1.2;
+    TCanvas* servicesCanvas = new TCanvas("servicesCanvas", "servicesCanvas"); // TODO Factory for canvases?!
     servicesCanvas->cd();
-    TH2D* myFrame = new TH2D("aServicesFrame", ";z [mm];r [mm]", 200, -3000, 3000, 100, 0, 1200);
-    myFrame->Draw();
+    TH2D* aServicesFrame = new TH2D("aServicesFrame", ";z [mm];r [mm]", 200, -maxZ, maxZ, 100, 0, maxR);
+    maxZ=0; maxR=0;
+    aServicesFrame->Draw();
     TBox* myBox;
     TText* myText;
 
-    myStringStream << "ID/I:z1/D:z2/D:r1/D:r2/D:Element/C:mass/D:mass_per_length/D:rl/D:il/D:local/I" << std::endl;
+    myStringStream << "serviceID/I,elementID/I,z1/D,z2/D,r1/D,r2/D,Element/C,mass/D,mass_per_length/D,rl/D,il/D,local/I" << std::endl;
 
     for (auto& iter : allServices) {
       z1 = iter.getZOffset();
@@ -4628,46 +4635,59 @@ namespace insur {
       rl = iter.getInteractionLength();
       il = iter.getRadiationLength();
 
+      // Update the maxZ and maxR with respect to the inactive surfaces
+      if (fabs(z1)>maxZ) maxZ=fabs(z1);
+      if (fabs(z2)>maxZ) maxZ=fabs(z2);
+      if (fabs(r1)>maxR) maxR=fabs(r1);
+      if (fabs(r2)>maxR) maxR=fabs(r2);
+
       bool isEmpty = true;
 
       const std::map<std::string, double>& localMasses = iter.getLocalMasses();
       const std::map<std::string, double>& exitingMasses = iter.getExitingMasses();
 
+      int elementId=0;
       for (auto& massIt : localMasses) {
 	mass = massIt.second;
 	if (mass==0) continue;
 	isEmpty=false;
-	myStringStream << serviceId << " "
-		       << z1 << " "
-		       << z2 << " "
-		       << r1 << " "
-		       << r2 << " "
-		       << massIt.first << " "
-		       << mass << " "
-		       << mass/length << " "
-                       << rl << " "
-                       << il << " " 
-                       << " 1" << std::endl;
+	myStringStream << serviceId << ","
+                       << elementId++ << ","
+		       << z1 << ","
+		       << z2 << ","
+		       << r1 << ","
+		       << r2 << ","
+		       << massIt.first << ","
+		       << mass << ","
+		       << mass/length << ","
+                       << rl << ","
+                       << il << "," 
+                       << "1" << std::endl;
       }
       for (auto& massIt : exitingMasses) {
 	mass = massIt.second;
 	if (mass==0) continue;
 	isEmpty=false;
-	myStringStream << serviceId << " "
-		       << z1 << " "
-		       << z2 << " "
-		       << r1 << " "
-		       << r2 << " "
-		       << massIt.first << " "
-		       << mass << " "
-		       << mass/length << " 0" << std::endl;
+	myStringStream << serviceId << ","
+                       << elementId++ << ","
+		       << z1 << ","
+		       << z2 << ","
+		       << r1 << ","
+		       << r2 << ","
+		       << massIt.first << ","
+		       << mass << ","
+		       << mass/length << ","
+                       << rl << ","
+                       << il << "," 
+                       << "1" << std::endl;
       }
 
       if (!isEmpty) {
 	myBox = new TBox(z1, r1, z2, r2);
 	myBox->SetLineColor(kBlack);
-	myBox->SetFillStyle(0);
-	myBox->Draw();
+	myBox->SetFillStyle(3003);
+	myBox->SetFillColor(kGray);
+	myBox->Draw("l");
 	
 	myText = new TText((z1+z2)/2, (r1+r2)/2, Form("%d", serviceId));
 	myText->SetTextAlign(22);
@@ -4675,19 +4695,17 @@ namespace insur {
 	myText->Draw();
       }
     
-
-    
       serviceId++;
     }
+    
+    aServicesFrame->GetXaxis()->SetRangeUser(-maxZ, maxZ);
+    aServicesFrame->GetYaxis()->SetRangeUser(0, maxR);
 
     RootWImage& servicesImage = myContent.addImage(servicesCanvas, 1800, 400);
     servicesImage.setComment("Display of the rz positions of the service volumes. Ignoring services with no material.");
     servicesImage.setName("InactiveSurfacesPosition");
 
-    Tracker& myTracker = materialBudget.getTracker();
-    std::string myName = myTracker.myid();
-    
-    RootWTextFile* myTextFile = new RootWTextFile(Form("inactiveSurfacesMaterials_%s", myName.c_str()), "file containing all the materials");
+    RootWTextFile* myTextFile = new RootWTextFile(Form("inactiveSurfacesMaterials_%s.csv", myTrackerName.c_str()), "file containing all the materials");
     myTextFile->addText(myStringStream.str());
     myContent.addItem(myTextFile);
     

--- a/src/tklayout.cpp
+++ b/src/tklayout.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     ("resolution,r", "Report resolution analysis.")
     ("trigger,t", "Report base trigger analysis.")
     ("trigger-ext,T", "Report extended trigger analysis.\n\t(implies 't')")
-    ("debug-services,d", "Service routing debug page")
+    ("debug-services,d", "Service additional debug info")
     ("all,a", "Report all analyses, except extended\ntrigger and debug page. (implies all other relevant\nreport options)")
     ("graph,g", "Build and report neighbour graph.")
     ("xml", po::value<std::string>(&xmldir)->implicit_value(""), "Produce XML output files for materials.\nOptional arg specifies the subdirectory\nof the output directory (chosen via inst\nscript) where to create XML files.\nIf not supplied, the config file name (minus extension)\nwill be used as subdir.")
@@ -144,7 +144,7 @@ int main(int argc, char* argv[]) {
       //if (squid.createMaterialBudget(verboseMaterial)) {
         if ( vm.count("all") || vm.count("material") || vm.count("resolution") ) {
           if (!squid.pureAnalyzeMaterialBudget(mattracks, vm.count("all") || vm.count("resolution"))) return EXIT_FAILURE;
-          if ((vm.count("all") || vm.count("material"))  && !squid.reportMaterialBudgetSite()) return EXIT_FAILURE;
+          if ((vm.count("all") || vm.count("material"))  && !squid.reportMaterialBudgetSite(vm.count("debug-services"))) return EXIT_FAILURE;
           if ((vm.count("all") || vm.count("resolution"))  && !squid.reportResolutionSite()) return EXIT_FAILURE;	  
         }
         if (vm.count("graph") && !squid.reportNeighbourGraphSite()) return EXIT_FAILURE;


### PR DESCRIPTION
With this new feature you can now run tkLayout with the -d option to get detailed information regarding the service materials.

Under the tab 'material' in a section named 'Service details' you will find a new plot indicating the positions of each service volume, identified by a number, for example:

![example](https://cloud.githubusercontent.com/assets/584822/7190703/4011cd2e-e488-11e4-91e6-0f19b31a0224.png)

Correspondingly a comma-separated file is linked next to this picture, where for each inactive volume all the materials are listed.
The table can easily be imported in root with the following syntax:
   TTree exampleTree;
   exampleTree.ReadFile("inactiveSurfacesMaterials_Outer.csv");