### PR TITLE
IMPORTANT! Bug fix. For startZMode = modulecenter, and for all -Z side, all modules properties specified for a given ring i in the cfg files were actually assigned to ring i+1.

### DIFF
--- a/include/RodPair.h
+++ b/include/RodPair.h
@@ -127,7 +127,7 @@ public:
   double thickness() const override { return smallDelta()*2. + maxModuleThickness(); }
   bool isTilted() const override { return false; }
 
-  
+  void check() override;
   void build(const RodTemplate& rodTemplate);
 
   std::set<int> solveCollisionsZPlus();

--- a/src/RodPair.cpp
+++ b/src/RodPair.cpp
@@ -310,9 +310,12 @@ void StraightRodPair::buildModules(Container& modules, const RodTemplate& rodTem
     BarrelModule* mod;
     if (!mezzanine() && (startZMode() == StartZMode::MODULECENTER) && (direction == BuildDir::LEFT)) { // skips the central module information.
       mod = GeometryFactory::make<BarrelModule>(i < (rodTemplate.size() - 1) ? *rodTemplate[i+1].get() : *rodTemplate.rbegin()->get());
+      mod->myid(i+2);
     }
-    else mod = GeometryFactory::make<BarrelModule>(i < rodTemplate.size() ? *rodTemplate[i].get() : *rodTemplate.rbegin()->get());
-    mod->myid(i+1);
+    else {
+      mod = GeometryFactory::make<BarrelModule>(i < rodTemplate.size() ? *rodTemplate[i].get() : *rodTemplate.rbegin()->get());
+      mod->myid(i+1);
+    }
     mod->side(side);
     //mod->store(propertyTree());
     //if (ringNode.count(i+1) > 0) mod->store(ringNode.at(i+1)); 

--- a/src/RodPair.cpp
+++ b/src/RodPair.cpp
@@ -364,7 +364,7 @@ void StraightRodPair::check() {
   PropertyObject::check();
 
   if (mezzanine()) {
-    if (startZMode.state()) logERROR("startZMode cannot be taken into account for a mezzanine.");
+    if (startZMode.state()) logWARNING("Ignoring startZMode (set to modulecenter by default) for a mezzanine.");
   }
 }
 


### PR DESCRIPTION
This bug has been there since startZMode = modulecenter was created.
With startZMode = modulecenter, when one specified modules properties for a given ring i, they were actually assigned to ring (i+1) on the -Z side.

startZMode = modulecenter is used for flat TBPS, tilted TBPS, and BPIX.
In practice, for flat TBPS and BPIX layouts, there was no module property specified for a given ring. So for these, the PR doesn't lead to any apparent change.

But this PR fixes bugs in the -Z side of tilted layouts.
The properties which are concerned are dsDistance and triggerWindow for example.

NB 1 : the XML export is not concerned, because only information from +Z side is used and then replicated on the -Z side. This was rechecked and there is no error indeed in the XML export.

NB 2 : performance studies displayed on the website are not concerned either, because they take only information from +Z side into consideration. 


Example :
Old layout SingleLayerTilted_L1 for example :

- on the +Z side :
     Layer Ring      R                    Z                        phi             dsDistance
TBPS, 1, 7, 247.000000, 287.138904, 1.570796, 2.600000
TBPS, 1, 8, 247.000000, 346.478797, 1.570796, 4.000000
TBPS, 1, 9, 247.000000, 425.326722, 1.570796, 4.000000
TBPS, 1, 10, 247.000000, 516.999364, 1.570796, 4.000000

- on the -Z side :
TBPS, 1, 7, 247.000000, -287.138904, 1.570796, 2.600000
TBPS, 1, 8, 247.000000, -346.478797, 1.570796, 2.600000
TBPS, 1, 9, 247.000000, -425.326722, 1.570796, 4.000000
TBPS, 1, 10, 247.000000, -516.999364, 1.570796, 4.000000

On the -Z side : 
module of TBPS, Layer 1, ring 8 placed at Z = -346.478797 
has a dsDistance = 2.6 instead of 4.0. 
Indeed, it has the dsDistance of ring 7, which is 2.6.


On this commit there has been a few improvements on mezzanine for clarity in the code, but this has nothing to do with the bug fix. mezzanine is not used and obsolete anyway.