### PR TITLE
Added possibility of having different modules sizes in flat part with respect to tilted part (tilted placement) + FIXED BUG IN ALL (RZ) geometry plots on website (all layouts, all tabs)

### DIFF
--- a/geometries/CMS_Phase2/Baseline_tilted_200_Pixel_4_1_0.cfg
+++ b/geometries/CMS_Phase2/Baseline_tilted_200_Pixel_4_1_0.cfg
@@ -1,3 +1,3 @@
 @include-std CMS_Phase2/SimParms
-@include OuterTracker/Tilted/OT_V351_200.cfg
+@include OuterTracker/Tilted/OT_V362_200.cfg
 @include Pixel/Pixel_V4/Pixel_V4_1_0.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_1_0.cfg
@@ -9,7 +9,7 @@
     smallDelta 0 
     numLayers 4
     startZMode modulecenter
-    zError 70
+    //zError 70
 
     compressed false
     innerRadius 29
@@ -19,9 +19,8 @@
     bigParity -1
 
     Layer 1 {
-      // TODO: materials are plain WRONG here (no tilt taken into account)
-
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2R_1x1_50x50
+      // TODO: materials are plain WRONG here (no tilt taken into account)      
+      
       @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
@@ -42,16 +41,18 @@
         // Different module types goes in the flat part
         @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       }
