### PR TITLE
Important: PS modules stub correlation should be "sameSegment" 

### DIFF
--- a/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPS
@@ -6,7 +6,7 @@ width 96
 length 46.26
 
 sensorLayout pt
-zCorrelation multisegment
+zCorrelation samesegment
 
 numSensors 2
 


### PR DESCRIPTION
like 2S modules!