### PR TITLE
Bug in minR calculation - starting value 0 instead of double::max

### DIFF
--- a/include/Endcap.h
+++ b/include/Endcap.h
@@ -41,9 +41,9 @@ public:
   {}
 
   void setup() {
-    maxR.setup([&]() { double max = 0; for (const auto& d : disks_) { max = MAX(max, d.maxR()); } return max; });
-    minR.setup([&]() { double min = 0; for (const auto& d : disks_) { min = MIN(min, d.minR()); } return min; });
-    maxZ.setup([&]() { double max = 0; for (const auto& d : disks_) { if(d.maxZ() > 0 ) max = MAX(max, d.maxZ()); } return max; });
+    maxR.setup([&]() { double max = 0;                                  for (const auto& d : disks_) { max = MAX(max, d.maxR()); } return max; });
+    minR.setup([&]() { double min = std::numeric_limits<double>::max(); for (const auto& d : disks_) { min = MIN(min, d.minR()); } return min; });
+    maxZ.setup([&]() { double max = 0;                                  for (const auto& d : disks_) { if(d.maxZ() > 0 ) max = MAX(max, d.maxZ()); } return max; });
     minZ.setup([&]() { double min = std::numeric_limits<double>::max(); for (const auto& d : disks_) { if(d.minZ() > 0 ) min = MIN(min, d.minZ()); } return min; });
   }
 


### PR DESCRIPTION
Found a bug in Endcap class. Setup function calculated wrongly the minR value. It was alwasy 0 independantly on the actual minimum radius value. The reason was in a wrong initialization of minR value in the algorithm.