-      Ring 4-99 {
+      Ring 4-8 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2R_1x1_50x50
         ringInnerRadius 37.1
         ringOuterRadius 37.6
         tiltAngle 80.0
         theta_g 20.0
         zOverlap 5.0
-      }        
+      }  
     }
   
     Layer 2 {
+      zError 70
       phiOverlap 0.60
       phiSegments 4
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
@@ -67,6 +68,7 @@
       numModules 5  // 3 on the right and 3 on the left and a central one
     }
     Layer 3 {
+      zError 70
       phiOverlap 0.60
       phiSegments 4
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
@@ -82,6 +84,7 @@
       numModules 5  // 3 on the right and 3 on the left and a central one
     }
     Layer 4 {
+      zError 70
       phiOverlap 0.60
       phiSegments 4
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_1_0.cfg
@@ -35,7 +35,7 @@
       isTiltedAuto true
       numModulesFlat 3          // Number of flat rings along Z+, central ring included
       numModulesTilted 5        // Number of tilted rings along Z+
-      numRods 12
+      numRods 13
 
       Ring 1-3 {
         // Different module types goes in the flat part

--- a/include/PlotDrawer.h
+++ b/include/PlotDrawer.h
@@ -192,8 +192,11 @@ struct Rounder {
 
 struct XY : public std::pair<int, int>, private Rounder {
   const bool valid;
+  // XY coordinates of the centre of module m.
  XY(const Module& m) : std::pair<int, int>(round(m.center().X()), round(m.center().Y())), valid(m.center().Z() >= 0) {}
+  // XY coordinates of vector v.
  XY(const XYZVector& v) : std::pair<int, int>(round(v.X()), round(v.Y())), valid(v.Z() >= 0) {}
+  // XY coordinates of vector v, in a (XY) plane passing by the center of module m.
  XY(const XYZVector& v, const Module& m) : XY(v) {}
   // bool operator<(const XY& other) const { return (x() < other.x()) || (x() == other.x() && y() < other.y()); }
   int x() const { return this->first; }
@@ -203,21 +206,24 @@ struct XY : public std::pair<int, int>, private Rounder {
 
 struct YZ : public std::pair<int, int>, private Rounder {
   const bool valid;
+  // RZ coordinates of the centre of module m, in the plane (RZ) defined by ((Z axis), moduleCenter).
  YZ(const Module& m) : std::pair<int,int>(round(m.center().Z()), round(m.center().Rho())), valid(m.center().Z() >= 0) {}
+  // RZ coordinates of vector v, in the plane (RZ) defined by ((Z axis), v).
  YZ(const XYZVector& v) : std::pair<int, int>(round(v.Z()), round(v.Rho())), valid(v.Z() >= 0) {}
+  // RZ coordinates of vector v, in the plane (RZ) defined by ((Z axis), moduleCenter).
  YZ(const XYZVector& v, const Module& m) : valid(v.Z() >= 0) {
     this->first = round(v.Z());
 
+    // This calculates the projection of vector v into plane ((Z axis), moduleCenter).
     XYZVector vProjected;
     XYZVector z(0., 0., 1.);
 
     XYZVector basePolyCenter = m.basePoly().getCenter();
-    XYZVector normal = crossProduct(z, basePolyCenter);
-    normal = normal.Unit();
+    XYZVector normal = crossProduct(z, basePolyCenter); // normal of plane ((Z axis), moduleCenter).
+    normal = normal.Unit(); // normalize.
 
-    vProjected = v - v.Dot(normal) * normal;
-    
-    this->second = round(vProjected.Rho());    
+    vProjected = v - v.Dot(normal) * normal; // Calculate projected vector. TO DO : Introduce this as a method !!   
+    this->second = round(vProjected.Rho()); // Take the Rho() of the projected vector.    
   }
   //  bool operator<(const YZ& other) const { return (y() < other.y()) || (y() == other.y() && z() < other.z()); }
   int y() const { return this->second; }

--- a/include/PlotDrawer.h
+++ b/include/PlotDrawer.h
@@ -217,15 +217,7 @@ struct YZ : public std::pair<int, int>, private Rounder {
 
     vProjected = v - v.Dot(normal) * normal;
     
-    this->second = round(vProjected.Rho());
-    /*if (vProjected.Rho() > 1000. && v.Z() > 500. && v.Z() < 650.) {
-      //std::cout << "v.Rho() = " << v.Rho() << std::endl;
-      std::cout << " basePolyCenter.X() = " << basePolyCenter.X() <<  "basePolyCenter.Y() = " << basePolyCenter.Y() <<  "basePolyCenter.Z() = " << basePolyCenter.Z() << std::endl;
-      //std::cout << "v.Dot(normal) = " << v.Dot(normal) << std::endl;
-      //std::cout << "vProjected.Rho() = " << vProjected.Rho() << "v.Z() = " << v.Z() << "vProjected.Z() = " << vProjected.Z() << std::endl;
-      std::cout << "(m.basePolyCenter().Rho() - m.length() / 2.) = " << (m.basePolyCenter().Rho() - m.length() / 2.) << std::endl;
-      }*/
-    
+    this->second = round(vProjected.Rho());    
   }
   //  bool operator<(const YZ& other) const { return (y() < other.y()) || (y() == other.y() && z() < other.z()); }
   int y() const { return this->second; }

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -23,20 +23,25 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
       zStartInner_REAL = m.planarMinZ();
 
       if (rStartInner != rEndInner) {
+	double fact = (((rStartInner - rEndInner) > 0) ? 1. : -1.);
+	
 	if (zStartInner_REAL != zEndInner_REAL) {
+	  // Let's call (H1pUP, H1ppDOWN) the line that binds H1pUP of the previous module, with H1ppDOWN of the next module.
+	  // Standard Case : (H1pUP, H1ppDOWN) is secant with (Z).
+	  // Let's call P the intersection point.
+	  // zError is defined as the Z of point P.
 	  double zErrorInnerAngle = atan( (rStartInner - rEndInner) / (zStartInner_REAL - zEndInner_REAL) );
-	  double fact = (((rStartInner - rEndInner) > 0) ? 1. : -1.);
 	  zErrorInner_[i] = fact * (zStartInner_REAL - rStartInner / tan(zErrorInnerAngle));
-	}
-	else {
-	  zErrorInner_[i] = zEndInner_REAL;
+	}	
+	else { // Case where (H1pUP, H1ppDOWN) is orthogonal to (Z).
+	  zErrorInner_[i] = fact * zStartInner_REAL;
 	}
       }
-      else {
-	if (zStartInner_REAL != zEndInner_REAL) {
+      else { // Case where consecutive modules are placed at the same r within a rod, for the Pixel for example.
+	if (zStartInner_REAL != zEndInner_REAL) { // If consecutive modules (along a rod) are not touching, zError is undefined.
 	  zErrorInner_[i] = std::numeric_limits<double>::quiet_NaN();
 	}
-	else {
+	else { // If consecutive modules (along a rod) are touching, zError is infinity.
 	  zErrorInner_[i] = std::numeric_limits<double>::infinity();
 	}
       }
@@ -59,13 +64,13 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
       zStartOuter_REAL = m.planarMinZ();
 
       if (rStartOuter != rEndOuter) {
+	double fact = (((rStartOuter - rEndOuter) > 0) ? 1. : -1.);
 	if (zStartOuter_REAL != zEndOuter_REAL) {
 	  double zErrorOuterAngle = atan( (rStartOuter - rEndOuter) / (zStartOuter_REAL - zEndOuter_REAL) );
-	  double fact = (((rStartOuter - rEndOuter) > 0) ? 1. : -1.);
 	  zErrorOuter_[i] = fact * (zStartOuter_REAL - rStartOuter / tan(zErrorOuterAngle));
 	}
 	else {
-	  zErrorOuter_[i] = zEndOuter_REAL;
+	  zErrorOuter_[i] = fact * zStartOuter_REAL;
 	}
       }
       else {

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -22,9 +22,25 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
       rStartInner = m.center().Rho() - 0.5 * m.dsDistance();
       zStartInner_REAL = m.planarMinZ();
 
-      double zErrorInnerAngle = atan( (rStartInner - rEndInner) / (zStartInner_REAL - zEndInner_REAL) );
-      double fact = (((rStartInner - rEndInner) > 0) ? 1. : -1.);
-      zErrorInner_[i] = fact * (zStartInner_REAL - rStartInner / tan(zErrorInnerAngle));
+      if (rStartInner != rEndInner) {
+	if (zStartInner_REAL != zEndInner_REAL) {
+	  double zErrorInnerAngle = atan( (rStartInner - rEndInner) / (zStartInner_REAL - zEndInner_REAL) );
+	  double fact = (((rStartInner - rEndInner) > 0) ? 1. : -1.);
+	  zErrorInner_[i] = fact * (zStartInner_REAL - rStartInner / tan(zErrorInnerAngle));
+	}
+	else {
+	  zErrorInner_[i] = zEndInner_REAL;
+	}
+      }
+      else {
+	if (zStartInner_REAL != zEndInner_REAL) {
+	  zErrorInner_[i] = std::numeric_limits<double>::quiet_NaN();
+	}
+	else {
+	  zErrorInner_[i] = std::numeric_limits<double>::infinity();
+	}
+      }
+
     }
 
     rEndInner = m.center().Rho() + 0.5 * m.dsDistance();
@@ -42,9 +58,25 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
       rStartOuter = m.center().Rho() - 0.5 * m.dsDistance();
       zStartOuter_REAL = m.planarMinZ();
 
-      double zErrorOuterAngle = atan( (rStartOuter - rEndOuter) / (zStartOuter_REAL - zEndOuter_REAL) );
-      double fact = (((rStartOuter - rEndOuter) > 0) ? 1. : -1.);
-      zErrorOuter_[i] = fact * (zStartOuter_REAL - rStartOuter / tan(zErrorOuterAngle));
+      if (rStartOuter != rEndOuter) {
+	if (zStartOuter_REAL != zEndOuter_REAL) {
+	  double zErrorOuterAngle = atan( (rStartOuter - rEndOuter) / (zStartOuter_REAL - zEndOuter_REAL) );
+	  double fact = (((rStartOuter - rEndOuter) > 0) ? 1. : -1.);
+	  zErrorOuter_[i] = fact * (zStartOuter_REAL - rStartOuter / tan(zErrorOuterAngle));
+	}
+	else {
+	  zErrorOuter_[i] = zEndOuter_REAL;
+	}
+      }
+      else {
+	if (zStartOuter_REAL != zEndOuter_REAL) {
+	  zErrorOuter_[i] = std::numeric_limits<double>::quiet_NaN();
+	}
+	else {
+	  zErrorOuter_[i] = std::numeric_limits<double>::infinity();
+	}
+      }
+
     }
 
     rEndOuter = m.center().Rho() + 0.5 * m.dsDistance();
@@ -340,7 +372,6 @@ void Layer::buildTilted() {
     double flatPartrOuterSmall = std::numeric_limits<double>::max();
     double flatPartrInnerBig = 0;
     double flatPartrOuterBig = 0;
-    double flatPartAverageR = 0.;
 
     if (buildNumModulesFlat() != 0) {
 
@@ -356,7 +387,6 @@ void Layer::buildTilted() {
 	  if (t1.valid()) (bigParity() > 0 ? tmspecso.push_back(t1) : tmspecsi.push_back(t1));
 	  (bigParity() > 0 ? flatPartrOuterSmall = MIN(flatPartrOuterSmall, m.center().Rho() + 0.5*m.dsDistance()) : flatPartrInnerSmall = MIN(flatPartrInnerSmall, m.center().Rho() + 0.5*m.dsDistance()));
 	  (bigParity() > 0 ? flatPartrOuterBig = MAX(flatPartrOuterBig, m.center().Rho() + 0.5*m.dsDistance()) : flatPartrInnerBig = MAX(flatPartrInnerBig, m.center().Rho() + 0.5*m.dsDistance()));
-	  flatPartAverageR += m.center().Rho();
 	}
 
 	StraightRodPair* flatPartRod2 = flatPartRods_.at(1);
@@ -366,7 +396,6 @@ void Layer::buildTilted() {
 	  if (t2.valid()) (bigParity() > 0 ? tmspecsi.push_back(t2) : tmspecso.push_back(t2));
 	  (bigParity() > 0 ? flatPartrInnerSmall = MIN(flatPartrInnerSmall, m.center().Rho() + 0.5*m.dsDistance()) : flatPartrOuterSmall = MIN(flatPartrOuterSmall, m.center().Rho() + 0.5*m.dsDistance()));
 	  (bigParity() > 0 ? flatPartrInnerBig = MAX(flatPartrInnerBig, m.center().Rho() + 0.5*m.dsDistance()) : flatPartrOuterBig = MAX(flatPartrOuterBig, m.center().Rho() + 0.5*m.dsDistance()));
-	  flatPartAverageR += m.center().Rho();
 	}
 
 	flatPartThetaEnd = (bigParity() > 0 ? flatPartRod1->thetaEnd() : flatPartRod2->thetaEnd());
@@ -380,8 +409,10 @@ void Layer::buildTilted() {
 
 	RectangularModule* flatPartrmod = GeometryFactory::make<RectangularModule>();
 	flatPartrmod->store(propertyTree());
+	if (ringNode.count(1) > 0) flatPartrmod->store(ringNode.at(1));
 	flatPartrmod->build();
 	double width = flatPartrmod->width();
+	double dsDistance = flatPartrmod->dsDistance();
 	double T = tan(2.*M_PI / numRods());
 	double A = 1. / (2. * flatPartrInnerSmall);
 	double B = 1. / (2. * flatPartrOuterSmall);
@@ -398,7 +429,7 @@ void Layer::buildTilted() {
 	s = (-b - sqrt(b*b - 4*a*c))/(2*a);
 	flatPartPhiOverlapSmallDeltaPlus_ = width + s;
 
-	flatPartAverageR_ = flatPartAverageR / (flatPartRod1->modules().first.size() + flatPartRod2->modules().first.size());
+	flatPartAverageR_ = (flatPartrInnerSmall + flatPartrInnerBig + flatPartrOuterSmall + flatPartrOuterBig) / 4. - 0.5 * dsDistance;
 
 	flatRingsGeometryInfo_.calculateFlatRingsGeometryInfo(flatPartRods_, bigParity());
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1418,14 +1418,16 @@ namespace insur {
 	    tiltedPartTable->setContent(15, i+1, l.tiltedRingsGeometryInfo().deltaZOuter()[ringNumber], coordPrecision);
 	    tiltedPartTable->setContent(16, 0, "phiOverlap");
 	    tiltedPartTable->setContent(16, i+1, l.tiltedRingsGeometry()[ringNumber]->phiOverlap(), coordPrecision);
+	    tiltedPartTable->setContent(17, 0, "zOverlap" + subStart + "Outer" + subEnd);
+	    tiltedPartTable->setContent(17, i+1, l.tiltedRingsGeometry()[ringNumber]->zOverlap(), coordPrecision);
 	    double zErrorInner = l.tiltedRingsGeometryInfo().zErrorInner()[ringNumber];	    
-	    tiltedPartTable->setContent(17, 0, "zError" + subStart + "Inner" + subEnd + " (Ring i & i-1)");
-	    if (!std::isnan(zErrorInner)) tiltedPartTable->setContent(17, i+1, zErrorInner, coordPrecision);
-	    else tiltedPartTable->setContent(17, i+1, "n/a");
+	    tiltedPartTable->setContent(18, 0, "zError" + subStart + "Inner" + subEnd + " (Ring i & i-1)");
+	    if (!std::isnan(zErrorInner)) tiltedPartTable->setContent(18, i+1, zErrorInner, coordPrecision);
+	    else tiltedPartTable->setContent(18, i+1, "n/a");
 	    double zErrorOuter = l.tiltedRingsGeometryInfo().zErrorOuter()[ringNumber];
-	    tiltedPartTable->setContent(18, 0, "zError" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
-	    if (!std::isnan(zErrorOuter)) tiltedPartTable->setContent(18, i+1, zErrorOuter, coordPrecision);
-	    else tiltedPartTable->setContent(18, i+1, "n/a");	    
+	    tiltedPartTable->setContent(19, 0, "zError" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
+	    if (!std::isnan(zErrorOuter)) tiltedPartTable->setContent(19, i+1, zErrorOuter, coordPrecision);
+	    else tiltedPartTable->setContent(19, i+1, "n/a");	    
 	  }
 	  tiltedPartTables.push_back(tiltedPartTable);
 
@@ -1454,15 +1456,22 @@ namespace insur {
 	    flatPartTable->setContent(6, i+1, m.center().Z(), coordPrecision);
 	    flatPartTable->setContent(7, 0, "phiOverlap");
 	    flatPartTable->setContent(7, i+1, (((minusBigDeltaRod->zPlusParity() * pow(-1, (i%2))) > 0) ? l.flatPartPhiOverlapSmallDeltaPlus() : l.flatPartPhiOverlapSmallDeltaMinus()), coordPrecision);
+	    int extraLine = 0;
+	    if (!l.flatPartRods().front()->beamSpotCover()) {
+	      extraLine = 1;
+	      flatPartTable->setContent(8, 0, "zOverlap");
+	      flatPartTable->setContent(8, i+1, l.flatPartRods().front()->zOverlap(), coordPrecision);
+	      // WARNING : zOverlap, in the geometry construction process, is one value common for all flat part (or straight rod)
+	    }
 	    if (i > 0) {
 	      double zErrorInner = l.flatRingsGeometryInfo().zErrorInner()[i];
-	      flatPartTable->setContent(8, 0, "zError" + subStart + "Inner" + subEnd + " (Ring i & i-1)");
-	      if (!std::isnan(zErrorInner)) flatPartTable->setContent(8, i+1, zErrorInner, coordPrecision);
-	      else flatPartTable->setContent(8, i+1, "n/a");
+	      flatPartTable->setContent(8 + extraLine, 0, "zError" + subStart + "Inner" + subEnd + " (Ring i & i-1)");
+	      if (!std::isnan(zErrorInner)) flatPartTable->setContent(8 + extraLine, i+1, zErrorInner, coordPrecision);
+	      else flatPartTable->setContent(8 + extraLine, i+1, "n/a");
 	      double zErrorOuter = l.flatRingsGeometryInfo().zErrorOuter()[i];
-	      flatPartTable->setContent(9, 0, "zError" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
-	      if (!std::isnan(zErrorOuter)) flatPartTable->setContent(9, i+1, zErrorOuter, coordPrecision);
-	      else flatPartTable->setContent(9, i+1, "n/a");
+	      flatPartTable->setContent(9 + extraLine, 0, "zError" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
+	      if (!std::isnan(zErrorOuter)) flatPartTable->setContent(9 + extraLine, i+1, zErrorOuter, coordPrecision);
+	      else flatPartTable->setContent(9 + extraLine, i+1, "n/a");
 	    }
 	    i++;
 	  }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1417,11 +1417,15 @@ namespace insur {
 	    tiltedPartTable->setContent(15, 0, "deltaZ" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
 	    tiltedPartTable->setContent(15, i+1, l.tiltedRingsGeometryInfo().deltaZOuter()[ringNumber], coordPrecision);
 	    tiltedPartTable->setContent(16, 0, "phiOverlap");
-	    tiltedPartTable->setContent(16, i+1, l.tiltedRingsGeometry()[ringNumber]->phiOverlap(), coordPrecision);	    
+	    tiltedPartTable->setContent(16, i+1, l.tiltedRingsGeometry()[ringNumber]->phiOverlap(), coordPrecision);
+	    double zErrorInner = l.tiltedRingsGeometryInfo().zErrorInner()[ringNumber];	    
 	    tiltedPartTable->setContent(17, 0, "zError" + subStart + "Inner" + subEnd + " (Ring i & i-1)");
-	    tiltedPartTable->setContent(17, i+1, l.tiltedRingsGeometryInfo().zErrorInner()[ringNumber], coordPrecision);
+	    if (!std::isnan(zErrorInner)) tiltedPartTable->setContent(17, i+1, zErrorInner, coordPrecision);
+	    else tiltedPartTable->setContent(17, i+1, "n/a");
+	    double zErrorOuter = l.tiltedRingsGeometryInfo().zErrorOuter()[ringNumber];
 	    tiltedPartTable->setContent(18, 0, "zError" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
-	    tiltedPartTable->setContent(18, i+1, l.tiltedRingsGeometryInfo().zErrorOuter()[ringNumber], coordPrecision);
+	    if (!std::isnan(zErrorOuter)) tiltedPartTable->setContent(18, i+1, zErrorOuter, coordPrecision);
+	    else tiltedPartTable->setContent(18, i+1, "n/a");	    
 	  }
 	  tiltedPartTables.push_back(tiltedPartTable);
 
@@ -1451,10 +1455,14 @@ namespace insur {
 	    flatPartTable->setContent(7, 0, "phiOverlap");
 	    flatPartTable->setContent(7, i+1, (((minusBigDeltaRod->zPlusParity() * pow(-1, (i%2))) > 0) ? l.flatPartPhiOverlapSmallDeltaPlus() : l.flatPartPhiOverlapSmallDeltaMinus()), coordPrecision);
 	    if (i > 0) {
+	      double zErrorInner = l.flatRingsGeometryInfo().zErrorInner()[i];
 	      flatPartTable->setContent(8, 0, "zError" + subStart + "Inner" + subEnd + " (Ring i & i-1)");
-	      flatPartTable->setContent(8, i+1, l.flatRingsGeometryInfo().zErrorInner()[i], coordPrecision);
+	      if (!std::isnan(zErrorInner)) flatPartTable->setContent(8, i+1, zErrorInner, coordPrecision);
+	      else flatPartTable->setContent(8, i+1, "n/a");
+	      double zErrorOuter = l.flatRingsGeometryInfo().zErrorOuter()[i];
 	      flatPartTable->setContent(9, 0, "zError" + subStart + "Outer" + subEnd + " (Ring i & i-1)");
-	      flatPartTable->setContent(9, i+1, l.flatRingsGeometryInfo().zErrorOuter()[i], coordPrecision);
+	      if (!std::isnan(zErrorOuter)) flatPartTable->setContent(9, i+1, zErrorOuter, coordPrecision);
+	      else flatPartTable->setContent(9, i+1, "n/a");
 	    }
 	    i++;
 	  }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1456,6 +1456,9 @@ namespace insur {
 	    flatPartTable->setContent(6, i+1, m.center().Z(), coordPrecision);
 	    flatPartTable->setContent(7, 0, "phiOverlap");
 	    flatPartTable->setContent(7, i+1, (((minusBigDeltaRod->zPlusParity() * pow(-1, (i%2))) > 0) ? l.flatPartPhiOverlapSmallDeltaPlus() : l.flatPartPhiOverlapSmallDeltaMinus()), coordPrecision);
+	    // In case beamSpotCover == false, zOverlap is the only parameter used as a Z-coverage constraint in the geometry construction process.
+	    // (There is then no zError taken into account).
+	    // As a result, it is interesting to display zOverlap !
 	    int extraLine = 0;
 	    if (!l.flatPartRods().front()->beamSpotCover()) {
 	      extraLine = 1;


### PR DESCRIPTION
**Tilted modules with auto placement for the Pixel :**
- Until now, width / length of a module for the flat part, could only be specified until Layer hierarchy level in cfg file.
It is now possible to specify width / length of a module for the flat part at the Ring hierarchy level in cfg file, if necessary.

- Having a zError info doesn't make sense for the flat part of the Pixel.
As a result, for the flat part of the Pixel, zOverlap info is now also displayed on the website.


**Plots :
All (RZ) geometry plots on the website displayed slightly wrong R coordinates since the beginnings of tkLayout :** 

Origin O, (X,Y,Z) is the frame of reference of the Tracker.
Let be S a sensor.
Let's call (P) the plane containing (O,Z) axis and the centre of S.
Let's call Rho vectors the projections in (XY) plane of the vectors binding origin O and the extrema points of S.
Rho vectors were directly used for calculating the radii on the plots on the website. 
They were not projected into (P), while they should be !

As a result, all radii values on the plots on the website were slightly too big !
Rho vectors are now projected into (P) !


NB : Code is operational now but debug style, I am working on improving this right now :)
	