### PR TITLE
Several bugs in Vizard::createXmlSite solved + added the metadata file to the XML tab

### DIFF
--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -748,7 +748,8 @@ namespace insur {
    
   void Squid::createAdditionalXmlSite(std::string xmlout) {
     std::string xmlpath = mainConfiguration.getXmlDirectory() + "/" + (xmlout.empty() ? baseName_ : xmlout) + "/";
-    std::string layoutpath = mainConfiguration.getLayoutDirectory() + "/" + (xmlout.empty() ? baseName_ : xmlout) + "/";
+    std::string layoutpath = mainConfiguration.getLayoutDirectory() + "/" + baseName_ +  "/";
+    //if (!xmlout.empty()) layoutpath = layoutpath + xmlout + "/";
     v.createXmlSite(site,xmlpath,layoutpath);
   }
 }

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -747,9 +747,9 @@ namespace insur {
   }
    
   void Squid::createAdditionalXmlSite(std::string xmlout) {
-    std::string xmlpath = mainConfiguration.getXmlDirectory() + "/" + (xmlout.empty() ? baseName_ : xmlout) + "/";
-    std::string layoutpath = mainConfiguration.getLayoutDirectory() + "/" + baseName_ +  "/";
-    v.createXmlSite(site,xmlpath,layoutpath);
+    std::string xmlPath = mainConfiguration.getXmlDirectory() + "/" + (xmlout.empty() ? baseName_ : xmlout) + "/";
+    std::string layoutPath = mainConfiguration.getLayoutDirectory() + "/" + baseName_ +  "/";
+    v.createXmlSite(site, xmlPath, layoutPath);
   }
 }
 

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -749,7 +749,6 @@ namespace insur {
   void Squid::createAdditionalXmlSite(std::string xmlout) {
     std::string xmlpath = mainConfiguration.getXmlDirectory() + "/" + (xmlout.empty() ? baseName_ : xmlout) + "/";
     std::string layoutpath = mainConfiguration.getLayoutDirectory() + "/" + baseName_ +  "/";
-    //if (!xmlout.empty()) layoutpath = layoutpath + xmlout + "/";
     v.createXmlSite(site,xmlpath,layoutpath);
   }
 }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -5312,56 +5312,60 @@ namespace insur {
     myContent.addItem(myTextFile);
 
   }
