### PR TITLE
Adding material summary computation also for pixel

### DIFF
--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -490,6 +490,11 @@ namespace insur {
       startTaskClock("Computing the weight summary");
       a.computeWeightSummary(*mb);
       stopTaskClock();
+      if (pm) {
+        startTaskClock("Computing the weight summary for pixels");
+        pixelAnalyzer.computeWeightSummary(*pm);
+        stopTaskClock();
+      }
       if (triggerResolution) {
         startTaskClock("Estimating tracking resolutions");
         a.analyzeTaggedTracking(*mb,
@@ -578,6 +583,7 @@ namespace insur {
       v.histogramSummary(a, *mb, debugServices, site, "outer");
       if (pm) v.histogramSummary(pixelAnalyzer, *pm, debugServices, site, "pixel");
       v.weigthSummart(a, weightDistributionTracker, site, "outer");
+      if (pm) v.weigthSummart(pixelAnalyzer, weightDistributionPixel, site, "pixel");
       stopTaskClock();
       return true;
     }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -369,7 +369,9 @@ namespace insur {
    * @param a A reference to the analysing class that examined the material budget and filled the histograms
    * @param site the RootWSite object for the output
    * @param name a qualifier that goes in parenthesis in the title (outer or strip, for example)
-   */  
+   */ 
+ 
+  // TODO: if weightGrid is actually unused, then remove it
   void Vizard::weigthSummart(Analyzer& a, WeightDistributionGrid& weightGrid, RootWSite& site, std::string name) {
     RootWContent* myContent;
 


### PR DESCRIPTION
Solves a bug reported by Giacomo, with pixel materials not being shown in the main summary page and the corresponding detailed mass breakdown tab not being computed at all.