### PR TITLE
Implemented Support structures at the end-cap level

### DIFF
--- a/include/Barrel.h
+++ b/include/Barrel.h
@@ -11,65 +11,56 @@
 #include "global_funcs.h"
 #include "Property.h"
 #include "Layer.h"
-#include "SupportStructure.h"
 #include "Visitable.h"
 
-using std::string;
-using std::vector;
-using material::SupportStructure;
+namespace material {
+  class SupportStructure;
+}
 
 class Barrel : public PropertyObject, public Buildable, public Identifiable<string>, Clonable<Barrel>, public Visitable {
- public:
-  typedef PtrVector<Layer> Container;
-  typedef PtrVector<SupportStructure> SupportStructures;
+
  private:
-  Container layers_;
+  typedef boost::ptr_vector<Layer>                      Container;
+  typedef boost::ptr_vector<material::SupportStructure> SupportStructures;
+
+  Container         layers_;
   SupportStructures supportStructures_;
 
   Property<double, NoDefault> innerRadius;
   Property<double, NoDefault> outerRadius;
-  Property<bool, Default> sameRods;
-  Property<double, Default> barrelRotation;
-  Property<double, Default> supportMarginOuter;
-  Property<double, Default> supportMarginInner;
-  Property<bool, Default> innerRadiusFixed;
-  Property<bool, Default> outerRadiusFixed;
+  Property<bool  , Default>   sameRods;
+  Property<double, Default>   barrelRotation;
+  Property<double, Default>   supportMarginOuter;
+  Property<double, Default>   supportMarginInner;
+  Property<bool  , Default>   innerRadiusFixed;
+  Property<bool  , Default>   outerRadiusFixed;
   
-  PropertyNode<int> layerNode;
+  PropertyNode<int>               layerNode;
   PropertyNodeUnique<std::string> supportNode;
+
  public:
-  Property<int, NoDefault> numLayers;
-  ReadonlyProperty<double, Computable> maxZ, minZ;
-  ReadonlyProperty<double, Computable> maxR, minR;
-  ReadonlyProperty<bool, Default> skipServices;
-  
   Barrel() : 
-      numLayers("numLayers", parsedAndChecked()),
-      innerRadius("innerRadius", parsedAndChecked()),
-      outerRadius("outerRadius", parsedAndChecked()),
-      innerRadiusFixed("innerRadiusFixed", parsedAndChecked(), true),
-      outerRadiusFixed("outerRadiusFixed", parsedAndChecked(), true),
-      sameRods("sameRods", parsedAndChecked(), false),
-      barrelRotation("barrelRotation", parsedOnly(), 0.),
+      numLayers(         "numLayers"         , parsedAndChecked()),
+      innerRadius(       "innerRadius"       , parsedAndChecked()),
+      outerRadius(       "outerRadius"       , parsedAndChecked()),
+      innerRadiusFixed(  "innerRadiusFixed"  , parsedAndChecked(), true),
+      outerRadiusFixed(  "outerRadiusFixed"  , parsedAndChecked(), true),
+      sameRods(          "sameRods"          , parsedAndChecked(), false),
+      barrelRotation(    "barrelRotation"    , parsedOnly(), 0.),
       supportMarginOuter("supportMarginOuter", parsedOnly(), 2.),
       supportMarginInner("supportMarginInner", parsedOnly(), 2.),
-      skipServices("skipServices", parsedOnly(), false), // broken, do not use
-      layerNode("Layer", parsedOnly()),
-      supportNode("Support", parsedOnly())
+      skipServices(      "skipServices"      , parsedOnly(), false), // broken, do not use
+      layerNode(         "Layer"             , parsedOnly()),
+      supportNode(       "Support"           , parsedOnly())
       {}
-  
   void setup() {
-    maxZ.setup([this]() { double max = 0; for (const auto& l : layers_) { max = MAX(max, l.maxZ()); } return max; });
+    maxZ.setup([this]() { double max = 0;                                  for (const auto& l : layers_) { max = MAX(max, l.maxZ()); } return max; });
     minZ.setup([this]() { double min = std::numeric_limits<double>::max(); for (const auto& l : layers_) { min = MIN(min, l.minZ()); } return min; });
-    maxR.setup([this]() { double max = 0; for (const auto& l : layers_) { max = MAX(max, l.maxR()); } return max; });
+    maxR.setup([this]() { double max = 0;                                  for (const auto& l : layers_) { max = MAX(max, l.maxR()); } return max; });
     minR.setup([this]() { double min = std::numeric_limits<double>::max(); for (const auto& l : layers_) { min = MIN(min, l.minR()); } return min; });
   }
-
   void build(); 
   void cutAtEta(double eta);
-
-  const Container& layers() const { return layers_; }
-
   void accept(GeometryVisitor& v) { 
     v.visit(*this); 
     for (auto& l : layers_) { l.accept(v); }
@@ -79,7 +70,13 @@ class Barrel : public PropertyObject, public Buildable, public Identifiable<stri
     for (const auto& l : layers_) { l.accept(v); }
   }
 
-  SupportStructures& supportStructures() {return supportStructures_;}
+  const Container& layers() const        { return layers_; }
+  SupportStructures& supportStructures() { return supportStructures_; }
+
+  Property<        int   , NoDefault>  numLayers;
+  ReadonlyProperty<double, Computable> maxZ, minZ;
+  ReadonlyProperty<double, Computable> maxR, minR;
+  ReadonlyProperty<bool  , Default>    skipServices;
 };
 
 #endif

