### PR TITLE
Fixing  bug to build correctly wedge-shaped sensors in disc region

### DIFF
--- a/include/Disk.h
+++ b/include/Disk.h
@@ -36,8 +36,8 @@ private:
   Property<double, NoDefault> innerRadius;
   Property<double, NoDefault> outerRadius;
   Property<double, NoDefault> bigDelta;
-  Property<double, Default> rOverlap;
-  Property<int, Default> bigParity;
+  Property<double, Default>   rOverlap;
+  Property<int   , Default>   bigParity;
 
   PropertyNode<int> ringNode;
   PropertyNodeUnique<std::string> stationsNode;
@@ -48,8 +48,9 @@ private:
 
   double averageZ_ = 0;
 public:
-  Property<int, NoDefault> numRings;
+  Property<int, NoDefault>    numRings;
   Property<double, NoDefault> zError;
+  Property<double, NoDefault> zHalfLength;
   Property<double, NoDefault> buildZ;
   Property<double, NoDefault> placeZ;
 
@@ -60,17 +61,18 @@ public:
   Disk() :
     materialObject_(MaterialObject::LAYER),
     flangeConversionStation_(nullptr),
-    numRings("numRings", parsedAndChecked()),
-    innerRadius("innerRadius", parsedAndChecked()),
-    outerRadius("outerRadius", parsedAndChecked()),
-    bigDelta("bigDelta", parsedAndChecked()),
-    zError("zError", parsedAndChecked()),
-    rOverlap("rOverlap", parsedOnly(), 1.),
-    bigParity("bigParity", parsedOnly(), 1),
-    buildZ("buildZ", parsedOnly()),
-    placeZ("placeZ", parsedOnly()),
-    ringNode("Ring", parsedOnly()),
-    stationsNode("Station", parsedOnly())
+    numRings(    "numRings"   , parsedAndChecked()),
+    innerRadius( "innerRadius", parsedAndChecked()),
+    outerRadius( "outerRadius", parsedAndChecked()),
+    bigDelta(    "bigDelta"   , parsedAndChecked()),
+    zError(      "zError"     , parsedAndChecked()),
+    zHalfLength( "zHalfLength", parsedAndChecked()),
+    rOverlap(    "rOverlap"   , parsedOnly(), 1.),
+    bigParity(   "bigParity"  , parsedOnly(), 1),
+    buildZ(      "buildZ"     , parsedOnly()),
+    placeZ(      "placeZ"     , parsedOnly()),
+    ringNode(    "Ring"       , parsedOnly()),
+    stationsNode("Station"    , parsedOnly())
   {}
 
   void setup() {

--- a/include/Ring.h
+++ b/include/Ring.h
@@ -51,12 +51,14 @@ public:
   enum BuildDirection { TOPDOWN, BOTTOMUP };
 
   ReadonlyProperty<double, NoDefault> smallDelta;
+  ReadonlyProperty<double, Computable> maxModuleThickness;
   Property<BuildDirection, NoDefault> buildDirection;
+  Property<int   , AutoDefault> disk;
   Property<double, NoDefault> buildStartRadius;
   Property<double, NoDefault> buildCropRadius;
   Property<double, Computable> minZ, maxZ;
-  Property<int, NoDefault> numModules; // if set forces the number of modules (in phi) to be exactly numModules
-  ReadonlyProperty<double, Computable> maxModuleThickness;
+  Property<int   , NoDefault> numModules; // if set forces the number of modules (in phi) to be exactly numModules
+
   Property<double, Default> zRotation;
   Property<double, Default> ringOuterRadius;
   Property<double, Default> ringInnerRadius;

--- a/include/Ring.h
+++ b/include/Ring.h
@@ -37,18 +37,19 @@ class Ring : public PropertyObject, public Buildable, public Identifiable<int>, 
 
   Property<ModuleShape, NoDefault> moduleShape;
   Property<double, Default> phiOverlap;
-  Property<bool, Default> requireOddModsPerSlice;
-  Property<int, Default> phiSegments;
-  Property<int, Default> additionalModules;
-  Property<bool, Default> alignEdges;
+  Property<bool  , Default> requireOddModsPerSlice;
+  Property<int   , Default> phiSegments;
+  Property<int   , Default> additionalModules;
+  Property<bool  , Default> alignEdges;
   Property<double, Default> ringGap;
-  Property<int, Default> smallParity;
+  Property<int   , Default> smallParity;
 
   double minRadius_, maxRadius_;
+  double averageZ_ = 0;
 
 public:
   enum BuildDirection { TOPDOWN, BOTTOMUP };
-  Property<int, AutoDefault> disk;
+
   ReadonlyProperty<double, NoDefault> smallDelta;
   Property<BuildDirection, NoDefault> buildDirection;
   Property<double, NoDefault> buildStartRadius;
@@ -60,9 +61,8 @@ public:
   Property<double, Default> ringOuterRadius;
   Property<double, Default> ringInnerRadius;
 
-
-  double minR() const { return minRadius_; }
-  double maxR() const { return maxRadius_; }
+  double minR()      const { return minRadius_; }
+  double maxR()      const { return maxRadius_; }
   double thickness() const { return smallDelta()*2 + maxModuleThickness(); } 
 
   const Container& modules() const { return modules_; }
@@ -102,6 +102,7 @@ public:
 
   void translateZ(double z);
   void mirrorZ();
+  double averageZ() const { return averageZ_; }
   void cutAtEta(double eta);
 
   void accept(GeometryVisitor& v) { 

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -48,7 +48,6 @@ void Disk::buildBottomUp(const vector<double>& buildDsDistances) {
       // Remember that disc put always in to the centre of endcap
       double shiftZ        = parity > 0 ? -zHalfLength() : +zHalfLength();
 
-      zError(10);
       // Calculate shift in Z due to beam spot
       double errorShiftZ   = parity > 0 ? -zError() : +zError();
 

--- a/src/Endcap.cpp
+++ b/src/Endcap.cpp
@@ -59,17 +59,24 @@ void Endcap::build() {
       Disk* diskp = GeometryFactory::make<Disk>();
       diskp->myid(i);
 
+      // Standard is to build & calculate parameters for the central disc (in the middle)
       diskp->buildZ((innerZ() + outerZ())/2);
+
+      // Apply correct offset for each disc versus middle position
       double offset = pow(alpha, i-1) * innerZ();
       diskp->placeZ(offset);
 
+      // Store parameters in a tree
       diskp->store(propertyTree());
       if (diskNode.count(i) > 0) diskp->store(diskNode.at(i));
 
-      diskp->zError(diskp->zError() + (outerZ()-innerZ())/2);
+      // To test the extreme cases -> one needs to test either first or last layer (based on parity)
+      diskp->zHalfLength((outerZ()-innerZ())/2.);
 
+      // Build
       diskp->build(maxDsDistances);
 
+      // Mirror discs
       Disk* diskn = GeometryFactory::clone(*diskp);
       diskn->mirrorZ();
 

--- a/src/GeometricModule.cpp
+++ b/src/GeometricModule.cpp
@@ -194,16 +194,13 @@ void WedgeModule::build() {
 
     // Add a check: if the module overcomes the max rho
     // it must be cut.
-
-    // Doesn't work as expected -> creates loop to exactly catch the 
-    // edge (problem when shifting new layer by overlap ...)
-    //if (buildCropDistance.state() && dfar > buildCropDistance()) {
-    //  amountCropped_ = dfar - buildCropDistance();
-    //  b1 = 0;
-    //  b2 = buildCropDistance() - d;
-    //  h2 = h1/d * buildCropDistance();
-    //  cropped_ = true;
-    //}
+    if (buildCropDistance.state() && dfar > buildCropDistance()) {
+      amountCropped_ = dfar - buildCropDistance();
+      b1 = 0;
+      b2 = buildCropDistance() - d;
+      h2 = h1/d * buildCropDistance();
+      cropped_ = true;
+    }
 
     // Some member variable computing:
     area_     = fabs((b1+b2) * (h2+h1));

--- a/src/GeometricModule.cpp
+++ b/src/GeometricModule.cpp
@@ -194,13 +194,16 @@ void WedgeModule::build() {
 
     // Add a check: if the module overcomes the max rho
     // it must be cut.
-    if (buildCropDistance.state() && dfar > buildCropDistance()) {
-      amountCropped_ = dfar - buildCropDistance();
-      b1 = 0;
-      b2 = buildCropDistance() - d;
-      h2 = h1/d * buildCropDistance();
-      cropped_ = true;
-    }
+
+    // Doesn't work as expected -> creates loop to exactly catch the 
+    // edge (problem when shifting new layer by overlap ...)
+    //if (buildCropDistance.state() && dfar > buildCropDistance()) {
+    //  amountCropped_ = dfar - buildCropDistance();
+    //  b1 = 0;
+    //  b2 = buildCropDistance() - d;
+    //  h2 = h1/d * buildCropDistance();
+    //  cropped_ = true;
+    //}
 
     // Some member variable computing:
     area_     = fabs((b1+b2) * (h2+h1));
@@ -211,14 +214,16 @@ void WedgeModule::build() {
   //dist_     = d;
   //aspectRatio_ = length_/(h1+h2);
 
+    // Right-handed drawing, (not left-handed as previously)
     basePoly_ << (XYZVector( length_/2., maxWidth_/2., 0))
-              << (XYZVector( length_/2.,-maxWidth_/2., 0))
+              << (XYZVector(-length_/2., minWidth_/2., 0))
               << (XYZVector(-length_/2.,-minWidth_/2., 0))
-              << (XYZVector(-length_/2., minWidth_/2., 0));
+              << (XYZVector( length_/2.,-maxWidth_/2., 0));
+
+    cleanup();
+    builtok(true);
   }
   catch (PathfulException& pe) { pe.pushPath(*this, myid()); throw; }
-  cleanup();
-  builtok(true);
 }
 
 define_enum_strings(ModuleShape) = { "rectangular", "wedge" };

--- a/src/Ring.cpp
+++ b/src/Ring.cpp
@@ -32,7 +32,7 @@ double Ring::computeTentativePhiAperture(double moduleWaferDiameter, double minR
   double y = pow(r/l, 2);
   double x = solvex(y);
 
-  bool   calculated = false;
+
   double tempd;
 
   int i = 0;
@@ -42,22 +42,15 @@ double Ring::computeTentativePhiAperture(double moduleWaferDiameter, double minR
     x = solvex(y);
 
     tempd = compute_d(x, y, l);
-    if (fabs(minRadius - tempd)<1e-03) { //1e-15 {
 
-      calculated = true;
-      break;
-    }
+    if (fabs(minRadius - tempd)<1e-15) break;
   }
 
-  // TODO: Just fix, needs to be done properly
-  // Starting value if algorithm fails
-  double alpha = 2*M_PI/10.;
-
-  if (!calculated) {
-    logWARNING("Maximum number of iterations hit while computing wedge geometry, uses default: 10 number of modules in a ring ");
-    //std::cout << ">>> " << "Maximum number of iterations hit while computing wedge geometry" << std::endl;
+  if (i >= MAX_WEDGE_CALC_LOOPS) {
+    //logWarning("Maximum number of iterations hit while computing wedge geometry");
   }
-  else alpha = asin(sqrt(x)) * 2;
+
+  double alpha = asin(sqrt(x)) * 2;
 
   return alpha;
 }
@@ -66,11 +59,10 @@ std::pair<double, int> Ring::computeOptimalRingParametersWedge(double moduleWafe
   double delta = phiOverlap()/minRadius;// SM: The needed overlap becomes an angle delta by
   //     checking the unsafest point (r=r_min)
 
-  double tentativeAlpha   = computeTentativePhiAperture(moduleWaferDiameter, minRadius) - delta;
-
-  float  tentativeNumMods = 2*M_PI / tentativeAlpha;
-  int    optimalNumMods   = (!requireOddModsPerSlice()? round(tentativeNumMods/phiSegments() + additionalModules()) : roundToOdd(tentativeNumMods/phiSegments()) + additionalModules()) * phiSegments();
-  float  optimalAlpha     = 2*M_PI/optimalNumMods + delta;
+  double tentativeAlpha = computeTentativePhiAperture(moduleWaferDiameter, minRadius) - delta;
+  float tentativeNumMods = 2*M_PI / tentativeAlpha; 
+  int optimalNumMods = (!requireOddModsPerSlice()? round(tentativeNumMods/phiSegments()) : roundToOdd(tentativeNumMods/phiSegments()) + additionalModules()) * phiSegments();
+  float optimalAlpha = 2*M_PI/optimalNumMods + delta;
 
   return std::make_pair(optimalAlpha, optimalNumMods);
 }
@@ -85,6 +77,7 @@ std::pair<double, int> Ring::computeOptimalRingParametersRectangle(double module
 
   return std::make_pair(optimalAlpha, optimalNumMods);
 }
+
 
 void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta) {
   double alignmentRotation = alignEdges() ? 0.5 : 0.;


### PR DESCRIPTION
Several bugs fixed:

- wedge-shaped polygons were flipped
- a small bug appeared when positioning sensors in discs (not correctly calculated optimal position to have all discs of the same layout taking into account either zError or rOverlap)