-  //create an extra tab for xml file linking
-  bool Vizard::createXmlSite(RootWSite& site,std::string xmldir,std::string layoutdir) {
+
+
+  // Create an extra tab for XML files linking
+  bool Vizard::createXmlSite(RootWSite& site, std::string xmlDir, std::string layoutDir) {
     RootWPage* myPage = new RootWPage("XML");
     myPage->setAddress("xml.html");
     site.addPage(myPage);
-    if (!boost::filesystem::exists(layoutdir)) { boost::filesystem::create_directory(layoutdir); }
 
-    std::vector<std::string> xmlMetadataFileNames, pixelxmlfilenames, trackerxmlfilenames;
-    boost::filesystem::path xmlDirectory(xmldir);
-    boost::filesystem::directory_iterator end_iter;
-    if ( boost::filesystem::exists(xmlDirectory) && boost::filesystem::is_directory(xmlDirectory)) {
-      for( boost::filesystem::directory_iterator dir_iter(xmlDirectory) ; dir_iter != end_iter ; ++dir_iter) {
-	if ( boost::filesystem::is_regular_file( dir_iter->path() ) ) {
-	  // assign current file name to current_file and echo it out to the console.
-	  std::string current_file =dir_iter->path().filename().string();
-	  //std::cout << current_file << "\tpath=" << dir_iter->path().string() << std::endl;
-	  if ((current_file.find(".cfg") != std::string::npos) || (current_file.find(".xml") != std::string::npos)) {
-	    boost::filesystem::copy_file( dir_iter->path(),
-					  layoutdir + current_file,
-					  boost::filesystem::copy_option::overwrite_if_exists);  //TO FIX !! the copy of files should be done by RootWBinaryFileList::dump, and not before !!
-	    if (current_file.find(".cfg") != std::string::npos ) {
-	      xmlMetadataFileNames.push_back(current_file);
+    std::vector<std::string> origMetadataXmlFiles, origPixelXmlFiles, origOuterTrackerXmlFiles;
+    std::vector<std::string> metadataXmlFileNames, pixelXmlFileNames, outerTrackerXmlFileNames;
+    
+    try {
+      boost::filesystem::directory_iterator end_iter;
+      for (boost::filesystem::directory_iterator dir_iter(xmlDir); dir_iter != end_iter; dir_iter++) {
+	if (boost::filesystem::is_regular_file(dir_iter->path())) {
+	  std::string origFile = dir_iter->path().string();
+	  std::string fileName = dir_iter->path().filename().string();
+	 
+	  if (fileName.find(".cfg") != std::string::npos ) {
+	    origMetadataXmlFiles.push_back(origFile);
+	    metadataXmlFileNames.push_back(fileName);
+	  }
+	  else {
+	    if (fileName.find("pixel") != std::string::npos ) {
+	      origPixelXmlFiles.push_back(origFile);
+	      pixelXmlFileNames.push_back(fileName);
 	    }
 	    else {
-	      if (current_file.find("pixel") != std::string::npos ) pixelxmlfilenames.push_back(current_file);
-	      else trackerxmlfilenames.push_back(current_file);
+	      origOuterTrackerXmlFiles.push_back(origFile);
+	      outerTrackerXmlFileNames.push_back(fileName);
 	    }
 	  }
 	}
       }
     }
-    else std::cerr << "XML directory does not exist" << std::endl;
+    catch (boost::filesystem::filesystem_error e) {
+      cerr << e.what() << " when trying to copy XML files from XML directory to website directory." << endl;
+    }
 
     RootWContent* content = new RootWContent("XML files");
-    if (!xmlMetadataFileNames.empty()) {
-      RootWBinaryFileList* xmlMetadataFileList = new RootWBinaryFileList(xmlMetadataFileNames.begin(), xmlMetadataFileNames.end(), 
-									 "XML generation Metadata", xmlMetadataFileNames.begin(), xmlMetadataFileNames.end());
-      content->addItem(xmlMetadataFileList);
+    if (!metadataXmlFileNames.empty()) {
+      RootWBinaryFileList* metadataXmlFileList = new RootWBinaryFileList(metadataXmlFileNames.begin(), metadataXmlFileNames.end(), "XML generation Metadata", origMetadataXmlFiles.begin(), origMetadataXmlFiles.end());
+      content->addItem(metadataXmlFileList);
     }
-    if (!pixelxmlfilenames.empty()) {
-      RootWBinaryFileList* pxFileList = new RootWBinaryFileList(pixelxmlfilenames.begin(), pixelxmlfilenames.end(), 
-								"XML for Pixel",pixelxmlfilenames.begin(), pixelxmlfilenames.end());
-      content->addItem(pxFileList);
+    if (!pixelXmlFileNames.empty()) {
+      RootWBinaryFileList* pixelXmlFileList = new RootWBinaryFileList(pixelXmlFileNames.begin(), pixelXmlFileNames.end(), "XML for Pixel", origPixelXmlFiles.begin(), origPixelXmlFiles.end());
+      content->addItem(pixelXmlFileList);
     }
-    if (!trackerxmlfilenames.empty()) {
-      RootWBinaryFileList* tkFileList = new RootWBinaryFileList(trackerxmlfilenames.begin(), trackerxmlfilenames.end(), 
-								"XML for Outer Tracker",trackerxmlfilenames.begin(), trackerxmlfilenames.end());
-      content->addItem(tkFileList);
+    if (!outerTrackerXmlFileNames.empty()) {
+      RootWBinaryFileList* outerTrackerXmlFileList = new RootWBinaryFileList(outerTrackerXmlFileNames.begin(), outerTrackerXmlFileNames.end(), "XML for Outer Tracker", origOuterTrackerXmlFiles.begin(), origOuterTrackerXmlFiles.end());
+      content->addItem(outerTrackerXmlFileList);
     }
     myPage->addContent(content);
   }
+  // NB : XML files are copied from the XML directory to the www/layout directory with RootWBinaryFileList::dump.
 
 }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -5334,7 +5334,7 @@ namespace insur {
 	    origMetadataXmlFiles.push_back(origFile);
 	    metadataXmlFileNames.push_back(fileName);
 	  }
-	  else {
+	  else if (fileName.find(".xml") != std::string::npos ) {
 	    if (fileName.find("pixel") != std::string::npos ) {
 	      origPixelXmlFiles.push_back(origFile);
 	      pixelXmlFileNames.push_back(fileName);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -5317,6 +5317,7 @@ namespace insur {
     RootWPage* myPage = new RootWPage("XML");
     myPage->setAddress("xml.html");
     site.addPage(myPage);
+    if (!boost::filesystem::exists(layoutdir)) { boost::filesystem::create_directory(layoutdir); }
 
     std::vector<std::string> pixelxmlfilenames,trackerxmlfilenames;
     boost::filesystem::path xmlDirectory(xmldir);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -5313,49 +5313,55 @@ namespace insur {
 
   }
   //create an extra tab for xml file linking
-    bool Vizard::createXmlSite(RootWSite& site,std::string xmldir,std::string layoutdir) {
+  bool Vizard::createXmlSite(RootWSite& site,std::string xmldir,std::string layoutdir) {
     RootWPage* myPage = new RootWPage("XML");
     myPage->setAddress("xml.html");
     site.addPage(myPage);
     if (!boost::filesystem::exists(layoutdir)) { boost::filesystem::create_directory(layoutdir); }
 
-    std::vector<std::string> pixelxmlfilenames,trackerxmlfilenames;
+    std::vector<std::string> xmlMetadataFileNames, pixelxmlfilenames, trackerxmlfilenames;
     boost::filesystem::path xmlDirectory(xmldir);
     boost::filesystem::directory_iterator end_iter;
     if ( boost::filesystem::exists(xmlDirectory) && boost::filesystem::is_directory(xmlDirectory)) {
       for( boost::filesystem::directory_iterator dir_iter(xmlDirectory) ; dir_iter != end_iter ; ++dir_iter) {
-         if ( boost::filesystem::is_regular_file( dir_iter->path() ) ) {
-            // assign current file name to current_file and echo it out to the console.
-            std::string current_file =dir_iter->path().filename().string();
-            std::cout << current_file << "\tpath=" << dir_iter->path().string() << std::endl;
-	    if( current_file.find(".xml") != std::string::npos ) {
-              boost::filesystem::copy_file( dir_iter->path(),
-                                            layoutdir + current_file,
-                                            boost::filesystem::copy_option::overwrite_if_exists);
-              if( current_file.find("pixel") != std::string::npos )
-                pixelxmlfilenames.push_back(current_file);
-              else 
-                trackerxmlfilenames.push_back(current_file);
-             }
-        }
+	if ( boost::filesystem::is_regular_file( dir_iter->path() ) ) {
+	  // assign current file name to current_file and echo it out to the console.
+	  std::string current_file =dir_iter->path().filename().string();
+	  //std::cout << current_file << "\tpath=" << dir_iter->path().string() << std::endl;
+	  if ((current_file.find(".cfg") != std::string::npos) || (current_file.find(".xml") != std::string::npos)) {
+	    boost::filesystem::copy_file( dir_iter->path(),
+					  layoutdir + current_file,
+					  boost::filesystem::copy_option::overwrite_if_exists);  //TO FIX !! the copy of files should be done by RootWBinaryFileList::dump, and not before !!
+	    if (current_file.find(".cfg") != std::string::npos ) {
+	      xmlMetadataFileNames.push_back(current_file);
+	    }
+	    else {
+	      if (current_file.find("pixel") != std::string::npos ) pixelxmlfilenames.push_back(current_file);
+	      else trackerxmlfilenames.push_back(current_file);
+	    }
+	  }
+	}
       }
     }
     else std::cerr << "XML directory does not exist" << std::endl;
 
-    RootWContent* content = new RootWContent("xml files");
+    RootWContent* content = new RootWContent("XML files");
+    if (!xmlMetadataFileNames.empty()) {
+      RootWBinaryFileList* xmlMetadataFileList = new RootWBinaryFileList(xmlMetadataFileNames.begin(), xmlMetadataFileNames.end(), 
+									 "XML generation Metadata", xmlMetadataFileNames.begin(), xmlMetadataFileNames.end());
+      content->addItem(xmlMetadataFileList);
+    }
     if (!pixelxmlfilenames.empty()) {
       RootWBinaryFileList* pxFileList = new RootWBinaryFileList(pixelxmlfilenames.begin(), pixelxmlfilenames.end(), 
-								"xml for Inner Pixel",pixelxmlfilenames.begin(), pixelxmlfilenames.end());
+								"XML for Pixel",pixelxmlfilenames.begin(), pixelxmlfilenames.end());
       content->addItem(pxFileList);
     }
- 
     if (!trackerxmlfilenames.empty()) {
       RootWBinaryFileList* tkFileList = new RootWBinaryFileList(trackerxmlfilenames.begin(), trackerxmlfilenames.end(), 
-								"xml for Outer Tracker",trackerxmlfilenames.begin(), trackerxmlfilenames.end());
+								"XML for Outer Tracker",trackerxmlfilenames.begin(), trackerxmlfilenames.end());
       content->addItem(tkFileList);
     }
     myPage->addContent(content);
-    
-    }
+  }
 
 }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -5328,7 +5328,7 @@ namespace insur {
             // assign current file name to current_file and echo it out to the console.
             std::string current_file =dir_iter->path().filename().string();
             std::cout << current_file << "\tpath=" << dir_iter->path().string() << std::endl;
-             if( current_file.find(".xml") != std::string::npos ) {
+	    if( current_file.find(".xml") != std::string::npos ) {
               boost::filesystem::copy_file( dir_iter->path(),
                                             layoutdir + current_file,
                                             boost::filesystem::copy_option::overwrite_if_exists);
@@ -5342,16 +5342,20 @@ namespace insur {
     }
     else std::cerr << "XML directory does not exist" << std::endl;
 
-    RootWBinaryFileList* pxFileList = new RootWBinaryFileList(pixelxmlfilenames.begin(), pixelxmlfilenames.end(), 
-                                          "xml for Inner Pixel",pixelxmlfilenames.begin(), pixelxmlfilenames.end());
- 
-    RootWBinaryFileList* tkFileList = new RootWBinaryFileList(trackerxmlfilenames.begin(), trackerxmlfilenames.end(), 
-                                          "xml for Outer Tracker",trackerxmlfilenames.begin(), trackerxmlfilenames.end());
     RootWContent* content = new RootWContent("xml files");
-    content->addItem(pxFileList);
-    content->addItem(tkFileList);
+    if (!pixelxmlfilenames.empty()) {
+      RootWBinaryFileList* pxFileList = new RootWBinaryFileList(pixelxmlfilenames.begin(), pixelxmlfilenames.end(), 
+								"xml for Inner Pixel",pixelxmlfilenames.begin(), pixelxmlfilenames.end());
+      content->addItem(pxFileList);
+    }
+ 
+    if (!trackerxmlfilenames.empty()) {
+      RootWBinaryFileList* tkFileList = new RootWBinaryFileList(trackerxmlfilenames.begin(), trackerxmlfilenames.end(), 
+								"xml for Outer Tracker",trackerxmlfilenames.begin(), trackerxmlfilenames.end());
+      content->addItem(tkFileList);
+    }
     myPage->addContent(content);
     
-  }
+    }
 
 }

--- a/src/rootweb.cpp
+++ b/src/rootweb.cpp
@@ -1165,12 +1165,13 @@ ostream& RootWBinaryFileList::dump(ostream& output) {
     catch (boost::filesystem::filesystem_error e) {
       cerr << e.what() << endl;
       return output;
-    }
-    
+    }   
   }
+
   std::vector<std::string> cleanedUpFileNames;
   std::transform(originalFileNames_.begin(), originalFileNames_.end(), std::back_inserter(cleanedUpFileNames), [](const std::string& s) {
       auto pos = s.find("stdinclude");
+      if (s.find("xml") != string::npos) pos = s.rfind("/") + 1;
       return pos != string::npos ? s.substr(pos) : s;
     });
   output << "<b>" << description_ << ":</b>";

--- a/src/rootweb.cpp
+++ b/src/rootweb.cpp
@@ -1158,22 +1158,21 @@ ostream& RootWBinaryFileList::dump(ostream& output) {
     //  if (!boost::filesystem::exists(destinationFileName)) boost::filesystem::create_directory(destinationFileName);
     //});
     destinationFileName += "/" + fn; //path.back();
-    if (boost::filesystem::exists(*it) && *it != destinationFileName) { // CUIDADO: naive control on copy on itself. 
-      try {
-        if (boost::filesystem::exists(destinationFileName))
-          boost::filesystem::remove(destinationFileName);
-        boost::filesystem::copy_file(*it++, destinationFileName);
-      } catch (boost::filesystem::filesystem_error e) {
-        cerr << e.what() << endl;
-        return output;
-      }
+    try {
+      if (boost::filesystem::exists(destinationFileName)) boost::filesystem::remove(destinationFileName);
+      boost::filesystem::copy_file(*it++, destinationFileName);
     }
+    catch (boost::filesystem::filesystem_error e) {
+      cerr << e.what() << endl;
+      return output;
+    }
+    
   }
   std::vector<std::string> cleanedUpFileNames;
   std::transform(originalFileNames_.begin(), originalFileNames_.end(), std::back_inserter(cleanedUpFileNames), [](const std::string& s) {
-    auto pos = s.find("stdinclude");
-    return pos != string::npos ? s.substr(pos) : s;
-  });
+      auto pos = s.find("stdinclude");
+      return pos != string::npos ? s.substr(pos) : s;
+    });
   output << "<b>" << description_ << ":</b>";
   auto dfn = fileNames_.begin();
   for (auto cfn : cleanedUpFileNames) {


### PR DESCRIPTION
Worked on Vizard::createXmlSite. To sum up, the following bugs were corrected : 
- in case of run with --xml, the copy of XML files did not work
- in case new TKG_LAYOUTDIRECTORY, the copy of XML files did not work
- in case run with --xml but no --pixelxml, Warning: RootWBinaryFileList::dump() appeared 
- RootWBinaryFileList objects were not instanciated correctly
- boost::filesystem::copy_file code was replicated
- error handling was incomplete

Also : added the metadata file to the XML tab.