--- a/include/Endcap.h
+++ b/include/Endcap.h
@@ -13,53 +13,62 @@
 #include "Disk.h"
 #include "Visitable.h"
 
+namespace material {
+  class SupportStructure;
+}
 
 class Endcap : public PropertyObject, public Buildable, public Identifiable<std::string>, public Visitable {
-  typedef boost::ptr_vector<Disk> Container;
 
-  Container disks_;
-  Property<double, NoDefault> barrelGap;
-  PropertyNode<int> diskNode;
-  
+ private:
+  typedef boost::ptr_vector<Disk>                       Container;
+  typedef boost::ptr_vector<material::SupportStructure> SupportStructures;
+
+  Container         disks_;
+  SupportStructures supportStructures_;
+
+  Property<double, NoDefault>     barrelGap;
+  PropertyNode<int>               diskNode;
+  PropertyNodeUnique<std::string> supportNode;
+
   vector<double> findMaxDsDistances();
-public:
-  Property<int, NoDefault> numDisks;
-  Property<double, NoDefault> barrelMaxZ;
-  Property<double, NoDefault> innerZ;
-  Property<double, NoDefault> outerZ;
-  ReadonlyProperty<double, Computable> maxZ, minZ;
-  ReadonlyProperty<double, Computable> maxR, minR;
-  ReadonlyProperty<bool, Default> skipServices;
 
+ public:
   Endcap() :
-      barrelGap("barrelGap", parsedOnly()),
-      numDisks("numDisks", parsedAndChecked()),
-      innerZ("minZ", parsedOnly()),
-      outerZ("maxZ", parsedAndChecked()),
+      barrelGap(   "barrelGap"   , parsedOnly()),
+      numDisks(    "numDisks"    , parsedAndChecked()),
+      innerZ(      "minZ"        , parsedOnly()),
+      outerZ(      "maxZ"        , parsedAndChecked()),
       skipServices("skipServices", parsedOnly(), false), // broken, do not use
-      diskNode("Disk", parsedOnly())
+      diskNode(    "Disk"        , parsedOnly()),
+      supportNode( "Support"     , parsedOnly())
   {}
-
   void setup() {
     maxR.setup([&]() { double max = 0;                                  for (const auto& d : disks_) { max = MAX(max, d.maxR()); } return max; });
     minR.setup([&]() { double min = std::numeric_limits<double>::max(); for (const auto& d : disks_) { min = MIN(min, d.minR()); } return min; });
     maxZ.setup([&]() { double max = 0;                                  for (const auto& d : disks_) { if(d.maxZ() > 0 ) max = MAX(max, d.maxZ()); } return max; });
     minZ.setup([&]() { double min = std::numeric_limits<double>::max(); for (const auto& d : disks_) { if(d.minZ() > 0 ) min = MIN(min, d.minZ()); } return min; });
   }
-
   void build();
   void cutAtEta(double eta);
-
-  const Container& disks() const { return disks_; }
-
-  void accept(GeometryVisitor& v) { 
-    v.visit(*this); 
+  void accept(GeometryVisitor& v) {
+    v.visit(*this);
     for (auto& d : disks_) { d.accept(v); }
   }
-  void accept(ConstGeometryVisitor& v) const { 
-    v.visit(*this); 
+  void accept(ConstGeometryVisitor& v) const {
+    v.visit(*this);
     for (const auto& d : disks_) { d.accept(v); }
   }
+
+  const Container& disks() const         { return disks_; }
+  SupportStructures& supportStructures() { return supportStructures_; }
+
+  Property<        int   , NoDefault>  numDisks;
+  Property<        double, NoDefault>  barrelMaxZ;
+  Property<        double, NoDefault>  innerZ;
+  Property<        double, NoDefault>  outerZ;
+  ReadonlyProperty<double, Computable> maxZ, minZ;
+  ReadonlyProperty<double, Computable> maxR, minR;
+  ReadonlyProperty<bool  , Default>    skipServices;
 };
 
 

--- a/include/SupportStructure.h
+++ b/include/SupportStructure.h
@@ -23,6 +23,7 @@ using insur::InactiveElement;
 using insur::InactiveSurfaces;
 
 class Barrel;
+class Endcap;
 
 namespace material {
   class MaterialTab;
@@ -53,13 +54,14 @@ namespace material {
     virtual ~SupportStructure() {};
     void buildInTracker();
     void buildInBarrel(Barrel& barrel);
+    void buildInEndcap(Endcap& endcap);
 
     void updateInactiveSurfaces(InactiveSurfaces& inactiveSurfaces);
     
   private:
     const double inactiveElementWidth = insur::volume_width;
-    const double autoLayerMarginUpper = 1.; //margins for the auto barrel support
-    const double autoLayerMarginLower = 2. + insur::volume_width; //upper is upper for the support (is lower for the layer) and viceversa
+    const double autoLayerMarginUpper = insur::geom_support_margin_bottom; //1.; // margins for the auto barrel support
+    const double autoLayerMarginLower = insur::geom_support_margin_top;    //2.; // + insur::geom_inactive_volume_width; //upper is upper for the support (is lower for the layer) and viceversa
 
     PropertyNodeUnique<std::string> componentsNode;
 

--- a/include/global_constants.h
+++ b/include/global_constants.h
@@ -27,6 +27,9 @@ namespace insur {
   static const double pixel_radius = 25.0;
   static const double z_threshold_service_zigzag = 100.0;
 
+  static const double geom_support_margin_bottom      = 1;      // mm
+  static const double geom_support_margin_top         = 2;      // mm
+
   /**
    * Visualisation constants: material parameters for active surfaces, services and supports, plus top volume padding.
    * The selected materials are completely arbitrary and only meant to distinguish one type of surface from another visually.

--- a/src/Barrel.cpp
+++ b/src/Barrel.cpp
@@ -1,5 +1,8 @@
 #include "Barrel.h"
 #include "messageLogger.h"
+#include "SupportStructure.h"
+
+using material::SupportStructure;
 
 void Barrel::cutAtEta(double eta) { 
   for (auto& l : layers_) l.cutAtEta(eta); 
@@ -36,6 +39,7 @@ void Barrel::build() {
 
   } catch (PathfulException& pe) { pe.pushPath(fullid(*this)); throw; }
 
+  // Supports defined within a Barrel
   for (auto& mapel : supportNode) {
     SupportStructure* s = new SupportStructure();
     s->store(propertyTree());
@@ -43,7 +47,6 @@ void Barrel::build() {
     s->buildInBarrel(*this);
     supportStructures_.push_back(s);
   }
-
 
   cleanup();
   builtok(true);

--- a/src/Endcap.cpp
+++ b/src/Endcap.cpp
@@ -1,5 +1,8 @@
 #include "Endcap.h"
 #include "messageLogger.h"
+#include "SupportStructure.h"
+
+using material::SupportStructure;
 
 void Endcap::cutAtEta(double eta) { 
   for (auto& d : disks_) d.cutAtEta(eta); 
@@ -88,7 +91,15 @@ void Endcap::build() {
     
   } catch (PathfulException& pe) { pe.pushPath(fullid(*this)); throw; }
 
+  // Supports defined within a Barrel
+  for (auto& mapel : supportNode) {
+    SupportStructure* s = new SupportStructure();
+    s->store(propertyTree());
+    s->store(mapel.second);
+    s->buildInEndcap(*this);
+    supportStructures_.push_back(s);
+  }
+
   cleanup();
   builtok(true);
 }
-

--- a/src/Materialway.cpp
+++ b/src/Materialway.cpp
@@ -1665,9 +1665,13 @@ namespace material {
           supportStructure.updateInactiveSurfaces(inactiveSurface_);
         }
       }
-      
       void visit (Barrel& barrel) {
         for (auto& supportStructure : barrel.supportStructures()) {
+          supportStructure.updateInactiveSurfaces(inactiveSurface_);
+        }
+      }
+      void visit (Endcap& endcap) {
+        for (auto& supportStructure : endcap.supportStructures()) {
           supportStructure.updateInactiveSurfaces(inactiveSurface_);
         }
       }

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -137,6 +137,18 @@ namespace insur {
         logERROR(ss);
       }
 
+      // Look for tag "Support" not associated with a concrete Tracker and build supports
+      childRange = getChildRange(pt, "Support");
+      std::for_each(childRange.first, childRange.second, [&](const ptree::value_type& kv) {
+
+        Support* support = new Support();
+        support->myid(kv.second.get_value(0));
+        support->store(kv.second);
+        support->build();
+        supports_.push_back(support);
+      });
+
+      // Read simulation parameters
       simParms_ = new SimParms();
 
       //iter between the default irradiation files vector and add each to simParm

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -42,6 +42,7 @@ void Tracker::build() {
       endcaps_.push_back(e);
     }
 
+    // Build support structures within tracker
     for (auto& mapel : supportNode) {
       SupportStructure* s = new SupportStructure();
       s->store(propertyTree());


### PR DESCRIPTION
Implemented Support structures at the end-cap level (same as for barrell), removed dependecy on Structure include files (using class def.), added constants instead of hard-coded numbers for Support margins, added more-readable INFO when building structures in barrel/end-cap.