### PR TITLE
Precise drawings and better report of ring coordinates

### DIFF
--- a/include/PlotDrawer.h
+++ b/include/PlotDrawer.h
@@ -186,8 +186,8 @@ struct CheckPhiIndex {
 
 
 struct Rounder {
-  static const int mmFraction = 10;
-  int round(double x) { return floor(x*mmFraction+0.5)/mmFraction; }
+  static const int mmFraction = 1000;  // Drawing with 1 micrometer precision
+  int round(double x) { return floor(x*mmFraction+0.5); }
 };
 
 struct XY : public std::pair<int, int>, private Rounder {
@@ -224,10 +224,10 @@ template<class CoordType> class LineGetter {
   CoordTypeY maxy_, miny_;
 public:
   LineGetter() : maxx_(std::numeric_limits<CoordTypeX>::min()), minx_(std::numeric_limits<CoordTypeX>::max()), maxy_(std::numeric_limits<CoordTypeY>::min()), miny_(std::numeric_limits<CoordTypeY>::max()) {}
-  CoordTypeX maxx() const { return maxx_; }
-  CoordTypeX minx() const { return minx_; }
-  CoordTypeY maxy() const { return maxy_; }
-  CoordTypeY miny() const { return miny_; }
+  CoordTypeX maxx() const { return double(maxx_)/Rounder::mmFraction; }
+  CoordTypeX minx() const { return double(minx_)/Rounder::mmFraction; }
+  CoordTypeY maxy() const { return double(maxy_)/Rounder::mmFraction; }
+  CoordTypeY miny() const { return double(miny_)/Rounder::mmFraction; }
   TPolyLine* operator()(const Module& m) {
     std::set<CoordType> xy; // duplicate detection
     double x[] = {0., 0., 0., 0., 0.}, y[] = {0., 0., 0., 0., 0.};
@@ -235,8 +235,8 @@ public:
     for (int i=0; i<4; i++) {
       CoordType c(m.basePoly().getVertex(i));
       if (xy.insert(c).second == true) {
-        x[j] = c.first;
-        y[j++] = c.second;
+        x[j] = double(c.first)/Rounder::mmFraction;
+        y[j++] = double(c.second)/Rounder::mmFraction;
       } 
       maxx_ = MAX(c.first, maxx_);
       minx_ = MIN(c.first, minx_);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1213,7 +1213,9 @@ namespace insur {
         diskTable->setContent(2, 0, "# mod");
         ringTable->setContent(0, 0, "Ring");
         ringTable->setContent(1, 0, "r"+subStart+"min"+subEnd);
-        ringTable->setContent(2, 0, "r"+subStart+"max"+subEnd);
+        ringTable->setContent(2, 0, "r"+subStart+"low"+subEnd);
+        ringTable->setContent(3, 0, "r"+subStart+"high"+subEnd);
+        ringTable->setContent(4, 0, "r"+subStart+"max"+subEnd);
       }
 
       void visit(const SimParms& s) override { nMB = s.numMinBiasEvents(); }
@@ -1290,7 +1292,9 @@ namespace insur {
           int aRing=(*typeIt).first;
           ringTable->setContent(0, aRing, aRing);
           ringTable->setContent(1, aRing, anEC->minR(), coordPrecision);
-          ringTable->setContent(2, aRing, anEC->minR()+anEC->length(), coordPrecision);
+          ringTable->setContent(2, aRing, sqrt(pow(anEC->minR(),2)+pow(anEC->minWidth()/2.,2)), coordPrecision); // Ugly, this should be accessible as a method
+          ringTable->setContent(3, aRing, anEC->minR()+anEC->length(), coordPrecision);
+          ringTable->setContent(4, aRing, anEC->maxR(), coordPrecision);
         }
       }
     };


### PR DESCRIPTION
BUGFIX: drawings were not rounded to 0.1mm as intended, but (since an int was used to store the coordinates to be drawn) their contour was rounded to 1mm. Too crude!
I fixed the bug and also changed the rounding to 1 micrometer. The change was tested and working

More information on the main page regarding the positions of endcap modules.
Now we report in detail the minimum and maximum radius (useful to know the ring's "envelope) and also the "low" and "high" radius (for which the ring is expected to be fully hermetic)
