### PR TITLE
Dev lite - Analyzer for Material budget analysis finished

### DIFF
--- a/source/Analysis/include/AnalyzerMatBudget.h
+++ b/source/Analysis/include/AnalyzerMatBudget.h
@@ -15,11 +15,22 @@
 
 #include <Visitor.h>
 #include <AnalyzerUnit.h>
+#include <CsvTextBuilder.h>
+#include <DetectorModule.h>
 
 // Forward declaration
+class BarrelModule;
 class BeamPipe;
 class ConstGeometryVisitor;
+class Disk;
+class EndcapModule;
+class ModuleCap;
+class RILength;
 class TCanvas;
+class TGraph;
+class TH1D;
+class TH2D;
+class Track;
 class Tracker;
 class RootWTable;
 
@@ -36,7 +47,7 @@ class AnalyzerMatBudget : public AnalyzerUnit {
   AnalyzerMatBudget(std::vector<const Tracker*> trackers, const BeamPipe* beamPipe);
 
   //! Destructor
-  virtual ~AnalyzerMatBudget() {};
+  virtual ~AnalyzerMatBudget();
 
   //! Initialize - mostly histograms & other containers
   //! @return True if OK
@@ -55,13 +66,92 @@ class AnalyzerMatBudget : public AnalyzerUnit {
 
  private:
 
+  //! Helper method creating profile histogram from histogram
+  //TProfile* createProfileHis(const TH1D& sourceHistogram) const;
+
+  //! Helper method calculating average value in the given cut regions
+  std::vector<double> average(TGraph& myGraph, std::vector<double> cuts);
+
+  //! Helper method modifying a TGraph, so that it looks like a histogram (can be filled)
+  void closeGraph(TGraph& myGraph);
+
+  //! Helper method calculating average histogram values in histogram range from lowest bin to cutoff
+  double averageHistogramValues(const TH1D& his, double cutoff) const;
+
+  //! Helper method calculating average histogram values in range cutoffStart - cutoffEnd
+  double averageHistogramValues(const TH1D& his, double cutoffStart, double cutoffEnd) const;
+
   int    m_nTracks;     //!< Number of geometry tracks to be used in material analysis
   double m_etaSpan;     //!< Eta interval to be analyzed
   double m_etaMin;      //!< Minimum eta value;
   double m_etaMax;      //!< Maximum eta value
 
-  // Histogram output
+  const float c_etaSafetyMargin = 0.01;
+
+  // Histogram output -> trkName stands for beam-pipe or given tracker name, componentName stands for "Barrel", "Endcap", "Supports", "Services" or "Total"
+  std::map<std::string, std::map<std::string, TH1D>> m_radMB; //!< Individual contributions to material budget [in rad. lengths] for given tracker: m_radMBComponents[trkName][componentName] = TH1D
+  std::map<std::string, std::map<std::string, TH1D>> m_intMB; //!< Individual contributions to material budget [in int. lengths] for given tracker: m_intMBComponents[trkName][componentName] = TH1D
+
+  // Component histogram output -> trkName stands for beam-pipe or given tracker name, componentName stands for any defined module component (given in geom. config), "Supports", "Services" and "Total"
+  std::map<std::string, std::map<std::string, TH1D>> m_radMBComp; //!< Individual contributions to material budget [in rad. lengths] for given tracker: m_radMBComponents[trkName][componentName] = TH1D
+  std::map<std::string, std::map<std::string, TH1D>> m_intMBComp; //!< Individual contributions to material budget [in int. lengths] for given tracker: m_intMBComponents[trkName][componentName] = TH1D
+
+  // Material maps for given trackers: "Total" corresponds to sum
+  std::map<std::string, TH2D> m_radMap;      //!< Material map in radiation lengths for given tracker: m_radMap[trkName] = TH2D
+  std::map<std::string, TH2D> m_radMapCount; //!< Counter for material map in terms of radiation length
+  std::map<std::string, TH2D> m_intMap;      //!< Material map in interaction lengths for given tracker: m_radMap[trkName] = TH2D
+  std::map<std::string, TH2D> m_intMapCount; //!< Counter for material map in terms of interaction length
+
+  // Hadrons
+  TGraph*             m_hadronTotalHitsGraph;
+  TGraph*             m_hadronAverageHitsGraph;
+  std::vector<double> m_hadronNeededHitsFraction;
+  std::vector<TGraph> m_hadronGoodTracksFraction;
+
+  // Csv output
+  CsvTextBuilder       m_materialCsv;
 
 }; // Class
+
+//! Helper class - Module caps visitor (visitor pattern) - checks that modules, beam-pipe etc. hit by a track -> returns radiation & interaction length & preanalyze material related data
+class MaterialVisitor : public ConstGeometryVisitor {
+
+public:
+
+  //! Constructor
+  //! As a parameter provide a track, under which the material is studied, container filling in
+  //! material for given subdetectors or components defined by name (Barrel, Endcap, ...) and
+  //! radiation maps as TH2D to be filled
+  MaterialVisitor(Track& matTrack, std::map<std::string, RILength>& matBudget, TH2D& radMap, TH2D& radMapCount, TH2D& intMap, TH2D& intMapCount);
+
+  //! Destructor
+  ~MaterialVisitor();
+
+  //! Visit BeamPipe
+  void visit(const BeamPipe& bp) override;
+
+  //! Visit BarrelModule (no limits on Rods, Layers or Barrels)
+  void visit(const BarrelModule& m) override;
+
+  //! Visit EndcapModule (no limits on Rings, Discs or Endcaps)
+  void visit(const EndcapModule& m) override;
+
+  //! Post visit method called after the whole visit-accept pattern done to recalibrate histograms, etc.
+  void postvisit();
+
+private:
+
+  //! Analyze if module crossed by given track & how much material is on the way
+  void analyzeModuleMB(const DetectorModule& m);
+
+  std::map<std::string, RILength>& m_matBudget;  //!< Material container for given subdetectors or components defined by name (Barrel, Endcap, ...)
+  TH2D&                            m_radMap;     //!< Material map in terms of radiation length
+  TH2D&                            m_radMapCount;//!< Counter for material map in terms of radiation length
+  TH2D&                            m_intMap;     //!< Material map in terms of interaction length
+  TH2D&                            m_intMapCount;//!< Counter for material map in terms of interaction length
+  Track&                           m_matTrack;   //!< Shooting direction + origin encapsulated in a track class -> update track with hits once found
+  int                              m_nEntries;   //!< Number of entries
+
+}; // Helper class
 
 #endif /* INCLUDE_ANALYZERMATBUDGET_H_ */

--- a/source/Analysis/include/AnalyzerMatBudget.h
+++ b/source/Analysis/include/AnalyzerMatBudget.h
@@ -102,11 +102,11 @@ class AnalyzerMatBudget : public AnalyzerUnit {
   std::map<std::string, TH2D> m_intMap;      //!< Material map in interaction lengths for given tracker: m_radMap[trkName] = TH2D
   std::map<std::string, TH2D> m_intMapCount; //!< Counter for material map in terms of interaction length
 
-  // Hadrons
-  TGraph*             m_hadronTotalHitsGraph;
-  TGraph*             m_hadronAverageHitsGraph;
-  std::vector<double> m_hadronNeededHitsFraction;
-  std::vector<TGraph> m_hadronGoodTracksFraction;
+  // Hadrons -> each variable for given tracker: "Total" corresponds to sum
+  std::map<std::string, TGraph> m_hadronTotalHitsGraph;
+  std::map<std::string, TGraph> m_hadronAverageHitsGraph;
+  std::map<std::string, std::vector<double>> m_hadronNeededHitsFraction;
+  std::map<std::string, std::vector<TGraph>> m_hadronGoodTracksFraction;
 
   // Csv output
   CsvTextBuilder       m_materialCsv;

--- a/source/Analysis/src/AnalysisManager.cc
+++ b/source/Analysis/src/AnalysisManager.cc
@@ -9,6 +9,7 @@
 // List of units
 #include <AnalyzerUnit.h>
 #include <AnalyzerGeometry.h>
+#include <AnalyzerMatBudget.h>
 #include <AnalyzerResolution.h>
 
 // Other include files
@@ -32,8 +33,14 @@ AnalysisManager::AnalysisManager(std::vector<const Tracker*> activeTrackers,
  m_webSite(nullptr),
  m_webSitePrepared(false)
 {
+  AnalyzerUnit* unit = nullptr;
+
   // Create AnalyzerGeometry
-  AnalyzerGeometry* unit = new AnalyzerGeometry(activeTrackers, beamPipe);
+  unit = new AnalyzerGeometry(activeTrackers, beamPipe);
+  m_units[unit->getName()] = unit;
+
+  // Create AnalyzerMatBudget
+  unit = new AnalyzerMatBudget(activeTrackers, beamPipe);
   m_units[unit->getName()] = unit;
 
   // Prepare Web site

--- a/source/Analysis/src/AnalyzerMatBudget.cc
+++ b/source/Analysis/src/AnalyzerMatBudget.cc
@@ -7,11 +7,29 @@
 #include "AnalyzerMatBudget.h"
 
 // Include files
-#include <BeamPipe.h>
+#include "BeamPipe.h"
+#include "DetectorModule.h"
+#include "Disk.h"
 #include <global_constants.h>
+#include <Hit.h>
+#include <MaterialProperties.h>
+#include <Math/Vector3D.h>
+#include <ModuleCap.h>
 #include <rootweb.h>
 #include <ostream>
+#include <Palette.h>
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TH1D.h>
+#include <TH2D.h>
+#include <THStack.h>
+#include <TLegend.h>
+#include <TPad.h>
+#include <TProfile.h>
 #include <Tracker.h>
+#include <Track.h>
+#include <TRandom3.h>
+#include <Units.h>
 #include <SimParms.h>
 
 //
@@ -21,8 +39,19 @@ AnalyzerMatBudget::AnalyzerMatBudget(std::vector<const Tracker*> trackers, const
  m_nTracks(0),
  m_etaSpan(geom_max_eta_coverage - geom_max_eta_coverage),
  m_etaMin(-1*geom_max_eta_coverage),
- m_etaMax(+1*geom_max_eta_coverage)
+ m_etaMax(+1*geom_max_eta_coverage),
+ m_hadronTotalHitsGraph(nullptr),
+ m_hadronAverageHitsGraph(nullptr)
 {};
+
+//
+// Destructor
+//
+AnalyzerMatBudget::~AnalyzerMatBudget()
+{
+  if (m_hadronTotalHitsGraph!=nullptr) delete m_hadronTotalHitsGraph;
+  if (m_hadronAverageHitsGraph!=nullptr) delete m_hadronAverageHitsGraph;
+}
 
 //
 // AnalyzerMatBudget init method
@@ -32,6 +61,14 @@ bool AnalyzerMatBudget::init(int nMatTracks)
   // Set nTracks
   m_nTracks = nMatTracks;
 
+  // Compute shooting intervals to analyze geometry
+  double etaMin = -1*geom_max_eta_coverage;
+  double etaMax = +1*geom_max_eta_coverage;
+
+  float  safeMargin = c_etaSafetyMargin;
+  m_etaSpan         = (etaMax - etaMin)*(1. + safeMargin);
+  m_etaMax          = etaMax * (1 + safeMargin);
+
   if (m_nTracks<=0 || m_trackers.size()==0) {
 
     std::ostringstream message;
@@ -39,13 +76,115 @@ bool AnalyzerMatBudget::init(int nMatTracks)
     logERROR(message.str());
     return false;
   }
+  else if (m_beamPipe==nullptr) {
+
+    std::ostringstream message;
+    message << "AnalyzerMatBudget::init(): No beam pipe defined for material budget studies";
+    logERROR(message.str());
+    return false;
+  }
   else {
 
-    for (auto iTracker : m_trackers) {
+    // Calculate final plot range, increase by safety factor
+    double maxZ = 0;
+    double maxR = 0;
+    for (auto iTrk : m_trackers) {
 
-      std::string trkName = iTracker->myid();
+      maxZ = MAX(maxZ, iTrk->maxZ()*vis_safety_factor);
+      maxR = MAX(maxR, iTrk->maxR()*vis_safety_factor);
+    }
 
-    } // For trackers
+    // Prepare histogram containers for each subdetector (components will be initialized on the fly)
+    for (int iTrk=0; iTrk<=m_trackers.size(); iTrk++) {
+
+      // Tracker name
+      std::string trkName;
+      if (iTrk==m_trackers.size()) trkName = "Tracker";
+      else                         trkName = m_trackers[iTrk]->myid();
+
+      // Maps
+      double step = 5.*Units::mm;
+      int materialMapBinsZ     = int( maxZ/step);
+      int materialMapBinsR     = int( maxR/step);
+      double materialMapRangeZ = materialMapBinsZ*step;
+      double materialMapRangeR = materialMapBinsR*step;
+
+      m_radMap[trkName].SetNameTitle("radMap", std::string(trkName +" Radiation length map;z [mm];r [mm]").c_str());
+      m_radMap[trkName].SetBins( materialMapBinsZ, 0, materialMapRangeZ, materialMapBinsR, 0, materialMapRangeR);
+      m_radMapCount[trkName].SetNameTitle("radMapCount", std::string(trkName +" Radiation length map (counter);z [mm];r [mm]").c_str());
+      m_radMapCount[trkName].SetBins( materialMapBinsZ, 0, materialMapRangeZ, materialMapBinsR, 0, materialMapRangeR);
+      m_intMap[trkName].SetNameTitle("intMap", std::string(trkName +" Interaction length map;z [mm];r [mm]").c_str());
+      m_intMap[trkName].SetBins( materialMapBinsZ, 0, materialMapRangeZ, materialMapBinsR, 0, materialMapRangeR);
+      m_intMapCount[trkName].SetNameTitle("intMapCount", std::string(trkName +" Interaction length map (counter);z [mm];r [mm]").c_str());
+      m_intMapCount[trkName].SetBins( materialMapBinsZ, 0, materialMapRangeZ, materialMapBinsR, 0, materialMapRangeR);
+
+      // Material distribution in barrels
+      m_radMB[trkName]["Barrel"].Reset();
+      m_radMB[trkName]["Barrel"].SetNameTitle("radMBBarrel", std::string(trkName +" Barrel Modules Radiation Length").c_str());
+      m_radMB[trkName]["Barrel"].SetBins(m_nTracks, 0, m_etaMax);
+      m_intMB[trkName]["Barrel"].Reset();
+      m_intMB[trkName]["Barrel"].SetNameTitle("intMBBarrel", std::string(trkName +" Barrel Modules Interaction Length").c_str());
+      m_intMB[trkName]["Barrel"].SetBins(m_nTracks, 0, m_etaMax);
+
+      // Material distribution in endcaps
+      m_radMB[trkName]["Endcap"].Reset();
+      m_radMB[trkName]["Endcap"].SetNameTitle("radMBEndcap", std::string(trkName +" Endcap Modules Radiation Length").c_str());
+      m_radMB[trkName]["Endcap"].SetBins(m_nTracks, 0, m_etaMax);
+      m_intMB[trkName]["Endcap"].Reset();
+      m_intMB[trkName]["Endcap"].SetNameTitle("intMBEndcap", std::string(trkName +" Endcap Modules Interaction Length").c_str());
+      m_intMB[trkName]["Endcap"].SetBins(m_nTracks, 0, m_etaMax);
+
+      // Material distribution in services
+      m_radMB[trkName]["Services"].Reset();
+      m_radMB[trkName]["Services"].SetNameTitle("radMBServices", std::string(trkName +" Services Radiation Length").c_str());
+      m_radMB[trkName]["Services"].SetBins(m_nTracks, 0, m_etaMax);
+      m_intMB[trkName]["Services"].Reset();
+      m_intMB[trkName]["Services"].SetNameTitle("intMBServices", std::string(trkName +" Services Interaction Length").c_str());
+      m_intMB[trkName]["Services"].SetBins(m_nTracks, 0, m_etaMax);
+
+      // Material distribution in supports
+      m_radMB[trkName]["Supports"].Reset();
+      m_radMB[trkName]["Supports"].SetNameTitle("radMBSupports", std::string(trkName +" Supports Radiation Length").c_str());
+      m_radMB[trkName]["Supports"].SetBins(m_nTracks, 0, m_etaMax);
+      m_intMB[trkName]["Supports"].Reset();
+      m_intMB[trkName]["Supports"].SetNameTitle("intMBSupports", std::string(trkName +" Supports Interaction Length").c_str());
+      m_intMB[trkName]["Supports"].SetBins(m_nTracks, 0, m_etaMax);
+
+      // Material distribution in total
+      m_radMB[trkName]["Total"].Reset();
+      m_radMB[trkName]["Total"].SetNameTitle("radMBTotal", "Total Radiation Length");
+      m_radMB[trkName]["Total"].SetBins(m_nTracks, 0, m_etaMax);
+      m_intMB[trkName]["Total"].Reset();
+      m_intMB[trkName]["Total"].SetNameTitle("intMBTotal", "Total Interaction Length");
+      m_intMB[trkName]["Total"].SetBins(m_nTracks, 0, m_etaMax);
+    }  // For trackers
+
+    // Material distribution in beam-pipe
+    m_radMB["Beampipe"]["Total"].Reset();
+    m_radMB["Beampipe"]["Total"].SetNameTitle("radMBPipe", "BeamPipe Radiation Length");
+    m_radMB["Beampipe"]["Total"].SetBins(m_nTracks, 0, m_etaMax);
+    m_intMB["Beampipe"]["Total"].Reset();
+    m_intMB["Beampipe"]["Total"].SetNameTitle("intMBPipe", "BeamPipe Interaction Length");
+    m_intMB["Beampipe"]["Total"].SetBins(m_nTracks, 0, m_etaMax);
+
+    // Nuclear interactions
+    m_hadronTotalHitsGraph = new TGraph();
+    m_hadronTotalHitsGraph->SetName("hadronTotalHitsGraph");
+    m_hadronAverageHitsGraph = new TGraph();
+    m_hadronAverageHitsGraph->SetName("hadronAverageHitsGraph");
+
+    // Clear the list of requested good hadron hits
+    m_hadronNeededHitsFraction.clear();
+    m_hadronGoodTracksFraction.clear();
+
+    m_hadronNeededHitsFraction.push_back(0);
+    m_hadronNeededHitsFraction.push_back(0.0001);
+    //m_hadronNeededHitsFraction.push_back(.33);
+    m_hadronNeededHitsFraction.push_back(.66);
+    m_hadronNeededHitsFraction.push_back(1);
+
+    std::sort(m_hadronNeededHitsFraction.begin(),
+              m_hadronNeededHitsFraction.end());
 
     m_isInitOK = true;
     return m_isInitOK;
@@ -60,23 +199,212 @@ bool AnalyzerMatBudget::analyze()
   // Check that initialization OK
   if (!m_isInitOK) return false;
 
+  TRandom3 myDice;
+  myDice.SetSeed(random_seed);
+
   // Print
   std::cout << std::endl;
 
-  // Go through all trackers
+  // Study all trackers
   for (auto iTracker : m_trackers) {
 
-    std::string trkName =  iTracker->myid();
+    std::string trkName = iTracker->myid();
+    std::cout << " " << trkName << " tracker" << std::endl;
 
-    // Print
-    std::cout << " " << iTracker->myid() << " tracker"<< std::endl;
+    // Analyze material budget for individual subdetector & beam-pipe
+    for (auto iTrack=0; iTrack<=m_nTracks; iTrack++) {
 
-    // Analyze geometry layout
-    for (auto iTrack=0; iTrack<m_nTracks; iTrack++) {
+      // Generate a track
+      double phi   = myDice.Rndm() * 2 * M_PI;
+      double eta   = 0 + m_etaMax/m_nTracks*iTrack; // Currently assumed +-Z symmetry // m_etaMin + m_etaSpan/m_nTracks*iTrack;
+      double theta = 2*atan(exp(-1*eta));
+      double pT    = 100*Units::TeV; // Arbitrarily high number
 
+      Track matTrack;
+      matTrack.setThetaPhiPt(theta, phi, pT);
+      matTrack.setOrigin(0, 0, 0); // TODO: Not assuming z-error when calculating Material budget
+
+      // Study beam pipe -> fill only once
+      if (iTracker==*m_trackers.begin()) {
+
+        m_radMB["Beampipe"]["Total"].Fill(eta, m_beamPipe->radLength()/sin(theta));
+        m_intMB["Beampipe"]["Total"].Fill(eta, m_beamPipe->intLength()/sin(theta));
+
+        m_radMB["Tracker"]["Total"].Fill(eta, m_beamPipe->radLength()/sin(theta));
+        m_intMB["Tracker"]["Total"].Fill(eta, m_beamPipe->intLength()/sin(theta));
+      }
+
+      //
+      // Get material related to detector modules, so-called module caps, beam-pipe etc.
+      std::map<std::string, Material> matBudget;
+      MaterialVisitor mcVisitor(matTrack, matBudget, m_radMap[trkName], m_radMapCount[trkName], m_intMap[trkName], m_intMapCount[trkName]);
+      iTracker->accept(mcVisitor);
+
+      // Given sub-tracker
+      m_radMB[trkName]["Barrel"].Fill(eta, matBudget["Barrel"].radiation);
+      m_intMB[trkName]["Barrel"].Fill(eta, matBudget["Barrel"].interaction);
+
+      m_radMB[trkName]["Endcap"].Fill(eta, matBudget["Endcap"].radiation);
+      m_intMB[trkName]["Endcap"].Fill(eta, matBudget["Endcap"].interaction);
+
+      m_radMB[trkName]["Supports"].Fill(eta, matBudget["Supports"].radiation);
+      m_intMB[trkName]["Supports"].Fill(eta, matBudget["Supports"].interaction);
+
+      m_radMB[trkName]["Services"].Fill(eta, matBudget["Services"].radiation);
+      m_intMB[trkName]["Services"].Fill(eta, matBudget["Services"].interaction);
+
+      m_radMB[trkName]["Total"].Fill(eta, matBudget["Barrel"].radiation +
+                                          matBudget["Endcap"].radiation +
+                                          matBudget["Supports"].radiation +
+                                          matBudget["Services"].radiation +
+                                          m_beamPipe->radLength()/sin(theta));
+      m_intMB[trkName]["Total"].Fill(eta, matBudget["Barrel"].interaction +
+                                          matBudget["Endcap"].interaction +
+                                          matBudget["Supports"].interaction +
+                                          matBudget["Services"].interaction +
+                                          m_beamPipe->intLength()/sin(theta));
+
+      // Total sum to tracker
+      m_radMB["Tracker"]["Barrel"].Fill(eta, matBudget["Barrel"].radiation);
+      m_intMB["Tracker"]["Barrel"].Fill(eta, matBudget["Barrel"].interaction);
+
+      m_radMB["Tracker"]["Endcap"].Fill(eta, matBudget["Endcap"].radiation);
+      m_intMB["Tracker"]["Endcap"].Fill(eta, matBudget["Endcap"].interaction);
+
+      m_radMB["Tracker"]["Supports"].Fill(eta, matBudget["Supports"].radiation);
+      m_intMB["Tracker"]["Supports"].Fill(eta, matBudget["Supports"].interaction);
+
+      m_radMB["Tracker"]["Services"].Fill(eta, matBudget["Services"].radiation);
+      m_intMB["Tracker"]["Services"].Fill(eta, matBudget["Services"].interaction);
+
+      m_radMB["Tracker"]["Total"].Fill(eta, matBudget["Barrel"].radiation +
+                                            matBudget["Endcap"].radiation +
+                                            matBudget["Supports"].radiation +
+                                            matBudget["Services"].radiation);
+      m_intMB["Tracker"]["Total"].Fill(eta, matBudget["Barrel"].interaction +
+                                            matBudget["Endcap"].interaction +
+                                            matBudget["Supports"].interaction +
+                                            matBudget["Services"].interaction);
+
+      // Create component contribution
+      for (auto iMap : matBudget) {
+
+        std::string compName = iMap.first;
+
+        // Avoid Barrel or Endcap -> interested in Modules components + Services + Supports
+        if (compName!="Barrel" && compName!="Endcap") {
+
+          // Set histogram binning etc. if not yet initialized
+          if (m_radMBComp[trkName].find(compName)==m_radMBComp[trkName].end()) {
+
+            m_radMBComp[trkName][compName].Reset();
+            m_radMBComp[trkName][compName].SetNameTitle(std::string("radMB"+compName).c_str(), std::string(trkName +" "+compName+" Radiation Length").c_str());
+            m_radMBComp[trkName][compName].SetBins(m_nTracks, 0, m_etaMax);
+
+            m_intMBComp[trkName][compName].Reset();
+            m_intMBComp[trkName][compName].SetNameTitle(std::string("intMB"+compName).c_str(), std::string(trkName +" "+compName+" Interaction Length").c_str());
+            m_intMBComp[trkName][compName].SetBins(m_nTracks, 0, m_etaMax);
+          }
+          if (m_radMBComp["Tracker"].find(compName)==m_radMBComp["Tracker"].end()) {
+
+            m_radMBComp["Tracker"][compName].Reset();
+            m_radMBComp["Tracker"][compName].SetNameTitle(std::string("radMB"+compName).c_str(), std::string("Tracker "+compName+" Radiation Length").c_str());
+            m_radMBComp["Tracker"][compName].SetBins(m_nTracks, 0, m_etaMax);
+
+            m_intMBComp["Tracker"][compName].Reset();
+            m_intMBComp["Tracker"][compName].SetNameTitle(std::string("intMB"+compName).c_str(), std::string("Tracker "+compName+" Interaction Length").c_str());
+            m_intMBComp["Tracker"][compName].SetBins(m_nTracks, 0, m_etaMax);
+          }
+
+          // Fill
+          m_radMBComp[trkName][compName].Fill(eta, iMap.second.radiation);
+          m_intMBComp[trkName][compName].Fill(eta, iMap.second.interaction);
+
+          m_radMBComp["Tracker"][compName].Fill(eta, iMap.second.radiation);
+          m_intMBComp["Tracker"][compName].Fill(eta, iMap.second.interaction);
+        }
+      }
+
+      // Calculate efficiency plots
+      if (!matTrack.hasNoHits()) {
+
+        matTrack.sortHits();
+
+        // Get hits
+        int nActive = matTrack.getNActiveHits("all",true);
+        if (nActive>0) {
+
+          m_hadronTotalHitsGraph->SetPoint(m_hadronTotalHitsGraph->GetN(), eta, nActive);
+
+          double probability;
+          std::vector<double> probabilities = matTrack.getHadronActiveHitsProbability("all");
+
+          double averageHits  = 0;
+          double exactProb    = 0;
+          double moreThanProb = 0;
+          for (int i=probabilities.size()-1; i>=0; --i) {
+
+            //if (nActive==10) { // debug
+            //  std::cerr << "probabilities.at("
+            //  << i << ")=" << probabilities.at(i)
+            //  << endl;
+            //}
+            exactProb     = probabilities.at(i)-moreThanProb;
+            averageHits  += (i+1)*exactProb;
+            moreThanProb += exactProb;
+          }
+
+          m_hadronAverageHitsGraph->SetPoint(m_hadronAverageHitsGraph->GetN(), eta, averageHits);
+          //m_hadronAverageHitsGraph.SetPointError(_hadronAverageHitsGraph.GetN()-1, 0, sqrt( averageSquaredHits - averageHits*averageHits) );
+
+          unsigned int requiredHits;
+          for (unsigned int i = 0; i<m_hadronNeededHitsFraction.size(); ++i) {
+
+            requiredHits = int(ceil(double(nActive) * m_hadronNeededHitsFraction.at(i)));
+            if      (requiredHits==0)                   probability = 1;
+            else if (requiredHits>probabilities.size()) probability = 0;
+            else                                        probability = probabilities.at(requiredHits-1);
+
+            //if (probabilities.size()==10) { // debug
+            //  std::cerr << "required " << requiredHits
+            //              << " out of " << probabilities.size()
+            //              << " == " << nActive
+            //              << endl;
+            // std::cerr << "      PROBABILITY = " << probability << endl << endl;
+            //}
+            m_hadronGoodTracksFraction.at(i).SetPoint(m_hadronGoodTracksFraction.at(i).GetN(), eta, probability);
+          }
+        }
+      } // Calculate efficiency plots
+
+    } // For nTracks
+
+    //
+    // Normalization calculation
+    int nBins = m_radMap[trkName].GetNbinsX()*m_radMap[trkName].GetNbinsY();
+
+    for (int iBin=1; iBin<=nBins; ++iBin) {
+
+      // Update radiation map
+      double content = m_radMap[trkName].GetBinContent(iBin);
+      double count   = m_radMapCount[trkName].GetBinContent(iBin);
+
+      if      (count==1) m_radMap[trkName].SetBinContent(iBin,content);
+      else if (count>1)  m_radMap[trkName].SetBinContent(iBin,content/double(count));
+
+      m_radMap["Tracker"].SetBinContent(iBin, m_radMap["Tracker"].GetBinContent(iBin) + m_radMap[trkName].GetBinContent(iBin));
+
+      // Update interaction map (the same number of bins)
+      content = m_intMap[trkName].GetBinContent(iBin);
+      count   = m_intMapCount[trkName].GetBinContent(iBin);
+
+      if      (count==1) m_intMap[trkName].SetBinContent(iBin,content);
+      else if (count>1)  m_intMap[trkName].SetBinContent(iBin,content/double(count));
+
+      m_intMap["Tracker"].SetBinContent(iBin, m_intMap["Tracker"].GetBinContent(iBin) + m_intMap[trkName].GetBinContent(iBin));
     }
 
-  } // For trackers
+  } // For nTrackers
 
   m_isAnalysisOK = true;
   return m_isAnalysisOK;
@@ -94,11 +422,24 @@ bool AnalyzerMatBudget::visualize(RootWSite& webSite)
   int webPriority         = 89;
   RootWPage*    myPage    = nullptr;
   RootWContent* myContent = nullptr;
+  RootWImage*   myImage   = nullptr;
+  RootWTable*   myTable   = nullptr;
 
-  for (auto iTracker : m_trackers) {
+  for (int iTrk=0; iTrk<=m_trackers.size(); iTrk++) {
 
     // Tracker name
-    std::string trkName =  iTracker->myid();
+    const Tracker* tracker = nullptr;
+    std::string trkName;
+    if (iTrk==m_trackers.size()) {
+
+      tracker = nullptr;
+      trkName = "Tracker";
+    }
+    else {
+
+      tracker = m_trackers[iTrk];
+      trkName = m_trackers[iTrk]->myid();
+    }
 
     // Create dedicated web-page & its content
     std::string        pageTitle  = "MatBudget";
@@ -106,13 +447,775 @@ bool AnalyzerMatBudget::visualize(RootWSite& webSite)
     myPage = new RootWPage(pageTitle);
 
     // Page address
-    std::string pageAddress = "index"+trkName+".html";
+    std::string pageAddress = "mb"+trkName+".html";
     myPage->setAddress(pageAddress);
 
     webSite.addPage(myPage, webPriority);
     webPriority--;
 
+    //
+    // Material overview
+    myContent = new RootWContent("Material overview", true);
+    myPage->addContent(myContent);
+
+    // Prepare canvas
+    TCanvas* myCanvas = new TCanvas(std::string("MaterialInTrackingVolume"+trkName).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    TPad* myPad = dynamic_cast<TPad*>(myCanvas->GetPad(0));
+    myPad->SetFillColor(color_pad_background);
+
+    // Rebin material histograms to readable values
+    int rebinCoef = vis_material_eta_step/m_radMB["Total"]["Total"].GetXaxis()->GetBinWidth(0);
+    if (rebinCoef==0) rebinCoef = 1;
+
+    m_radMB[trkName]["Total"].SetFillColor(kGray + 2);
+    m_radMB[trkName]["Total"].SetLineColor(kBlue + 2);
+    m_radMB[trkName]["Total"].SetXTitle("#eta");
+    m_radMB[trkName]["Total"].Rebin(rebinCoef);
+    m_radMB[trkName]["Total"].Scale(1./rebinCoef);
+    double max = m_radMB[trkName]["Total"].GetMaximum();
+    m_radMB[trkName]["Total"].GetYaxis()->SetRangeUser(0, vis_safety_factor*max);
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(1));
+    myPad->cd();
+    m_radMB[trkName]["Total"].SetStats(kFALSE);
+    m_radMB[trkName]["Total"].Draw();
+
+    m_intMB[trkName]["Total"].SetFillColor(kGray + 2);
+    m_intMB[trkName]["Total"].SetLineColor(kBlue + 2);
+    m_intMB[trkName]["Total"].SetXTitle("#eta");
+    m_intMB[trkName]["Total"].Rebin(rebinCoef);
+    m_intMB[trkName]["Total"].Scale(1./rebinCoef);
+    max = m_intMB[trkName]["Total"].GetMaximum();
+    m_intMB[trkName]["Total"].GetYaxis()->SetRangeUser(0, vis_safety_factor*max);
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(2));
+    myPad->cd();
+    m_intMB[trkName]["Total"].SetStats(kFALSE);
+    m_intMB[trkName]["Total"].Draw();
+
+    // Write tracking volume plots to the web site
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment(std::string("Material overview in tracking volume: "+trkName));
+    myImage->setName("matOverview");
+
+    myTable = new RootWTable();
+    char titleString[256];
+    sprintf(titleString, std::string("Average radiation length [%] in tracking volume ("+web_etaLetter+" = [0, %.1f])").c_str(), geom_max_eta_coverage);
+    myTable->setContent(1, 1, titleString);
+    sprintf(titleString, std::string("Average interaction length [%] in tracking volume ("+web_etaLetter+" = [0, %.1f])").c_str(), geom_max_eta_coverage);
+    myTable->setContent(2, 1, titleString);
+    myTable->setContent(1, 2, averageHistogramValues(m_radMB[trkName]["Total"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(2, 2, averageHistogramValues(m_intMB[trkName]["Total"], geom_max_eta_coverage)*100, 2);
+    myContent->addItem(myTable);
+    myContent->addItem(myImage);
+
+    // Calculate summary table
+    RootWTable* materialSummaryTable = new RootWTable();
+
+    double averageValue;
+    materialSummaryTable->setContent(0,0,"Material    ");
+    materialSummaryTable->setContent(1,0,"Rad. length [%]");
+    materialSummaryTable->setContent(2,0,"Int. length [%]");
+    materialSummaryTable->setContent(3,0,"Photon conv. prob.");
+
+    // Material csv file
+    if (!m_materialCsv.existCsvText("Label")) {
+
+      m_materialCsv.addCsvElement("Label", "Tracker/Component name");
+      m_materialCsv.addCsvElement("Label", "Type");
+      for (unsigned int j=1; j< geom_name_eta_regions.size(); ++j) {
+
+        ostringstream label;
+        label << "eta(" << std::fixed << std::setprecision(1) << geom_range_eta_regions[j-1] << "-" <<geom_range_eta_regions[j] << ")";
+        m_materialCsv.addCsvElement("Label", label.str());
+      }
+      m_materialCsv.addCsvEOL("Label");
+    }
+
+    m_materialCsv.addCsvElement(trkName, trkName);
+    m_materialCsv.addCsvElement(trkName, "Rad. length [%]");
+    for (unsigned int j=1; j< geom_name_eta_regions.size(); ++j) {
+      // First row: the cut name
+      materialSummaryTable->setContent(0,j, geom_name_eta_regions[j]);
+
+      // Second row: the radiation length
+      averageValue = averageHistogramValues(m_radMB[trkName]["Total"], geom_range_eta_regions[j-1], geom_range_eta_regions[j]);
+      materialSummaryTable->setContent(1,j, averageValue*100 ,2);
+      m_materialCsv.addCsvElement(trkName, averageValue*100);
+    }
+    m_materialCsv.addCsvEOL(trkName);
+
+    m_materialCsv.addCsvElement(trkName, "");
+    m_materialCsv.addCsvElement(trkName, "Int. length [%]");
+    for (unsigned int j=1; j< geom_name_eta_regions.size(); ++j) {
+      // Third row: the interaction length
+      averageValue = averageHistogramValues(m_intMB[trkName]["Total"], geom_range_eta_regions[j-1], geom_range_eta_regions[j]);
+      materialSummaryTable->setContent(2,j, averageValue*100 ,2);
+      m_materialCsv.addCsvElement(trkName, averageValue*100);
+    }
+    m_materialCsv.addCsvEOL(trkName);
+
+    m_materialCsv.addCsvElement(trkName, "");
+    m_materialCsv.addCsvElement(trkName, "Photon conv. prob.");
+    for (unsigned int j=1; j< geom_name_eta_regions.size(); ++j) {
+      // Third row: the photon conversion probability
+      averageValue *= -7./9.;
+      averageValue = 1 - exp(averageValue);
+      materialSummaryTable->setContent(3,j, averageValue ,4);
+      m_materialCsv.addCsvElement(trkName, averageValue);
+    }
+    m_materialCsv.addCsvEOL(trkName);
+
+    //
+    // Detailed tracker material overview
+    myContent = new RootWContent("Material overview by category", true);
+    myPage->addContent(myContent);
+
+    // Set variables and book histograms
+    THStack* radContainer = new THStack("rstack", "Radiation Length by Category");
+    THStack* intContainer = new THStack("istack", "Interaction Length by Category");
+    TH1D *acr = nullptr, *aci = nullptr, *ser = nullptr, *sei = nullptr, *sur = nullptr, *sui = nullptr, *bpr = nullptr, *bpi = nullptr;
+
+    // Radiation length in tracking volume by active, serving or passive
+    m_radMB["Beampipe"]["Total"].SetFillColor(kGreen);
+    m_radMB["Beampipe"]["Total"].SetLineColor(kGreen);
+    m_radMB["Beampipe"]["Total"].SetXTitle("#eta");
+    m_radMB["Beampipe"]["Total"].Rebin(rebinCoef);
+    m_radMB["Beampipe"]["Total"].Scale(1./rebinCoef);
+    m_radMB[trkName]["Barrel"].SetFillColor(kYellow);
+    m_radMB[trkName]["Barrel"].SetLineColor(kYellow);
+    m_radMB[trkName]["Barrel"].SetXTitle("#eta");
+    m_radMB[trkName]["Barrel"].Rebin(rebinCoef);
+    m_radMB[trkName]["Barrel"].Scale(1./rebinCoef);
+    m_radMB[trkName]["Endcap"].SetFillColor(kRed);
+    m_radMB[trkName]["Endcap"].SetLineColor(kRed);
+    m_radMB[trkName]["Endcap"].SetXTitle("#eta");
+    m_radMB[trkName]["Endcap"].Rebin(rebinCoef);
+    m_radMB[trkName]["Endcap"].Scale(1./rebinCoef);
+    m_radMB[trkName]["Supports"].SetFillColor(kOrange+4);
+    m_radMB[trkName]["Supports"].SetLineColor(kOrange+4);
+    m_radMB[trkName]["Supports"].SetXTitle("#eta");
+    m_radMB[trkName]["Supports"].Rebin(rebinCoef);
+    m_radMB[trkName]["Supports"].Scale(1./rebinCoef);
+    m_radMB[trkName]["Services"].SetFillColor(kBlue);
+    m_radMB[trkName]["Services"].SetLineColor(kBlue);
+    m_radMB[trkName]["Services"].SetXTitle("#eta");
+    m_radMB[trkName]["Services"].Rebin(rebinCoef);
+    m_radMB[trkName]["Services"].Scale(1./rebinCoef);
+
+    // Interaction length in tracking volume by active, serving or passive
+    m_intMB["Beampipe"]["Total"].SetFillColor(kGreen-2);
+    m_intMB["Beampipe"]["Total"].SetLineColor(kGreen-2);
+    m_intMB["Beampipe"]["Total"].SetXTitle("#eta");
+    m_intMB["Beampipe"]["Total"].Rebin(rebinCoef);
+    m_intMB["Beampipe"]["Total"].Scale(1./rebinCoef);
+    m_intMB[trkName]["Barrel"].SetFillColor(kYellow+1);
+    m_intMB[trkName]["Barrel"].SetLineColor(kYellow+1);
+    m_intMB[trkName]["Barrel"].SetXTitle("#eta");
+    m_intMB[trkName]["Barrel"].Rebin(rebinCoef);
+    m_intMB[trkName]["Barrel"].Scale(1./rebinCoef);
+    m_intMB[trkName]["Endcap"].SetFillColor(kRed+1);
+    m_intMB[trkName]["Endcap"].SetLineColor(kRed+1);
+    m_intMB[trkName]["Endcap"].SetXTitle("#eta");
+    m_intMB[trkName]["Endcap"].Rebin(rebinCoef);
+    m_intMB[trkName]["Endcap"].Scale(1./rebinCoef);
+    m_intMB[trkName]["Supports"].SetFillColor(kOrange+2);
+    m_intMB[trkName]["Supports"].SetLineColor(kOrange+2);
+    m_intMB[trkName]["Supports"].SetXTitle("#eta");
+    m_intMB[trkName]["Supports"].Rebin(rebinCoef);
+    m_intMB[trkName]["Supports"].Scale(1./rebinCoef);
+    m_intMB[trkName]["Services"].SetFillColor(kAzure-2);
+    m_intMB[trkName]["Services"].SetLineColor(kAzure-2);
+    m_intMB[trkName]["Services"].SetXTitle("#eta");
+    m_intMB[trkName]["Services"].Rebin(rebinCoef);
+    m_intMB[trkName]["Services"].Scale(1./rebinCoef);
+
+    // Write all material information into web page table
+    myTable = new RootWTable();
+
+    // Average values by active, service and passive
+    sprintf(titleString, std::string("Average ("+web_etaLetter+" = [0, %.1f])").c_str(), geom_max_eta_coverage);
+    myTable->setContent(0, 0, titleString);
+    myTable->setContent(1, 0, "Beam pipe (green)");
+    myTable->setContent(2, 0, "Barrel modules (yellow)");
+    myTable->setContent(3, 0, "Endcap modules (red)");
+    myTable->setContent(4, 0, "Supports (brown)");
+    myTable->setContent(5, 0, "Services (blue)");
+    myTable->setContent(6, 0, "Total");
+    myTable->setContent(0, 1, "Radiation length [%]");
+    myTable->setContent(0, 2, "Interaction length [%]");
+    myTable->setContent(1, 1, averageHistogramValues(m_radMB["Beampipe"]["Total"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(1, 2, averageHistogramValues(m_intMB["Beampipe"]["Total"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(2, 1, averageHistogramValues(m_radMB[trkName]["Barrel"]  , geom_max_eta_coverage)*100, 2);
+    myTable->setContent(2, 2, averageHistogramValues(m_intMB[trkName]["Barrel"]  , geom_max_eta_coverage)*100, 2);
+    myTable->setContent(3, 1, averageHistogramValues(m_radMB[trkName]["Endcap"]  , geom_max_eta_coverage)*100, 2);
+    myTable->setContent(3, 2, averageHistogramValues(m_intMB[trkName]["Endcap"]  , geom_max_eta_coverage)*100, 2);
+    myTable->setContent(4, 1, averageHistogramValues(m_radMB[trkName]["Supports"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(4, 2, averageHistogramValues(m_intMB[trkName]["Supports"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(5, 1, averageHistogramValues(m_radMB[trkName]["Services"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(5, 2, averageHistogramValues(m_intMB[trkName]["Services"], geom_max_eta_coverage)*100, 2);
+    myTable->setContent(6, 1, averageHistogramValues(m_radMB[trkName]["Total"]   , geom_max_eta_coverage)*100, 2);
+    myTable->setContent(6, 2, averageHistogramValues(m_intMB[trkName]["Total"]   , geom_max_eta_coverage)*100, 2);
+    myContent->addItem(myTable);
+
+    // Rebin histograms, draw them to a canvas and write the canvas to the web page
+    myCanvas = new TCanvas(std::string("MaterialByCategoryIn"+trkName).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(0));
+    myPad->SetFillColor(color_pad_background);
+
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(1));
+    myPad->cd();
+    radContainer->Add(&m_radMB["Beampipe"]["Total"]);
+    radContainer->Add(&m_radMB[trkName]["Barrel"]);
+    radContainer->Add(&m_radMB[trkName]["Endcap"]);
+    radContainer->Add(&m_radMB[trkName]["Supports"]);
+    radContainer->Add(&m_radMB[trkName]["Services"]);
+    radContainer->Draw();
+    radContainer->GetXaxis()->SetTitle("#eta");
+
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(2));
+    myPad->cd();
+    intContainer->Add(&m_intMB["Beampipe"]["Total"]);
+    intContainer->Add(&m_intMB[trkName]["Barrel"]);
+    intContainer->Add(&m_intMB[trkName]["Endcap"]);
+    intContainer->Add(&m_intMB[trkName]["Supports"]);
+    intContainer->Add(&m_intMB[trkName]["Services"]);
+    intContainer->Draw();
+    intContainer->GetXaxis()->SetTitle("#eta");
+
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Material overview by category in tracking volume: "+trkName);
+    myImage->setName("riDistrCateg");
+    myContent->addItem(myImage);
+
+    //
+    // Detailed material overview by component
+    myContent = new RootWContent("Material overview by component", false);
+    myPage->addContent(myContent);
+
+    myTable = new RootWTable();
+    sprintf(titleString, std::string("Average ("+web_etaLetter+" = [0, %.1f])").c_str(), geom_max_eta_coverage);
+    myTable->setContent(0, 0, titleString);
+    myTable->setContent(0, 1, "Radiation length [%]");
+    myTable->setContent(0, 2, "Interaction length [%]");
+
+    // Set variables & book histograms
+    THStack* radCompStack = new THStack("rcompstack", "Radiation Length by Component");
+    THStack* intCompStack = new THStack("icompstack", "Interaction Length by Component");
+
+    TLegend* compLegend = new TLegend(0.1,0.6,0.35,0.9);
+
+    myCanvas = new TCanvas(std::string("MaterialByComponentIn"+trkName).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(0));
+    myPad->SetFillColor(color_pad_background);
+
+    // Radiation length for components
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(1));
+    myPad->cd();
+    int    compIndex      = 1;
+    double totalRadLength = 0;
+
+    m_radMB["Beampipe"]["Total"].SetLineColor(Palette::color(compIndex));
+    m_radMB["Beampipe"]["Total"].SetFillColor(Palette::color(compIndex));
+    m_radMB["Beampipe"]["Total"].SetXTitle("#eta");
+    radCompStack->Add(&m_radMB["Beampipe"]["Total"]);
+    compLegend->AddEntry(&m_radMB["Beampipe"]["Total"], "Beampipe");
+    compIndex++;
+    double avgValue = averageHistogramValues(m_radMB["Beampipe"]["Total"], geom_max_eta_coverage);
+    myTable->setContent(compIndex, 0, "Beampipe");
+    myTable->setContent(compIndex++, 1, avgValue*100, 2);
+    totalRadLength += avgValue;
+
+    for (auto& iComp : m_radMBComp[trkName]) {
+
+      iComp.second.SetLineColor(Palette::color(compIndex));
+      iComp.second.SetFillColor(Palette::color(compIndex));
+      iComp.second.SetXTitle("#eta");
+      iComp.second.Rebin(rebinCoef);
+      iComp.second.Scale(1./rebinCoef);
+      radCompStack->Add(&(iComp.second));
+      compLegend->AddEntry(&(iComp.second), iComp.first.c_str());
+      avgValue = averageHistogramValues(iComp.second, geom_max_eta_coverage);
+      myTable->setContent(compIndex, 0, iComp.first);
+      myTable->setContent(compIndex++, 1, avgValue*100, 2);
+      totalRadLength += avgValue;
+    }
+    myTable->setContent(compIndex, 0, "Total");
+    myTable->setContent(compIndex, 1, totalRadLength*100, 2);
+    radCompStack->Draw();
+    radCompStack->GetXaxis()->SetTitle("#eta");
+    compLegend->Draw();
+
+    // Interaction length for components
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(2));
+    myPad->cd();
+    compIndex             = 1;
+    double totalIntLength = 0;
+
+    m_intMB["Beampipe"]["Total"].SetLineColor(Palette::color(compIndex));
+    m_intMB["Beampipe"]["Total"].SetFillColor(Palette::color(compIndex));
+    m_intMB["Beampipe"]["Total"].SetXTitle("#eta");
+    intCompStack->Add(&m_intMB["Beampipe"]["Total"]);
+    compIndex++;
+    avgValue = averageHistogramValues(m_intMB["Beampipe"]["Total"], geom_max_eta_coverage);
+    myTable->setContent(compIndex++, 2, avgValue*100, 2);
+    totalIntLength += avgValue;
+
+    for (auto& iComp : m_intMBComp[trkName]) {
+
+      iComp.second.SetLineColor(Palette::color(compIndex));
+      iComp.second.SetFillColor(Palette::color(compIndex));
+      iComp.second.SetXTitle("#eta");
+      iComp.second.Rebin(rebinCoef);
+      iComp.second.Scale(1./rebinCoef);
+      intCompStack->Add(&(iComp.second));
+      avgValue = averageHistogramValues(iComp.second, geom_max_eta_coverage);
+      myTable->setContent(compIndex++, 2, avgValue*100, 2);
+      totalIntLength += avgValue;
+    }
+    myTable->setContent(compIndex, 2, totalIntLength*100, 2);
+    intCompStack->Draw();
+    intCompStack->GetXaxis()->SetTitle("#eta");
+    compLegend->Draw();
+
+    myContent->addItem(myTable);
+
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment(std::string("Material overview by component in tracking volume: "+trkName));
+    myImage->setName("riDistrComp");
+    myContent->addItem(myImage);
+
+    //
+    // Material map
+    myContent = new RootWContent("Material map", true);
+    myPage->addContent(myContent);
+
+
+    // Set variables & book histograms
+    TH2D *mapRad = nullptr, *mapInt = nullptr;
+
+    // Calculate final plot range, increase by safety factor
+    double maxZ = 0;
+    double maxR = 0;
+
+    if (tracker!=nullptr) {
+
+      maxZ = tracker->maxZ()*vis_safety_factor;
+      maxR = tracker->maxR()*vis_safety_factor;
+    }
+    else {
+
+      for (auto jTrk : m_trackers) {
+
+        MAX(maxZ, jTrk->maxZ()*vis_safety_factor);
+        MAX(maxR, jTrk->maxR()*vis_safety_factor);
+      }
+    }
+
+    // Radiation length plot
+    myCanvas = new TCanvas(std::string("RadMaterialMapIn"+trkName).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->cd();
+
+    m_radMap[trkName].GetXaxis()->SetRangeUser(0, maxZ);
+    m_radMap[trkName].GetYaxis()->SetRangeUser(0, maxR);
+    m_radMap[trkName].SetContour(vis_temperature_levels, 0);
+    m_radMap[trkName].GetYaxis()->SetTitleOffset(1.1);
+    m_radMap[trkName].SetStats(kFALSE);
+    m_radMap[trkName].Draw("COLZ");
+
+    myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Radiation length material map");
+    myImage->setName("matMapRad");
+    myContent->addItem(myImage);
+
+    // Interaction length plot
+    myCanvas = new TCanvas(std::string("IntMaterialMapIn"+trkName).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->cd();
+
+    m_intMap[trkName].GetXaxis()->SetRangeUser(0, maxZ);
+    m_intMap[trkName].GetYaxis()->SetRangeUser(0, maxR);
+    m_intMap[trkName].SetContour(vis_temperature_levels, 0);
+    m_intMap[trkName].GetYaxis()->SetTitleOffset(1.1);
+    m_intMap[trkName].SetStats(kFALSE);
+    m_intMap[trkName].Draw("COLZ");
+
+    myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Interaction length material map");
+    myImage->setName("matMapInt");
+    myContent->addItem(myImage);
+
+    //
+    // Hits occupancy
+    myContent = new RootWContent("Hits occupancy & track efficiency", true);
+    myPage->addContent(myContent);
+
+    // Set variables
+    std::map<int, std::vector<double> > averages;
+
+    // Number of hits
+    myCanvas = new TCanvas(std::string("HadronsHitsNumberIn"+trkName).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(0));
+    myPad->SetFillColor(color_pad_background);
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(1));
+    myPad->cd();
+
+    m_hadronTotalHitsGraph->SetTitle("Maximum (black) & average (red) number of hits");
+    m_hadronAverageHitsGraph->SetTitle("Maximum (black) & average (red) number of hits");
+    m_hadronTotalHitsGraph->SetMarkerStyle(8);
+    m_hadronTotalHitsGraph->SetMarkerColor(kBlack);
+    m_hadronTotalHitsGraph->SetMinimum(0);
+    m_hadronTotalHitsGraph->GetXaxis()->SetTitle("#eta");
+    m_hadronTotalHitsGraph->Draw("alp");
+    m_hadronAverageHitsGraph->SetMarkerStyle(8);
+    m_hadronAverageHitsGraph->SetMarkerColor(kRed);
+    m_hadronAverageHitsGraph->Draw("same lp");
+
+    //
+    // Track fraction
+    myPad = dynamic_cast<TPad*>(myCanvas->GetPad(2));
+    myPad->cd();
+    TLegend* myLegend = new TLegend(0.65, 0.16, .85, .40);
+    // Old-style palette by Stefano, with custom-generated colors
+    // Palette::prepare(hadronGoodTracksFraction.size()); // there was a 120 degree phase here
+    // Replaced by the libreOffice-like palette
+    TH1D* ranger = new TH1D(std::string("HadTrackRangerIn"+trkName).c_str(),"Track efficiency with given fraction of hits ", 100, 0, geom_max_eta_coverage);
+    ranger->SetMaximum(1.);
+    ranger->GetXaxis()->SetTitle("#eta");
+    //myAxis = ranger->GetYaxis();
+    //myAxis->SetTitle("Tracks fraction");
+    ranger->Draw();
+    ostringstream tempSS;
+    std::map<int, std::string> fractionTitles;
+
+    for (auto i=0; i<m_hadronGoodTracksFraction.size(); ++i) {
+
+      TGraph& myGraph = m_hadronGoodTracksFraction.at(i);
+      //std::cerr << "Good Hadrons fractions at (" << i <<") has " << myGraph.GetN() << " points" << std::endl;
+      //double xx, yy;
+      //myGraph.GetPoint(myGraph.GetN()-1, xx, yy);
+      //std::cerr << "Last point (x,y) = ("<< xx <<", " << yy <<")" << std::endl;
+      averages[i] = average(myGraph, geom_range_eta_regions);
+      closeGraph(myGraph);
+      myGraph.SetFillColor(Palette::color(i+1));
+      myGraph.Draw("same F");
+      tempSS.str("");
+      if (m_hadronNeededHitsFraction.at(i)!=0) {
+        if (m_hadronNeededHitsFraction.at(i)==0.0001)
+          tempSS << "1 hit required";
+        else
+          tempSS << int(m_hadronNeededHitsFraction.at(i)*100)
+            << "% hits required";
+        fractionTitles[i]=tempSS.str();
+        myLegend->AddEntry(&myGraph, fractionTitles[i].c_str(), "F");
+      }
+    }
+    ranger->Draw("sameaxis");
+    myLegend->Draw();
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Hits occupancy & track efficiency for hadrons");
+    myImage->setName("hadHitsTracks");
+    myContent->addItem(myImage);
+
+    //
+    // Summary table
+    RootWContent& summaryContent = myPage->addContent("Summary", false);
+
+    // Define variables
+    ostringstream label;
+
+    // Cuts summary table
+    RootWTable&   cutsSummaryTable = summaryContent.addTable();
+    cutsSummaryTable.setContent(0,0,"Region: ");
+    cutsSummaryTable.setContent(1,0,"Min "+web_etaLetter+":");
+    cutsSummaryTable.setContent(2,0,"Max "+web_etaLetter+":");
+
+    myTable = &cutsSummaryTable;
+    for (unsigned int iBorder=0; iBorder<geom_name_eta_regions.size()-1; ++iBorder) {
+      myTable->setContent(0,iBorder+1,geom_name_eta_regions[iBorder+1]);
+      label.str(""); label << std::fixed << std::setprecision(1) << geom_range_eta_regions[iBorder];
+      myTable->setContent(1,iBorder+1,label.str());
+      label.str(""); label << std::fixed << std::setprecision(1) << geom_range_eta_regions[iBorder+1];
+      myTable->setContent(2,iBorder+1,label.str());
+    }
+
+    // Calculate material bill
+    //for (auto materialBudget : materialBudgets) {
+    //  if (!m_materialBillCsv.existCsvText(materialBudget->getTracker().myid())) m_materialBillCsv.inspectTracker(*materialBudget);
+    //}
+
+    // Material summary table
+    summaryContent.addItem(materialSummaryTable);
+
   } // Trackers
 
+
+
   return true;
+}
+
+//
+// Helper method creating profile histogram from histogram
+//
+//TProfile* AnalyzerMatBudget::createProfileHis(const TH1D& sourceHistogram) const {
+//
+//  TProfile* resultProfile = nullptr;
+//  resultProfile = new TProfile(Form("%s_profile",sourceHistogram.GetName()),
+//                               sourceHistogram.GetTitle(),
+//                               sourceHistogram.GetNbinsX(),
+//                               sourceHistogram.GetXaxis()->GetXmin(),
+//                               sourceHistogram.GetXaxis()->GetXmax());
+//
+//  for (int i=1; i<=sourceHistogram.GetNbinsX(); ++i) {
+//    resultProfile->Fill(sourceHistogram.GetBinCenter(i), sourceHistogram.GetBinContent(i));
+//  }
+//  resultProfile->SetLineColor(sourceHistogram.GetLineColor());
+//  resultProfile->SetLineWidth(sourceHistogram.GetLineWidth());
+//  resultProfile->SetLineStyle(sourceHistogram.GetLineStyle());
+//  resultProfile->SetFillColor(sourceHistogram.GetFillColor());
+//  resultProfile->SetFillStyle(sourceHistogram.GetFillStyle());
+//
+//  return resultProfile;
+//}
+
+//
+// Helper method calculating average value in the given cut regions
+//
+std::vector<double> AnalyzerMatBudget::average(TGraph& myGraph, std::vector<double> cuts) {
+
+  std::vector<double> averages;
+  if (cuts.size()<2) return averages;
+
+  std::sort(cuts.begin(), cuts.end());
+  int iBorder;
+  int nBoarders=cuts.size();
+  double valuesCount, valuesSum;
+  double vx, vy;
+
+  for (iBorder=0; iBorder<nBoarders-1; ++iBorder) {
+
+    // Here we have a cut between
+    // cuts[iBorder] and cuts[iBorder+1]
+    //std::cerr << myGraph.GetTitle() << std::endl;
+    //std::cerr << cuts[iBorder] << "< x <= "<< cuts[iBorder+1] << std::endl;
+
+    // Average on points within the cut
+    valuesSum=0;
+    valuesCount=0;
+    for (int iPoint=0; iPoint<myGraph.GetN(); ++iPoint) {
+      myGraph.GetPoint(iPoint, vx, vy);
+      if ((vx>=cuts[iBorder]) && (vx<cuts[iBorder+1])) {
+        valuesCount++;
+        valuesSum+=vy;
+      }
+    }
+    averages.push_back(valuesSum/valuesCount);
+  }
+  return averages;
+}
+
+//
+// Modifies a TGraph, so that it looks like a histogram (can be filled)
+//
+void AnalyzerMatBudget::closeGraph(TGraph& myGraph) {
+  double x, y, x0, y0;
+  myGraph.GetPoint(myGraph.GetN()-1, x, y);
+  myGraph.GetPoint(0, x0, y0);
+  myGraph.SetPoint(myGraph.GetN(), x,0);
+  myGraph.SetPoint(myGraph.GetN(), x0,0);
+}
+
+//
+// Helper method calculating average histogram values in histogram range from lowest bin to cutoff
+//
+double AnalyzerMatBudget::averageHistogramValues(const TH1D& his, double cutoff) const {
+
+  double avg   = 0.0;
+  int    cobin = 1;
+
+  // Find last relevant bin
+  while ((cobin < his.GetNbinsX()) && (his.GetBinLowEdge(cobin) < cutoff)) cobin++;
+
+  // Calculate average
+  for (auto i = 1; i <= cobin; i++) avg = avg + his.GetBinContent(i) / (double)cobin;
+
+  return avg;
+}
+
+//
+// Helper method calculating average histogram values in range cutoffStart - cutoffEnd
+//
+double AnalyzerMatBudget::averageHistogramValues(const TH1D& his, double cutoffStart, double cutoffEnd) const {
+
+  double avg        = 0.0;
+  int    coBinStart = 1;
+  int    coBinEnd   = 1;
+
+  if (cutoffStart >= cutoffEnd) return 0;
+
+  // Find first relevant bin
+  while ((coBinStart < his.GetNbinsX()) && (his.GetBinLowEdge(coBinStart) < cutoffStart)) coBinStart++;
+  coBinEnd=coBinStart;
+
+  // Find last relevant bin
+  while ((coBinEnd < his.GetNbinsX()) && (his.GetBinLowEdge(coBinEnd) < cutoffEnd)) coBinEnd++;
+  double coBinN=coBinEnd-coBinStart+1; // TODO: IMPORTANT check this
+
+  // Calculate average
+  if (coBinStart> his.GetNbinsX() - 1) coBinStart= his.GetNbinsX() - 1;
+  if (coBinEnd > his.GetNbinsX() - 1) coBinEnd= his.GetNbinsX() - 1;
+  for (int i = coBinStart; i <= coBinEnd; i++) avg = avg + his.GetBinContent(i) / coBinN;
+
+  return avg;
+}
+
+//
+// ModuelCapsVisitor constructor
+//
+MaterialVisitor::MaterialVisitor(Track& matTrack, std::map<std::string, Material>& matBudget, TH2D& radMap, TH2D& radMapCount, TH2D& intMap, TH2D& intMapCount) :
+    m_matTrack(matTrack),
+    m_nEntries(0),
+    m_matBudget(matBudget),
+    m_radMap(radMap),
+    m_radMapCount(radMapCount),
+    m_intMap(intMap),
+    m_intMapCount(intMapCount)
+{
+}
+
+//
+// Destructor
+//
+MaterialVisitor::~MaterialVisitor()
+{
+}
+
+//
+// Visit BeamPipe -> update track with beam pipe hit
+//
+void MaterialVisitor::visit(const BeamPipe& bp)
+{
+  // Add hit corresponding with beam-pipe
+  double theta    = m_matTrack.getTheta();
+  double distance = (bp.radius()+bp.thickness())/2./sin(theta);
+  Hit* hit = new Hit(distance);
+  hit->setOrientation(HitOrientation::Horizontal);
+  hit->setObjectKind(HitKind::Inactive);
+
+  Material material;
+  material.radiation   = bp.radLength()/sin(theta);
+  material.interaction = bp.intLength()/sin(theta);
+  hit->setCorrectedMaterial(material);
+  hit->setBeamPipe(true);
+  m_matTrack.addHit(hit); ;
+}
+
+//
+// Visit BarrelModule (no limits on Rods, Layers or Barrels)
+//
+void MaterialVisitor::visit(const BarrelModule& m)
+{
+  analyzeModuleMB(m);
+}
+
+//
+// Visit EndcapModule (no limits on Rings or Endcaps)
+//
+void MaterialVisitor::visit(const EndcapModule& m)
+{
+  analyzeModuleMB(m);
+}
+
+//
+// Post visit method called after the whole visit-accept pattern done to recalibrate histograms, etc.
+//
+void MaterialVisitor::postvisit()
+{
+}
+
+//
+// Analyze if module crossed by given track & how much material is in the way
+//
+void MaterialVisitor::analyzeModuleMB(const DetectorModule& m)
+{
+  // Collision detection: material tracks being shot in z+ only, so consider only modules that lie on +Z side
+  if (m.maxZ() > 0) {
+
+    XYZVector direction(m_matTrack.getDirection());
+    auto pair    = m.checkTrackHits(m_matTrack.getOrigin(), direction);
+    auto hitRho  = pair.first.rho();
+    auto hitType = pair.second;
+
+    if (hitType!=HitType::NONE) {
+
+      // Number of entries
+      m_nEntries++;
+
+      Material material;
+      material.radiation   = m.getModuleCap().getRadiationLength();
+      material.interaction = m.getModuleCap().getInteractionLength();
+
+      // Fill material map
+      double theta = m_matTrack.getTheta();
+      double rho   = hitRho;
+      double z     = rho/tan(theta);
+
+      if (material.radiation>0){
+
+        m_radMap.Fill(z,rho,material.radiation);
+        m_radMapCount.Fill(z,rho);
+      }
+      if (material.interaction>0) {
+
+        m_intMap.Fill(z,rho,material.interaction);
+        m_intMapCount.Fill(z,rho);
+      }
+
+      // Treat barrel & endcap modules separately
+      double tiltAngle = m.tiltAngle();
+
+      if (m.subdet() == BARREL) {
+
+        material.radiation   /= sin(theta + tiltAngle);
+        material.interaction /= sin(theta + tiltAngle);
+
+        // Fill barrel container
+        m_matBudget["Barrel"].radiation   += material.radiation;
+        m_matBudget["Barrel"].interaction += material.interaction;
+      }
+      else if (m.subdet() == ENDCAP) {
+
+        material.radiation   /= cos(theta + tiltAngle - M_PI/2);
+        material.interaction /= cos(theta + tiltAngle - M_PI/2);
+
+        // Fill endcap container
+        m_matBudget["Endcap"].radiation   += material.radiation;
+        m_matBudget["Endcap"].interaction += material.interaction;
+      }
+      else {
+        logWARNING("AnalyzerMatBudget::analyzeModuleMB -> incorrectly scaled material, unknown module type. Neither barrel or endcap");
+      }
+
+      // Fill other components
+      std::map<std::string, Material> components = m.getModuleCap().getComponentsRI();
+
+      for (auto iComponent : components) {
+
+        m_matBudget[iComponent.first].radiation   += iComponent.second.radiation / (m.subdet()==BARREL ? sin(theta + tiltAngle) : cos(theta + tiltAngle - M_PI/2));
+        m_matBudget[iComponent.first].interaction += iComponent.second.interaction / (m.subdet()==BARREL ? sin(theta + tiltAngle) : cos(theta + tiltAngle - M_PI/2));
+      }
+
+      // Create Hit object with appropriate parameters, add to Track t
+      Hit* hit = new Hit(pair.first.R(), &m, hitType);
+      hit->setCorrectedMaterial(material);
+      m_matTrack.addHit(hit);
+    }
+  } // Z>0
 }

--- a/source/Geometry/include/BeamPipe.h
+++ b/source/Geometry/include/BeamPipe.h
@@ -52,8 +52,8 @@ class BeamPipe : public PropertyObject, public Identifiable<string>, public Buil
   ReadonlyProperty<double, Default>   radius;           //!< Beam pipe radius
   ReadonlyProperty<double, Default>   thickness;        //!< Beam pipe thickness
   ReadonlyProperty<double, Default>   maxZ;             //!< Beam pipe extends from minimum Z to maximum Z
-  ReadonlyProperty<double, Default>   radLength;        //!< Beam pipe rad. length in [%] @ 90 deg
-  ReadonlyProperty<double, Default>   intLength;        //!< Beam pipe int. lenght in [%] @ 90 deg
+  ReadonlyProperty<double, Default>   radLength;        //!< Beam pipe rad. length @ 90 deg
+  ReadonlyProperty<double, Default>   intLength;        //!< Beam pipe int. lenght @ 90 deg
 
  private:
 

--- a/source/Geometry/include/DetectorModule.h
+++ b/source/Geometry/include/DetectorModule.h
@@ -67,8 +67,11 @@ public:
   //! Set materials, so called module-cap to a module
   void setModuleCap(ModuleCap* newCap);
 
-  //! Get materials, i.e. module-cap
+  //! Get materials, i.e. module-cap to be modified
   ModuleCap* getModuleCap() { return m_myModuleCap;}
+
+  //! Get materials, i.e. module-cap to be read-only
+  const ModuleCap& getModuleCap() const { return *m_myModuleCap; }
 
   //! Geometric module interface -> return reference to a geometrical representation of a module
   const Polygon3d<4>& basePoly() const { return decorated().basePoly(); }
@@ -216,7 +219,7 @@ public:
   virtual int16_t  moduleRing() const { return -1; }
 
   double trackCross(const XYZVector& PL, const XYZVector& PU) { return decorated().trackCross(PL, PU); }
-  std::pair<XYZVector, HitType> checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir);
+  std::pair<XYZVector, HitType> checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir) const;
 
  protected:
 

--- a/source/Geometry/include/MaterialProperties.h
+++ b/source/Geometry/include/MaterialProperties.h
@@ -98,8 +98,8 @@ namespace insur {
         double getTotalMass() const;
         double getLocalMass();
         double getExitingMass();
-        double getRadiationLength();
-        double getInteractionLength();
+        double getRadiationLength() const;
+        double getInteractionLength() const ;
         RILength getMaterialLengths();
         const std::map<std::string, RILength>& getComponentsRI() const;
         // output calculations

--- a/source/Geometry/src/DetectorModule.cc
+++ b/source/Geometry/src/DetectorModule.cc
@@ -336,7 +336,7 @@ double DetectorModule::effectiveDsDistance() const {
   else return dsDistance()*sin(center().Theta())/sin(center().Theta()+tiltAngle());
 }
 
-std::pair<XYZVector, HitType> DetectorModule::checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir) {
+std::pair<XYZVector, HitType> DetectorModule::checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir) const {
 
   HitType ht = HitType::NONE;
   XYZVector gc; // global coordinates of the hit
@@ -359,7 +359,7 @@ std::pair<XYZVector, HitType> DetectorModule::checkTrackHits(const XYZVector& tr
     else if (outSegm.second > -1) { gc = outSegm.first; ht = HitType::OUTER; }
   }
   //basePoly().isLineIntersecting(trackOrig, trackDir, gc); // this was just for debug
-  if (ht != HitType::NONE) m_numHits++;
+  // if (ht != HitType::NONE) m_numHits++; // TODO: correct -> don't change it's content!!!
   return std::make_pair(gc, ht);
 };
 

--- a/source/Geometry/src/MaterialProperties.cc
+++ b/source/Geometry/src/MaterialProperties.cc
@@ -252,7 +252,7 @@ namespace insur {
      * Get the radiation length of the inactive element.
      * @return The overall radiation length, taking into account all registered materials; -1 if the value has not yet been computed
      */
-    double MaterialProperties::getRadiationLength() { return r_length; }
+    double MaterialProperties::getRadiationLength() const { return r_length; }
     
 
     const std::map<std::string, RILength>& MaterialProperties::getComponentsRI() const { return componentsRI; } // CUIDADO: I know it parts with the old API but it's so much more practical this way
@@ -261,7 +261,7 @@ namespace insur {
      * Get the intraction length of the inactive element.
      * @return The overall radiation length, taking into account all registered materials; -1 if the value has not yet been computed
      */
-    double MaterialProperties::getInteractionLength() { return i_length; }
+    double MaterialProperties::getInteractionLength() const { return i_length; }
 
     RILength MaterialProperties::getMaterialLengths() {
       RILength myMaterials;

--- a/source/Tools/include/CsvTextBuilder.h
+++ b/source/Tools/include/CsvTextBuilder.h
@@ -20,20 +20,20 @@
 class CsvTextBuilder {
 
  public:
-  // Constructor - default
+  //! Constructor - default
   CsvTextBuilder() : m_csvSeparator(";") {}
-  // Constructor - set csv separator
+  //! Constructor - set csv separator
   CsvTextBuilder(std::string csvSeparator) : m_csvSeparator(csvSeparator) {}
-  // Add an element (element+;) to a csv formatted text (map of strings), id identifies a given section in the text (label etc.)
+  //! Add an element (element+;) to a csv formatted text (map of strings), id identifies a given section in the text (label etc.)
   void addCsvElement(std::string id, std::string element);
   void addCsvElement(std::string id,  double element);
-  // Remove last ';' character and add end-of-line character to a csv formatted text
+  //! Remove last ';' character and add end-of-line character to a csv formatted text
   void addCsvEOL(std::string id);
-  // Read text block content
+  //! Read text block content
   std::string getCsvText(std::string id) { return m_text[id]; }
-  // Clear text block content
+  //! Clear text block content
   void clearCsVText(std::string id);
-  // Test if text block exists
+  //! Test if text block exists
   bool existCsvText(std::string id);
 
   // Iterators over ids & individual text blocks
@@ -41,8 +41,8 @@ class CsvTextBuilder {
   std::map<std::string, std::string>::iterator getCsvTextEnd()   { return m_text.end();}
 
  private:
-  std::string                        m_csvSeparator; // csv separator character
-  std::map<std::string, std::string> m_text;         // by ID one identifies the text block
+  std::string                        m_csvSeparator; //!< csv separator character
+  std::map<std::string, std::string> m_text;         //!< by ID one identifies the text block
 
 
 };

--- a/source/Tools/include/Palette.h
+++ b/source/Tools/include/Palette.h
@@ -7,20 +7,31 @@
 #include <string>
 #include <map>
 
+/*
+ * @class Color Palette
+ * @brief Helper static class providing color from ROOT color palette based on index or color name
+ */
 class Palette {
+
  public:
-  static Color_t color(const std::string& objectName);
-  static Color_t color(const unsigned int& colorIndex);
+
+  //! Based on module predefined type return standard color
+  static       Color_t color(const std::string& objectName);
+
+  //! Based on index return predefined color, if index higher than color range, modulo range operator used
+  static       Color_t color(const unsigned int& colorIndex);
+
   static const Color_t color_invalid_module = kGray + 1;
+
  private:
+
   static std::map<std::string, int> colorPickMap;
+
+  //! Internal definition of color map
   static Color_t color_int(const unsigned int& plotIndex);
   static bool initialized;
   static void initializeMe();
-  // static void skipColors(unsigned int colorIndex);
-  //private:
-  //static unsigned int myColorBase;
-  //static unsigned int myColors;
-};
+
+}; // Class
 
 #endif

--- a/source/Tools/include/Palette.h
+++ b/source/Tools/include/Palette.h
@@ -1,8 +1,7 @@
-#ifndef palette_h
-#define palette_h
+#ifndef INLCUDE_PALETTE_H_
+#define INCLUDE_PALETTE_H_
 
 #include <TColor.h>
-#include <TROOT.h>
 #include <iostream>
 #include <string>
 #include <map>
@@ -21,17 +20,21 @@ class Palette {
   //! Based on index return predefined color, if index higher than color range, modulo range operator used
   static       Color_t color(const unsigned int& colorIndex);
 
+  //! Set one of Root predefined palettes for drawing TH2D etc -> default RainBow (i.e. 55)
+  static       void setRootPalette(short palette);
+
   static const Color_t color_invalid_module = kGray + 1;
 
  private:
 
   static std::map<std::string, int> colorPickMap;
 
-  //! Internal definition of color map
+  //! Internal definition of color map: index <-> color relation
   static Color_t color_int(const unsigned int& plotIndex);
-  static bool initialized;
-  static void initializeMe();
+
+  static bool    initialized;    //!< Has been initialized
+  static void    initializeMe(); //!< Standard initialization method
 
 }; // Class
 
-#endif
+#endif /* INCLUDE_PALETTE_H_*/

--- a/source/Tools/include/global_constants.h
+++ b/source/Tools/include/global_constants.h
@@ -112,6 +112,13 @@ static const double vis_eta_step           = 0.1;
 static const double vis_material_eta_step  = 0.05;
 static const int    vis_n_bins             = geom_max_eta_coverage/vis_eta_step;  // Default number of bins in histogram from eta=0  to max_eta_coverage
 
+// Colors for plot background and such
+static const int color_plot_background     = kWhite;
+static const int color_pad_background      = kGray;
+static const int color_grid                = kGreen-10;
+static const int color_hard_grid           = kGray;
+static const std::vector<std::string> color_names = {"Black","BrightBlue","Red","BrightGreen","Yellow","Pink","Aqua","Green","Blue"};
+
 /**
  * Internal string constants for standard one-sided and specialised double-sided, rotated types
  */

--- a/source/Tools/src/Palette.cc
+++ b/source/Tools/src/Palette.cc
@@ -1,4 +1,5 @@
 #include <Palette.h>
+#include <TStyle.h>
 
 bool Palette::initialized = false;  
 std::map<std::string, int> Palette::colorPickMap;
@@ -45,6 +46,14 @@ Color_t Palette::color(const std::string& type) {
 Color_t Palette::color(const unsigned int& plotIndex) {
   if (!initialized) initializeMe();
   return color_int(plotIndex);
+}
+
+//
+// Set one of predefined Root palette -> default RainBow (i.e. 55)
+//
+void Palette::setRootPalette(short palette=55) {
+
+  gStyle->SetPalette(palette);
 }
 
 //

--- a/source/Tools/src/Palette.cc
+++ b/source/Tools/src/Palette.cc
@@ -3,18 +3,21 @@
 bool Palette::initialized = false;  
 std::map<std::string, int> Palette::colorPickMap;
 
-
 void Palette::initializeMe() {
-  Palette::colorPickMap["pt2S"] = 2;
-  Palette::colorPickMap["rphi"] = 4;
+  Palette::colorPickMap["pt2S"]   = 2;
+  Palette::colorPickMap["rphi"]   = 4;
   Palette::colorPickMap["stereo"] = 6;
-  Palette::colorPickMap["ptIn"] = 9;
-  Palette::colorPickMap["ptPS"] = 1;
-  Palette::colorPickMap["pixel"] = 9;
+  Palette::colorPickMap["ptIn"]   = 9;
+  Palette::colorPickMap["ptPS"]   = 1;
+  Palette::colorPickMap["pixel"]  = 9;
   initialized = true;
 }
 
+//
+// Based on module predefined type return standard color
+//
 Color_t Palette::color(const std::string& type) {
+
   if (!initialized) initializeMe();
   if (type=="") return color_invalid_module;
   if (colorPickMap[type]==0) {
@@ -36,11 +39,17 @@ Color_t Palette::color(const std::string& type) {
   return color_int(colorPickMap[type]);
 }
 
+//
+// Based on index return predefined color, if index higher than color range, modulo range operator used
+//
 Color_t Palette::color(const unsigned int& plotIndex) {
   if (!initialized) initializeMe();
   return color_int(plotIndex);
 }
 
+//
+// Internal definition of color map
+//
 Color_t Palette::color_int(const unsigned int& plotIndex) {
   std::string colorCode;
   

--- a/source/Tracking/include/Hit.h
+++ b/source/Tracking/include/Hit.h
@@ -64,6 +64,7 @@ public:
   void setTrack(const Track* newTrack)              { m_track = newTrack; updateRadius();};
   void setCorrectedMaterial(RILength newMaterial)   { m_correctedMaterial = newMaterial;};
   void setPixel(bool isPixel)                       { m_isPixel = isPixel;}
+  void setBeamPipe(bool isBeamPipe)                 { m_isBeamPipe = isBeamPipe;}
   void setTrigger(bool isTrigger)                   { m_isTrigger = isTrigger;}
   void setResolutionRphi(double newRes)             { m_resolutionRphi = newRes; } // Only used for virtual hits on non-modules
   void setResolutionY(double newRes)                { m_resolutionY = newRes; } // Only used for virtual hits on non-modules
@@ -86,6 +87,7 @@ public:
   bool isPixel() const   { return m_isPixel; };
   bool isTrigger() const { return m_isTrigger; };
   bool isIP() const      { return m_isIP; };
+  bool isBeamPipe() const{ return m_isBeamPipe; };
   bool isSquareEndcap();
   bool isStub() const;
 
@@ -100,11 +102,12 @@ protected:
   const DetectorModule* m_hitModule;  //!< Const pointer to the hit module
   const Track*          m_track;      //!< Const pointer to the track, into which the hit was assigned
   
-  RILength m_correctedMaterial;
+  RILength m_correctedMaterial; //!< Material in the way of particle shot at m_track direction, i.e. theta, module tilt angles corrected
   
   bool m_isPixel;   //!< Hit coming from the pixel module?
   bool m_isTrigger; //!< Hit comint from the trigger module?
   bool m_isIP;      //!< An artificial hit, simulating IP constraint?
+  bool m_isBeamPipe;//!< An artificial hit, simulating colision with beam-pipe?
 
 private:
   

--- a/source/Tracking/include/Hit.h
+++ b/source/Tracking/include/Hit.h
@@ -30,6 +30,7 @@ enum class HitKind        : short { Undefined, Active, Inactive };     // Hit ob
  * All the other information is available to both categories. For convenience, the scaled radiation and interaction lengths are stored in
  * here as well to avoid additional computation and callbacks to the material property objects.
  */
+// TODO: Remove pointer to track and find another method without any pointers involved!
 class Hit {
 
 public:

--- a/source/Tracking/include/Hit.h
+++ b/source/Tracking/include/Hit.h
@@ -1,28 +1,25 @@
 /**
- * @file hit.hh
+ * @file Hit.h
  * @brief This header file defines the hit and track classes used for internal analysis
  */
-
-
 #ifndef INCLUDE_HIT_H_
 #define INCLUDE_HIT_H_
 
-#include "DetectorModule.h"
-#include "PtErrorAdapter.h"
-#include <MaterialProperties.h>
 #include <cmath>
 #include <vector>
-#include <TMatrixT.h>
-#include <TMatrixTSym.h>
-#include <MessageLogger.h>
 
-//using namespace ROOT::Math;
-using namespace std;
+#include "DetectorModule.h"
+#include "MaterialProperties.h"
 
+// Forward declaration
+class DetectorModule;
 class Track;
 
 #undef HIT_DEBUG
 #undef HIT_DEBUG_RZ
+
+enum class HitOrientation : short { Undefined, Horizontal, Vertical};  // Hit object orientation
+enum class HitKind        : short { Undefined, Active, Inactive };     // Hit object type
 
 /**
  * @class Hit
@@ -34,79 +31,87 @@ class Track;
  * here as well to avoid additional computation and callbacks to the material property objects.
  */
 class Hit {
-protected:
-  
-  double distance_;      // distance of hit from origin in 3D
-  double radius_;        // distance of hit from origin in the x/y plane
-  int    orientation_;   // orientation of the surface
-  int    objectKind_;    // kind of hit object
-  
-  DetectorModule* hitModule_;    // Pointer to the hit module
-  const Track*          myTrack_;      // Pointer to the track
-  
-  RILength correctedMaterial_;
-  
-  bool isPixel_;
-  bool isTrigger_;
-  bool isIP_;
-  
-  HitType activeHitType_;
-
-private:
-  
-  double myResolutionRphi_; // Only used for virtual hits on non-modules
-  double myResolutionY_;    // Only used for virtual hits on non-modules
 
 public:
- 
+
+  //! Constructor
   Hit();
-  ~Hit();
+
+  //
   Hit(const Hit& h);
+
+  //! Constructor for a hit with no module at a given distance from the origin
   Hit(double myDistance);
-  Hit(double myDistance, DetectorModule* myModule, HitType activeHitType);
-  
+
+  //! Constructor for a hit on a given module at a given distance from the origin
+  Hit(double myDistance, const DetectorModule* myModule, HitType activeHitType);
+
+  //! Destructor
+  ~Hit();
+
   //! Given two hits, compare the distance to the z-axis.
   static bool sortSmallerR(Hit* h1, Hit* h2);
 
-  DetectorModule* getHitModule() { return hitModule_; };
-  void setHitModule(DetectorModule* myModule);
-  
-  /**
-   * @enum An enumeration of the category and orientation constants used within the object
-   */
-  enum { Undefined, Horizontal, Vertical,  // Hit object orientation 
-    Active, Inactive };                    // Hit object type
+  //! Update hit radius (radius in 2D - xy plane), based on new track parameters
+  void updateRadius() {m_radius = m_distance * sin(getTrackTheta());};
 
-  double   getDistance() {return distance_;};
-  void     setDistance(double newDistance) { if (newDistance>0) distance_ = newDistance; updateRadius(); };
-  double   getRadius() {return radius_;};
-  void     updateRadius() {radius_ = distance_ * sin(getTrackTheta());};
-  int      getOrientation() { return orientation_;};
-  void     setOrientation(int newOrientation) { orientation_ = newOrientation; };
-  int      getObjectKind() { return objectKind_;};
-  void     setObjectKind(int newObjectKind) { objectKind_ = newObjectKind;};
-  void     setTrack(const Track* newTrack) {myTrack_ = newTrack; updateRadius();};
-  double   getTrackTheta();
-  RILength getCorrectedMaterial();
-  void     setCorrectedMaterial(RILength newMaterial) { correctedMaterial_ = newMaterial;};
-  
-  bool   isPixel() { return isPixel_; };
-  bool   isTrigger() { return isTrigger_; };
-  bool   isIP() { return isIP_; };
-  void   setPixel(bool isPixel) { isPixel_ = isPixel;}
-  void   setTrigger(bool isTrigger) { isTrigger_ = isTrigger;}
-  double getResolutionRphi(double trackR);
-  double getResolutionZ(double trackR);
-  void   setResolutionRphi(double newRes) { myResolutionRphi_ = newRes; } // Only used for virtual hits on non-modules
-  void   setResolutionY(double newRes) { myResolutionY_ = newRes; } // Only used for virtual hits on non-modules
-  bool   setIP(bool newIP) { return isIP_ = newIP; }
+  // Setter methods
+  void setHitModule(const DetectorModule* myModule);
+  void setDistance(double newDistance)              { if (newDistance>0) m_distance = newDistance; updateRadius(); };
+  void setOrientation(HitOrientation newOrientation){ m_orientation = newOrientation; };
+  void setObjectKind(HitKind newObjectKind)         { m_objectKind = newObjectKind;};
+  void setTrack(const Track* newTrack)              { m_track = newTrack; updateRadius();};
+  void setCorrectedMaterial(RILength newMaterial)   { m_correctedMaterial = newMaterial;};
+  void setPixel(bool isPixel)                       { m_isPixel = isPixel;}
+  void setTrigger(bool isTrigger)                   { m_isTrigger = isTrigger;}
+  void setResolutionRphi(double newRes)             { m_resolutionRphi = newRes; } // Only used for virtual hits on non-modules
+  void setResolutionY(double newRes)                { m_resolutionY = newRes; } // Only used for virtual hits on non-modules
+  bool setIP(bool newIP)                            { return m_isIP = newIP; }
+  void setActiveHitType(HitType activeHitType)      { m_activeHitType = activeHitType; }
 
+  // Getter methods
+  const DetectorModule* getHitModule() { return m_hitModule; };
+
+  double         getDistance() const               { return m_distance;};
+  double         getRadius() const                 { return m_radius;};
+  HitOrientation getOrientation() const            { return m_orientation;};
+  HitKind        getObjectKind() const             { return m_objectKind;};
+  RILength       getCorrectedMaterial();
+  double         getResolutionRphi(double trackR);
+  double         getResolutionZ(double trackR);
+  double         getD();
+  HitType        getActiveHitType() const          { return m_activeHitType; } // NONE, INNER, OUTER, BOTH or STUB -- only meaningful for hits on active elements
+
+  bool isPixel() const   { return m_isPixel; };
+  bool isTrigger() const { return m_isTrigger; };
+  bool isIP() const      { return m_isIP; };
   bool isSquareEndcap();
-  double getD();
+  bool isStub() const;
 
-  void setActiveHitType(HitType activeHitType) { activeHitType_ = activeHitType; }
-  HitType getActiveHitType() const { return activeHitType_; } // NONE, INNER, OUTER, BOTH or STUB -- only meaningful for hits on active elements
-  bool isStub() const { return activeHitType_ == HitType::STUB; }
-};
+protected:
+  
+  double         m_distance;      //!< Distance of hit from origin in 3D
+  double         m_radius;        //!< Distance of hit from origin in the x/y plane
+  HitOrientation m_orientation;   //!< Orientation of the surface
+  HitKind        m_objectKind;    //!< Kind of hit object: Active, Inactive, ...
+  HitType        m_activeHitType; //!< Hit coming from inner, outer, stub, ... module
+  
+  const DetectorModule* m_hitModule;  //!< Const pointer to the hit module
+  const Track*          m_track;      //!< Const pointer to the track, into which the hit was assigned
+  
+  RILength m_correctedMaterial;
+  
+  bool m_isPixel;   //!< Hit coming from the pixel module?
+  bool m_isTrigger; //!< Hit comint from the trigger module?
+  bool m_isIP;      //!< An artificial hit, simulating IP constraint?
+
+private:
+  
+  double   getTrackTheta();
+
+  double m_resolutionRphi; // Only used for virtual hits on non-modules
+  double m_resolutionY;    // Only used for virtual hits on non-modules
+
+}; // Class
 
 #endif /* INCLUDE_HIT_H_ */

--- a/source/Tracking/include/Track.h
+++ b/source/Tracking/include/Track.h
@@ -115,7 +115,7 @@ public:
   const std::set<std::string>& getTags() const { return m_tags; }
 
   //! Get a vector of pairs: Detector module & hit type
-  std::vector<std::pair<DetectorModule*, HitType>> getHitModules() const;
+  std::vector<std::pair<const DetectorModule*, HitType>> getHitModules() const;
 
   const double& getDeltaRho() const      { return m_deltaRho; }
   const double& getDeltaPhi() const      { return m_deltaPhi; }

--- a/source/Tracking/include/Track.h
+++ b/source/Tracking/include/Track.h
@@ -96,10 +96,14 @@ public:
   double getRho() const                { return (m_radius>0 ? 1/m_radius : 0);}
   double getRadius() const             { return m_radius; }
   
-  //! Get number of active hits assigned to track for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file)
+  const Polar3DVector& getDirection() const { return m_direction; }
+  const XYZVector& getOrigin() const        { return m_origin; }
+
+  //! Get number of active hits assigned to track for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file). If tag specified as "all" no extra tag required
   int getNActiveHits(std::string tag, bool useIP = true) const;
 
   //! Get the probabilty of having "clean" hits for nuclear-interacting particles for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file)
+  //! If tag specified as "all" no extra tag required
   std::vector<double> getHadronActiveHitsProbability(std::string tag);
 
   //! Get the probabilty of having a given number of "clean" hits for nuclear-interacting particles for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file)

--- a/source/Tracking/src/Hit.cc
+++ b/source/Tracking/src/Hit.cc
@@ -199,7 +199,13 @@ double Hit::getResolutionZ(double trackR) {
   else {
 
     if (m_hitModule) {
-      return m_hitModule->resolutionEquivalentZ(getRadius(), trackR, m_track->getCotgTheta());
+
+      if (m_track==nullptr) {
+
+        logWARNING("Hit::getResolutionZ -> no track assigned, will return zero!");
+        return 0;
+      }
+      else return m_hitModule->resolutionEquivalentZ(getRadius(), trackR, m_track->getCotgTheta());
       //if (isTrigger_) return hitModule_->resolutionYTrigger();
       //else return hitModule_->resolutionY();
     }

--- a/source/Tracking/src/Hit.cc
+++ b/source/Tracking/src/Hit.cc
@@ -5,14 +5,17 @@
 
 #include "Hit.h"
 
-#include "Track.h"
-//#include "module.hh"
 #include <global_constants.h>
 #include <vector>
 #include <algorithm>
 #include <cstdlib>
 
-using namespace ROOT::Math;
+#include "DetectorModule.h"
+#include <MessageLogger.h>
+#include "PtErrorAdapter.h"
+#include "Track.h"
+
+//using namespace ROOT::Math;
 using namespace std;
 
 // bool Track::debugRemoval = false; // debug
@@ -39,18 +42,18 @@ Hit::~Hit() {}
  * The default constructor sets the internal parameters to default values.
  */
 Hit::Hit() {
-    distance_   = 0;
-    radius_     = 0;
-    objectKind_ = Undefined;
-    hitModule_  = NULL;
-    orientation_= Undefined;
-    myTrack_    = NULL;
-    isPixel_    = false;
-    isTrigger_  = false;
-    isIP_       = false;
-    myResolutionRphi_ = 0;
-    myResolutionY_    = 0;
-    activeHitType_    = HitType::NONE;
+    m_distance         = 0;
+    m_radius           = 0;
+    m_objectKind       = HitKind::Undefined;
+    m_orientation      = HitOrientation::Undefined;
+    m_hitModule        = nullptr;
+    m_track            = nullptr;
+    m_isPixel          = false;
+    m_isTrigger        = false;
+    m_isIP             = false;
+    m_resolutionRphi = 0;
+    m_resolutionY    = 0;
+    m_activeHitType    = HitType::NONE;
 }
 
 /**
@@ -58,19 +61,19 @@ Hit::Hit() {
  * be set explicitly later). The pointer to the module, on the other hand, stays the same as that of the original.
  */
 Hit::Hit(const Hit& h) {
-    distance_    = h.distance_;
-    radius_      = h.radius_;
-    orientation_ = h.orientation_;
-    objectKind_  = h.objectKind_;
-    hitModule_   = h.hitModule_;
-    correctedMaterial_ = h.correctedMaterial_;
-    myTrack_     = NULL;
-    isPixel_     = h.isPixel_;
-    isTrigger_   = h.isTrigger_;
-    isIP_        = h.isIP_;
-    myResolutionRphi_ = h.myResolutionRphi_;
-    myResolutionY_    = h.myResolutionY_;
-    activeHitType_    = h.activeHitType_;
+    m_distance          = h.m_distance;
+    m_radius            = h.m_radius;
+    m_objectKind        = h.m_objectKind;
+    m_orientation       = h.m_orientation;
+    m_hitModule         = h.m_hitModule;
+    m_track             = nullptr;
+    m_correctedMaterial = h.m_correctedMaterial;
+    m_isPixel           = h.m_isPixel;
+    m_isTrigger         = h.m_isTrigger;
+    m_isIP              = h.m_isIP;
+    m_resolutionRphi    = h.m_resolutionRphi;
+    m_resolutionY       = h.m_resolutionY;
+    m_activeHitType     = h.m_activeHitType;
 }
 
 /**
@@ -78,15 +81,18 @@ Hit::Hit(const Hit& h) {
  * @param myDistance distance from the origin
  */
 Hit::Hit(double myDistance) {
-    distance_    = myDistance;
-    objectKind_  = Undefined;
-    hitModule_   = NULL;
-    orientation_ = Undefined;
-    isTrigger_   = false;
-    isPixel_     = false;
-    isIP_        = false;
-    myTrack_     = NULL;
-    activeHitType_ = HitType::NONE;
+    m_distance         = myDistance;
+    m_radius           = 0;
+    m_objectKind       = HitKind::Undefined;
+    m_orientation      = HitOrientation::Undefined;
+    m_hitModule        = nullptr;
+    m_track            = nullptr;
+    m_isTrigger        = false;
+    m_isPixel          = false;
+    m_isIP             = false;
+    m_resolutionRphi   = 0;
+    m_resolutionY      = 0;
+    m_activeHitType    = HitType::NONE;
 }
 
 /**
@@ -94,16 +100,19 @@ Hit::Hit(double myDistance) {
  * @param myDistance distance from the origin
  * @param myModule pointer to the module with the hit 
  */
-Hit::Hit(double myDistance, DetectorModule* myModule, HitType activeHitType) {
-    distance_    = myDistance;
-    objectKind_  = Active;
-    orientation_ = Undefined; 
-    isTrigger_   = false;
-    isPixel_     = false;
-    isIP_        = false;
+Hit::Hit(double myDistance, const DetectorModule* myModule, HitType activeHitType) {
+    m_distance         = myDistance;
+    m_radius           = 0;
+    m_objectKind       = HitKind::Active;
+    m_orientation      = HitOrientation::Undefined;
     setHitModule(myModule);
-    myTrack_       = NULL;
-    activeHitType_ = activeHitType;
+    m_track            = nullptr;
+    m_isTrigger        = false;
+    m_isPixel          = false;
+    m_isIP             = false;
+    m_resolutionRphi   = 0;
+    m_resolutionY      = 0;
+    m_activeHitType    = activeHitType;
 }
 
 
@@ -111,15 +120,16 @@ Hit::Hit(double myDistance, DetectorModule* myModule, HitType activeHitType) {
  * Setter for the pointer to the active surface that caused the hit.
  * @param myModule A pointer to a barrel or endcap module; may be <i>NULL</i>
  */
-void Hit::setHitModule(DetectorModule* myModule) {
-    if (myModule) {
-        hitModule_ = myModule;
-        if (myModule->subdet() == BARREL) {
-            orientation_ = Horizontal;
-        } else {
-            orientation_ = Vertical;
-        }
-    }
+void Hit::setHitModule(const DetectorModule* myModule) {
+
+  if (myModule) {
+
+    m_hitModule = myModule;
+
+    if (myModule->subdet() == BARREL) m_orientation = HitOrientation::Horizontal;
+    else                              m_orientation = HitOrientation::Vertical;
+  }
+  else logWARNING("Hit::setHitModule -> can't set module to given hit, pointer null!");
 }
 
 /**
@@ -127,8 +137,13 @@ void Hit::setHitModule(DetectorModule* myModule) {
  * @return The angle from the z-axis of the entire track
  */
 double Hit::getTrackTheta() {
-    if (myTrack_==NULL) return 0;
-    return (myTrack_->getTheta());
+
+  if (m_track==nullptr) {
+
+    logWARNING("Hit::getTrackTheta -> no track assigned, will return zero!");
+    return 0;
+  }
+  return (m_track->getTheta());
 };
 
 /**
@@ -136,7 +151,7 @@ double Hit::getTrackTheta() {
  * @return A copy of the pair containing the requested values; radiation length first, interaction length second
  */
 RILength Hit::getCorrectedMaterial() {
-    return correctedMaterial_;
+    return m_correctedMaterial;
 }
 
 /**
@@ -148,17 +163,20 @@ RILength Hit::getCorrectedMaterial() {
  * @return the hit's local resolution
  */
 double Hit::getResolutionRphi(double trackR) {
-  if (objectKind_!=Active) {
-    std::cerr << "ERROR: Hit::getResolutionRphi called on a non-active hit" << std::endl;
+
+  if (m_objectKind!=HitKind::Active) {
+
+    logERROR("Hit::getResolutionRphi called on a non-active hit");
     return -1;
-  } else {
-    if (hitModule_) {
-      return hitModule_->resolutionEquivalentRPhi(getRadius(), trackR);
+  }
+  else {
+
+    if (m_hitModule) {
+      return m_hitModule->resolutionEquivalentRPhi(getRadius(), trackR);
      // if (isTrigger_) return hitModule_->resolutionRPhiTrigger();
      // else return hitModule_->resolutionRPhi();
-    } else {
-      return myResolutionRphi_;
     }
+    else return m_resolutionRphi;
   }
 }
 
@@ -172,17 +190,20 @@ double Hit::getResolutionRphi(double trackR) {
  * @return the hit's local resolution
  */
 double Hit::getResolutionZ(double trackR) {
-  if (objectKind_!=Active) {
-    std::cerr << "ERROR: Hit::getResolutionZ called on a non-active hit" << std::endl;
+
+  if (m_objectKind!=HitKind::Active) {
+
+    logERROR("Hit::getResolutionZ called on a non-active hit");
     return -1;
-  } else {
-    if (hitModule_) {
-      return hitModule_->resolutionEquivalentZ(getRadius(), trackR, myTrack_->getCotgTheta());
+  }
+  else {
+
+    if (m_hitModule) {
+      return m_hitModule->resolutionEquivalentZ(getRadius(), trackR, m_track->getCotgTheta());
       //if (isTrigger_) return hitModule_->resolutionYTrigger();
       //else return hitModule_->resolutionY();
-    } else {
-      return myResolutionY_;
     }
+    else return m_resolutionY;
   }
 }
 
@@ -192,19 +213,25 @@ double Hit::getResolutionZ(double trackR) {
  * @return true if the module is in outer endcap and square
  */
 bool Hit::isSquareEndcap() {
-  bool result = false;
-  if (isPixel_) return false;
+
+  if (m_isPixel) return false;
   //std::cout << "Hit::isSquareEndcap() "; //debug
-  if (hitModule_) {
+
+  if (m_hitModule) {
     //std::cout << " hitModule_!= NULL "; //debug
-    if (hitModule_->subdet() == ENDCAP && hitModule_->shape() == RECTANGULAR) {
+    if (m_hitModule->subdet() == ENDCAP && m_hitModule->shape() == RECTANGULAR) {
       //std::cout << " getSubdetectorType()==Endcap "; //debug
        //std::cout << " getShape()==Rectangular "; //debug
-       result = true;
+       return true;
     }
   }
   //std::cout << std::endl; // debug
-  return result;
+  return false;
+}
+
+bool Hit::isStub() const
+{
+  return m_activeHitType == HitType::STUB;
 }
 
 /*
@@ -213,16 +240,21 @@ bool Hit::isSquareEndcap() {
  * @return Modules half width
  */
 double Hit::getD() {
+
   double result = 0;
   //std::cout << "Hit::getD() "; //debug
-  if (hitModule_) {
+  if (m_hitModule) {
     //std::cout << " hitModule_!= NULL "; //debug
-    EndcapModule* myECModule = hitModule_->as<EndcapModule>();
-    if (myECModule) {
-      //std::cout << " myECModule!= NULL "; //debug
-      result = (myECModule->minWidth() + myECModule->maxWidth()) / 2. / 2.;
-      //std::cout << " result = " << result; //debug
+    try {
+
+      const EndcapModule* myECModule = dynamic_cast<const EndcapModule*>(m_hitModule);//->as<EndcapModule>();
+      if (myECModule) {
+        //std::cout << " myECModule!= NULL "; //debug
+        result = (myECModule->minWidth() + myECModule->maxWidth()) / 2. / 2.;
+        //std::cout << " result = " << result; //debug
+      }
     }
+    catch (exception& e) {}
   }
   //std::cout << std::endl; // debug
   return result;

--- a/source/Tracking/src/Track.cc
+++ b/source/Tracking/src/Track.cc
@@ -350,7 +350,7 @@ const Polar3DVector& Track::setThetaPhiPt(const double& newTheta, const double& 
   m_magField  = SimParms::getInstance()->magneticField();
   m_radius    = m_pt / (0.3 * m_magField);
 
-  m_direction.SetCoordinates(m_radius/sin(m_theta), m_theta, m_phi);
+  m_direction.SetCoordinates(1, m_theta, m_phi);
 
   if (m_magField<=0) {
     logERROR("Track::setThetaPhiPt -> Magnetic field not defined!!!");
@@ -363,7 +363,7 @@ const Polar3DVector& Track::setThetaPhiPt(const double& newTheta, const double& 
 };
 
 //
-// Get number of active hits assigned to track for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file)
+// Get number of active hits assigned to track for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file). If tag specified as "all" no extra tag required
 //
 int Track::getNActiveHits (std::string tag, bool useIP /* = true */ ) const {
 
@@ -374,7 +374,7 @@ int Track::getNActiveHits (std::string tag, bool useIP /* = true */ ) const {
     if (iHit) {
       if ((useIP) || (!iHit->isIP())) {
         for (auto it=iHit->getHitModule()->trackingTags.begin(); it!=iHit->getHitModule()->trackingTags.end(); it++) {
-          if ((tag==*it) && (iHit->getObjectKind()==HitKind::Active)) nHits++;
+          if ((tag==*it || tag=="all") && (iHit->getObjectKind()==HitKind::Active)) nHits++;
         }
       }
     }
@@ -385,6 +385,7 @@ int Track::getNActiveHits (std::string tag, bool useIP /* = true */ ) const {
 
 //
 // Get the probabilty of having "clean" hits for nuclear-interacting particles for given tag: pixel, strip, tracker, etc. (as defined in the geometry config file)
+// If tag specified as "all" no extra tag required
 //
 std::vector<double> Track::getHadronActiveHitsProbability(std::string tag) {
 
@@ -398,7 +399,7 @@ std::vector<double> Track::getHadronActiveHitsProbability(std::string tag) {
   for (auto iHit : m_hits) {
     if (iHit) {
       for (auto it=iHit->getHitModule()->trackingTags.begin(); it!=iHit->getHitModule()->trackingTags.end(); it++) {
-         if ((tag==*it) && (iHit->getObjectKind()==HitKind::Active)) probabilities.push_back(probability);
+         if ((tag==*it || tag=="all") && (iHit->getObjectKind()==HitKind::Active)) probabilities.push_back(probability);
       }
 
       // Decrease the probability that the next hit is a clean one


### PR DESCRIPTION
Still several functionalities "missing":

* Hadron efficiency plot available for inidividual sub-trackers not for overall tracker yet 
* Material budget of module caps + beam-pipe done for now (MaterialBudget class removed, all done within the analyzer) -> similar approach expected for Services & Supports -> will be implemented once the Material approach in tkLayout is revised