### PR TITLE
Implemented DetId in tkLayout for entire Outer Tracker

### DIFF
--- a/config/det_id_schemes.list
+++ b/config/det_id_schemes.list
@@ -1,0 +1,3 @@
+Phase2Subdetector5 4 3 1 4 2 8 8 2
+
+Phase2Subdetector4 4 3 2 1 4 6 2 8 2

--- a/geometries/CMS_Phase2/OuterTracker/Flat/OT_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/OT_200.cfg
@@ -12,6 +12,9 @@ Tracker Outer {
     smallParity 1
 
     trackingTags trigger,tracker
+    
+    barrelDetIdScheme Phase2Subdetector5
+    endcapDetIdScheme Phase2Subdetector4
 
     Barrel TBPS {
       @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_flat.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V362_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V362_200.cfg
@@ -8,6 +8,9 @@ Tracker Outer {
   etaCut 10
 
   trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
 
   @include TBPS_V362_200.cfg
   @include TB2S_V360_200.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_1.cfg
@@ -13,6 +13,9 @@ Tracker Pixels {
   barrelRotation 1.57079632679
  
   trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
 
   @include BPIX_4_0_0.cfg
   @include FPIX1_4_0_2_1.cfg

--- a/include/Barrel.h
+++ b/include/Barrel.h
@@ -74,6 +74,10 @@ class Barrel : public PropertyObject, public Buildable, public Identifiable<stri
     v.visit(*this); 
     for (const auto& l : layers_) { l.accept(v); }
   }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this); 
+    for (auto& l : layers_) { l.accept(v); }
+  }
 
   const Container& layers() const        { return layers_; }
   SupportStructures& supportStructures() { return supportStructures_; }

--- a/include/DetectorModule.h
+++ b/include/DetectorModule.h
@@ -28,8 +28,6 @@ using material::MaterialObject;
 // ======================================================= DETECTOR MODULES ===============================================================
 //
 
-
-enum ModuleSubdetector { BARREL = 1, ENDCAP = 2 };
 enum SensorLayout { NOSENSORS, MONO, PT, STEREO };
 enum ZCorrelation { SAMESEGMENT, MULTISEGMENT }; 
 enum ReadoutType { READOUT_STRIP, READOUT_PIXEL, READOUT_PT };
@@ -361,6 +359,11 @@ public:
     v.visit(*(const DetectorModule*)this);
     decorated().accept(v);
   }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this);
+    v.visit(*(DetectorModule*)this);
+    for (auto& s : sensors_) { s.accept(v); }
+  }
 
   void setup() override {
     DetectorModule::setup();
@@ -640,6 +643,11 @@ public:
     v.visit(*this); 
     v.visit(*(const DetectorModule*)this);
     decorated().accept(v); 
+  }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this);
+    v.visit(*(DetectorModule*)this);
+    for (auto& s : sensors_) { s.accept(v); }
   }
 
   //double minZ() const { return center().Z(); } // CUIDADO not accounting for sensor placement

--- a/include/DetectorModule.h
+++ b/include/DetectorModule.h
@@ -46,7 +46,7 @@ namespace insur {
 using insur::ModuleCap;
 using material::ElementsVector;
 
-class DetectorModule : public Decorator<GeometricModule>, public ModuleBase {// implementors of the DetectorModuleInterface must take care of rotating the module based on which part of the subdetector it will be used in (Barrel, EC)
+class DetectorModule : public Decorator<GeometricModule>, public ModuleBase, public DetIdentifiable {// implementors of the DetectorModuleInterface must take care of rotating the module based on which part of the subdetector it will be used in (Barrel, EC)
   PropertyNode<int> sensorNode;
 
   typedef PtrVector<Sensor> Sensors;

--- a/include/DetectorModule.h
+++ b/include/DetectorModule.h
@@ -177,6 +177,7 @@ public:
 
   double tiltAngle() const { return tiltAngle_; }
   double skewAngle() const { return skewAngle_; }
+  bool isTilted() const { return tiltAngle_ != 0.; }
 
   double alpha (double trackPhi) const {
     double deltaPhi = center().Phi() + skewAngle() - trackPhi;

--- a/include/DetectorModule.h
+++ b/include/DetectorModule.h
@@ -232,9 +232,15 @@ public:
   void skew(double angle) { rotateY(-angle); skewAngle_ += angle; }
 
   bool flipped() const { return decorated().flipped(); } 
-  bool flipped(bool newFlip) { return decorated().flipped(newFlip); } 
+  bool flipped(bool newFlip) {
+    if (newFlip && numSensors() > 1) {
+      sensors_.front().innerOuter(SensorPosition::UPPER);
+      sensors_.back().innerOuter(SensorPosition::LOWER);
+    }
+    return decorated().flipped(newFlip);
+  } 
   ModuleShape shape() const { return decorated().shape(); }
-////////
+  ////////
 
   double maxZ() const { return maxget2(sensors_.begin(), sensors_.end(), &Sensor::maxZ); }
   double minZ() const { return minget2(sensors_.begin(), sensors_.end(), &Sensor::minZ); }

--- a/include/Disk.h
+++ b/include/Disk.h
@@ -33,6 +33,7 @@ private:
   MaterialObject materialObject_;
   ConversionStation* flangeConversionStation_;
   std::vector<ConversionStation*> secondConversionStations_;
+  int diskNumber_;
 
   Property<double, NoDefault> innerRadius;
   Property<double, NoDefault> outerRadius;
@@ -104,6 +105,10 @@ public:
   const Container& rings() const { return rings_; }
   const RingIndexMap& ringsMap() const { return ringIndexMap_; }
 
+  void diskNumber(int num) { diskNumber_ = num; }
+  int diskNumber() const { return diskNumber_; }
+  int numEmptyRings() const { return count_if(rings_.begin(), rings_.end(), [](const Ring& r) { return r.numModules() == 0; }); }
+
   void accept(GeometryVisitor& v) {
     v.visit(*this); 
     for (auto& r : rings_) { r.accept(v); }
@@ -111,6 +116,10 @@ public:
   void accept(ConstGeometryVisitor& v) const { 
     v.visit(*this); 
     for (const auto& r : rings_) { r.accept(v); }
+  }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this); 
+    for (auto& r : rings_) { r.accept(v); }
   }
   const MaterialObject& materialObject() const;
   ConversionStation* flangeConversionStation() const;

--- a/include/Disk.h
+++ b/include/Disk.h
@@ -100,6 +100,7 @@ public:
   void cutAtEta(double eta);
 
   double averageZ() const { return averageZ_; }
+  bool side() const { return averageZ_ > 0.; }
   double thickness() const { return bigDelta()*2 + maxRingThickness(); } 
 
   const Container& rings() const { return rings_; }

--- a/include/Endcap.h
+++ b/include/Endcap.h
@@ -68,6 +68,10 @@ class Endcap : public PropertyObject, public Buildable, public Identifiable<std:
     v.visit(*this);
     for (const auto& d : disks_) { d.accept(v); }
   }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this);
+    for (auto& d : disks_) { d.accept(v); }
+  }
 
   const Container& disks() const         { return disks_; }
   SupportStructures& supportStructures() { return supportStructures_; }

--- a/include/Layer.h
+++ b/include/Layer.h
@@ -73,6 +73,7 @@ class Layer : public PropertyObject, public Buildable, public Identifiable<int>,
   FlatRingsGeometryInfo flatRingsGeometryInfo_;
   TiltedRingsTemplate tiltedRingsGeometry_;
   TiltedRingsGeometryInfo tiltedRingsGeometryInfo_ = TiltedRingsGeometryInfo(0,0,0,0,0, tiltedRingsGeometry_);
+  int layerNumber_;
  
   double calculatePlaceRadius(int numRods, double bigDelta, double smallDelta, double dsDistance, double moduleWidth, double overlap);
   pair<float, int> calculateOptimalLayerParms(const RodTemplate&);
@@ -174,6 +175,20 @@ public:
   TiltedRingsTemplate tiltedRingsGeometry() const { return tiltedRingsGeometry_; }
   TiltedRingsGeometryInfo tiltedRingsGeometryInfo() const { return tiltedRingsGeometryInfo_; }
 
+  void layerNumber(int num) { layerNumber_ = num; }
+  int layerNumber() const { return layerNumber_; }
+  /*int calculateTotalNumRings(int numModulesSide) const { 
+    int num = 0;
+    if (rods_.size() !=0) {
+      if (rods_.front().startZMode() != StartZMode::MODULECENTER) num = 2 * numModulesSide;
+      else num = 2 * numModulesSide - 1;
+    }
+  }
+  int numRings() const { return calculateTotalNumRings(buildNumModules()); }
+  int numFlatRings() const { return calculateTotalNumRings(buildNumModulesFlat()); }
+  int numTiltedRings() const { return calculateTotalNumRings(buildNumModulesTilted()); }*/
+
+
   void cutAtEta(double eta);
   void rotateZ(double angle) { for (auto& r : rods_) r.rotateZ(angle); }
 
@@ -184,6 +199,10 @@ public:
   void accept(ConstGeometryVisitor& v) const { 
     v.visit(*this);
     for (const auto& r : rods_) { r.accept(v); }
+  }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this);
+    for (auto& r : rods_) { r.accept(v); }
   }
   const MaterialObject& materialObject() const;
 

--- a/include/Ring.h
+++ b/include/Ring.h
@@ -236,6 +236,10 @@ public:
     v.visit(*this); 
     for (const auto& m : modules_) { m.accept(v); }
   }
+  void accept(SensorGeometryVisitor& v) { 
+    v.visit(*this); 
+    for (auto& m : modules_) { m.accept(v); }
+  }
   const MaterialObject& materialObject() const;
 };
 

--- a/include/RodPair.h
+++ b/include/RodPair.h
@@ -100,6 +100,11 @@ public:
     for (const auto& m : zPlusModules_) { m.accept(v); }
     for (const auto& m : zMinusModules_) { m.accept(v); }
   }
+  void accept(SensorGeometryVisitor& v) {
+    v.visit(*this); 
+    for (auto& m : zPlusModules_) { m.accept(v); }
+    for (auto& m : zMinusModules_) { m.accept(v); }
+  }
 
   const MaterialObject& materialObject() const;
 };

--- a/include/RodPair.h
+++ b/include/RodPair.h
@@ -84,6 +84,14 @@ public:
   void translateR(double radius);
   void rotateZ(double angle);
 
+  double Phi() const {
+    double phi;
+    if (zPlusModules_.size() != 0) phi = zPlusModules_.front().center().Phi();
+    else if (zMinusModules_.size() != 0) phi = zMinusModules_.front().center().Phi();
+    else phi = std::numeric_limits<double>::quiet_NaN();
+    return phi;
+  }
+
   void cutAtEta(double eta);
 
   const std::pair<const Container&,const Container&> modules() const { return std::pair<const Container&,const Container&>(zPlusModules_,zMinusModules_); }

--- a/include/RodPair.h
+++ b/include/RodPair.h
@@ -42,12 +42,11 @@ protected:
 public:
   enum class BuildDir { RIGHT = 1, LEFT = -1 };
   enum class StartZMode { MODULECENTER, MODULEEDGE };
-protected:
-  Property<StartZMode, Default> startZMode;
 
 private:
   void clearComputables();
 public:
+  Property<StartZMode, Default> startZMode;
   //Property<double, NoDefault> maxZ;
   Property<double, Computable> maxZ;
   Property<double, Computable> minZ, maxR, minR;

--- a/include/Sensor.h
+++ b/include/Sensor.h
@@ -25,8 +25,6 @@ class Sensor : public PropertyObject, public Buildable, public Identifiable<int>
   mutable const Polygon3d<4>* hitPoly_ = 0; 
   mutable const Polygon3d<4>* envPoly_ = 0; 
   Polygon3d<4>* buildOwnPoly(double polyOffset) const;
-  //uint32_t myDetId_ = 0;
-  //std::map<int, uint32_t> detIdRef_;
 public:
   ReadonlyProperty<int, NoDefault> numStripsAcross;
   ReadonlyProperty<double, NoDefault> pitchEstimate;
@@ -96,10 +94,6 @@ public:
   void clearPolys();
   const Polygon3d<4>& hitPoly() const;
   const Polygon3d<4>& envelopePoly() const;
-
-  //void buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts);
-  //uint32_t myDetId() const { return myDetId_; }
-  //std::map<int, uint32_t> detIdRef() const { return detIdRef_; }
 
   void accept(SensorGeometryVisitor& v) { 
     v.visit(*this);

--- a/include/Sensor.h
+++ b/include/Sensor.h
@@ -8,16 +8,24 @@
 #include "Polygon3d.h"
 #include "Property.h"
 #include "CoordinateOperations.h"
+#include "Visitor.h"
+
+
+enum ModuleSubdetector { BARREL = 1, ENDCAP = 2 };
+enum SensorPosition { NO, LOWER, UPPER };
+enum class SensorType { Pixel, Largepix, Strip, None };
 
 class DetectorModule;
 
-enum class SensorType { Pixel, Largepix, Strip, None };
-
 class Sensor : public PropertyObject, public Buildable, public Identifiable<int> {
   const DetectorModule* parent_;
+  ModuleSubdetector subdet_;
+  SensorPosition innerOuter_ = SensorPosition::NO;
   mutable const Polygon3d<4>* hitPoly_ = 0; 
   mutable const Polygon3d<4>* envPoly_ = 0; 
   Polygon3d<4>* buildOwnPoly(double polyOffset) const;
+  uint32_t myDetId_ = 0;
+  std::map<int, uint32_t> detIdRef_;
 public:
   ReadonlyProperty<int, NoDefault> numStripsAcross;
   ReadonlyProperty<double, NoDefault> pitchEstimate;
@@ -41,6 +49,11 @@ public:
       {}
 
   void parent(const DetectorModule* m) { parent_ = m; }
+
+  ModuleSubdetector subdet(ModuleSubdetector s) { subdet_ = s; }
+  ModuleSubdetector subdet() const { return subdet_; }
+  SensorPosition innerOuter(SensorPosition pos) { innerOuter_ = pos; }
+  SensorPosition innerOuter() const { return innerOuter_; }
 
   int numStripsAcrossEstimate() const;
   int numSegmentsEstimate() const;
@@ -82,6 +95,14 @@ public:
   void clearPolys();
   const Polygon3d<4>& hitPoly() const;
   const Polygon3d<4>& envelopePoly() const;
+
+  void buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts);
+  uint32_t myDetId() const { return myDetId_; }
+  std::map<int, uint32_t> detIdRef() const { return detIdRef_; }
+
+  void accept(SensorGeometryVisitor& v) { 
+    v.visit(*this);
+  }
 };
 
 #endif

--- a/include/Sensor.h
+++ b/include/Sensor.h
@@ -18,15 +18,15 @@ enum class SensorType { Pixel, Largepix, Strip, None };
 
 class DetectorModule;
 
-class Sensor : public PropertyObject, public Buildable, public Identifiable<int> {
+class Sensor : public PropertyObject, public Buildable, public Identifiable<int>, public DetIdentifiable {
   const DetectorModule* parent_;
   ModuleSubdetector subdet_;
   SensorPosition innerOuter_ = SensorPosition::NO;
   mutable const Polygon3d<4>* hitPoly_ = 0; 
   mutable const Polygon3d<4>* envPoly_ = 0; 
   Polygon3d<4>* buildOwnPoly(double polyOffset) const;
-  uint32_t myDetId_ = 0;
-  std::map<int, uint32_t> detIdRef_;
+  //uint32_t myDetId_ = 0;
+  //std::map<int, uint32_t> detIdRef_;
 public:
   ReadonlyProperty<int, NoDefault> numStripsAcross;
   ReadonlyProperty<double, NoDefault> pitchEstimate;
@@ -97,9 +97,9 @@ public:
   const Polygon3d<4>& hitPoly() const;
   const Polygon3d<4>& envelopePoly() const;
 
-  void buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts);
-  uint32_t myDetId() const { return myDetId_; }
-  std::map<int, uint32_t> detIdRef() const { return detIdRef_; }
+  //void buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts);
+  //uint32_t myDetId() const { return myDetId_; }
+  //std::map<int, uint32_t> detIdRef() const { return detIdRef_; }
 
   void accept(SensorGeometryVisitor& v) { 
     v.visit(*this);

--- a/include/Sensor.h
+++ b/include/Sensor.h
@@ -9,6 +9,7 @@
 #include "Property.h"
 #include "CoordinateOperations.h"
 #include "Visitor.h"
+#include <bitset>
 
 
 enum ModuleSubdetector { BARREL = 1, ENDCAP = 2 };

--- a/include/Tracker.h
+++ b/include/Tracker.h
@@ -17,8 +17,8 @@
 #include "Endcap.h"
 #include "SupportStructure.h"
 #include "Visitor.h"
-
 #include "Visitable.h"
+#include "mainConfigHandler.h"
 
 using std::set;
 using material::SupportStructure;

--- a/include/Tracker.h
+++ b/include/Tracker.h
@@ -54,6 +54,8 @@ public:
   ReadonlyProperty<bool, Default> skipAllServices;
   ReadonlyProperty<bool, Default> skipAllSupports;
 
+  std::map<std::string, std::vector<int> > detIdSchemes_;
+
 private:
   Barrels barrels_;
   Endcaps endcaps_;
@@ -67,6 +69,11 @@ private:
 
   MultiProperty<set<string>, ','> containsOnly;
 
+  Property<std::string, AutoDefault> barrelDetIdScheme;
+  Property<std::string, AutoDefault> endcapDetIdScheme;
+
+  //std::map<std::string, std::vector<int> > detIdSchemes_;
+
   Tracker(const Tracker&) = default;
 public:
 
@@ -78,7 +85,9 @@ public:
       servicesForcedUp("servicesForcedUp", parsedOnly(), true),
       skipAllServices("skipAllServices", parsedOnly(), false),
       skipAllSupports("skipAllSupports", parsedOnly(), false),
-      containsOnly("containsOnly", parsedOnly())
+      containsOnly("containsOnly", parsedOnly()),
+      barrelDetIdScheme("barrelDetIdScheme", parsedOnly()),
+      endcapDetIdScheme("endcapDetIdScheme", parsedOnly())
   {}
 
   void setup() {
@@ -134,8 +143,7 @@ public:
 	  return hasStep;
 	});
 
-
-
+      detIdSchemes_ = detIdSchemes();
   }
 
   void build();
@@ -148,6 +156,8 @@ public:
 
   bool isPixelTracker() const { return myid() == "Pixels"; }
 
+  std::map<std::string, std::vector<int> > detIdSchemes();
+
   void accept(GeometryVisitor& v) { 
     v.visit(*this); 
     for (auto& b : barrels_) { b.accept(v); }
@@ -157,6 +167,11 @@ public:
     v.visit(*this); 
     for (const auto& b : barrels_) { b.accept(v); }
     for (const auto& e : endcaps_) { e.accept(v); }
+  }
+  void accept(SensorGeometryVisitor& v) { 
+    v.visit(*this); 
+    for (auto& b : barrels_) { b.accept(v); }
+    for (auto& e : endcaps_) { e.accept(v); }
   }
 
   std::pair<double, double> computeMinMaxEta() const; // pair.first = minEta, pair.second = maxEta (reversed with respect to the previous tkLayout geometry model)

--- a/include/Visitor.h
+++ b/include/Visitor.h
@@ -16,6 +16,7 @@ class DetectorModule;
 class RectangularModule;
 class WedgeModule;
 class GeometricModule;
+class Sensor;
 class SimParms;
 
 class GeometryVisitor { 
@@ -54,6 +55,26 @@ public:
   virtual void visit(const WedgeModule&) {}
   virtual void visit(const GeometricModule&) {}
   virtual void visit(const SimParms&) {}
+};
+
+class SensorGeometryVisitor { 
+public:
+  virtual void visit(Tracker&) {}
+  virtual void visit(Barrel&) {}
+  virtual void visit(Endcap&) {}
+  virtual void visit(Layer&) {}
+  virtual void visit(Disk&) {}
+  virtual void visit(Ring&) {}
+  virtual void visit(TiltedRing&) {}
+  virtual void visit(RodPair&) {}
+  virtual void visit(BarrelModule&) {}
+  virtual void visit(EndcapModule&) {}
+  virtual void visit(DetectorModule&) {}
+  // virtual void visit(RectangularModule&) {}
+  // virtual void visit(WedgeModule&) {}
+  //virtual void visit(GeometricModule&) {}
+  virtual void visit(Sensor&) {}
+  //virtual void visit(SimParms&) {}
 };
 
 #endif

--- a/include/capabilities.h
+++ b/include/capabilities.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "GeometryFactory.h"
+#include "messageLogger.h"
 
 using std::string;
 
@@ -51,6 +52,29 @@ public:
 
 template<class T> string fullid(const T& o) { return string(typeid(T).name()) + "(" + any2str(o.myid()) + ")"; }
 
+class DetIdentifiable {
+  uint32_t myDetId_ = 0;
+  std::map<int, uint32_t> detIdRef_;
+
+ public:
+  uint32_t myDetId() const { return myDetId_; }
+  std::map<int, uint32_t> detIdRef() const { return detIdRef_; }
+  // i will create a capabilities.cc and put that in it, sorry in the meantime ;p
+  void buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts) {
+    detIdRef_ = refs;
+    for (int i = 0; i < schemeShifts.size(); i++) {
+      uint32_t ref = refs.at(i);
+      int shift = schemeShifts.at(i);
+      if (ref <= pow(2, shift) ) {
+	myDetId_ <<= shift;
+	myDetId_ |= ref;
+	//std::bitset<32> test(myDetId_);
+	//std::cout << "detid_ = " << test << std::endl;
+      }
+      else logWARNING("buildDetId : At rank " + any2str(i) + ", ref number " + any2str(ref) + " is reached, while size allocated by the DetId scheme is 2^" + any2str(shift) + ".");
+    }
+  }
+};
 
 template<class T>
 class Clonable {

--- a/include/capabilities.h
+++ b/include/capabilities.h
@@ -68,8 +68,6 @@ class DetIdentifiable {
       if (ref <= pow(2, shift) ) {
 	myDetId_ <<= shift;
 	myDetId_ |= ref;
-	//std::bitset<32> test(myDetId_);
-	//std::cout << "detid_ = " << test << std::endl;
       }
       else logWARNING("buildDetId : At rank " + any2str(i) + ", ref number " + any2str(ref) + " is reached, while size allocated by the DetId scheme is 2^" + any2str(shift) + ".");
     }

--- a/include/global_constants.h
+++ b/include/global_constants.h
@@ -149,6 +149,8 @@ namespace insur {
   static const std::string suffix_pixel_material_file            = "_Materials.cfg.pix";
   static const std::string suffix_geometry_file                  = ".cfg";
   static const std::string suffix_types_file                     = "_Types.cfg";
+  static const std::string default_detidschemesdir               = "config";
+  static const std::string default_detidschemesfile              = "det_id_schemes.list";
   static const std::string default_rootfiledir                   = "rootfiles";
   static const std::string default_rootfile                      = "trackergeometry.root";
   static const std::string default_graphdir                      = "graphs";

--- a/include/global_funcs.h
+++ b/include/global_funcs.h
@@ -108,6 +108,14 @@ std::string lctrim(std::string str, const std::string& chars);
 std::string rctrim(std::string str, const std::string& chars);
 std::string ctrim(std::string str, const std::string& chars);
 
+// In C++11, the default modulo operator fmod is the truncated modulo.
+// Here, femod is the Euclidian modulo operator.
+// Please note, though, that for double comparaison purposes, an approximation of 0., if negative, stays negative !
+template<typename ArgType> inline ArgType femod(const ArgType& Phi, const ArgType& base) {
+  ArgType femodPhi = fmod(Phi, base);
+  if (femodPhi < -1e-10) femodPhi = femodPhi + base;
+  return femodPhi;
+}
 
 template<typename ArgType> inline int signum(const ArgType& x) {
   return (x > ArgType(0)) - (x < ArgType(0));

--- a/include/global_funcs.h
+++ b/include/global_funcs.h
@@ -111,10 +111,11 @@ std::string ctrim(std::string str, const std::string& chars);
 // In C++11, the default modulo operator fmod is the truncated modulo.
 // Here, femod is the Euclidian modulo operator.
 // Please note, though, that for double comparaison purposes, an approximation of 0., if negative, stays negative !
-template<typename ArgType> inline ArgType femod(const ArgType& Phi, const ArgType& base) {
-  ArgType femodPhi = fmod(Phi, base);
-  if (femodPhi < -1e-10) femodPhi = femodPhi + base;
-  return femodPhi;
+template<typename ArgType> inline ArgType femod(const ArgType& phi, const ArgType& base) {
+  ArgType result = fmod(phi, base);
+  if (fabs(result - base) < 1.e-5) result -= base;
+  if (result < -1.e-5) result += base;
+  return result;
 }
 
 template<typename ArgType> inline int signum(const ArgType& x) {

--- a/include/mainConfigHandler.h
+++ b/include/mainConfigHandler.h
@@ -61,6 +61,7 @@ public:
   string getMattabDirectory();
   string getIrradiationDirectory();
   string getDefaultMaterialsDirectory();
+  string getDetIdSchemesDirectory();
   string getStandardIncludeDirectory();
   string getGeometriesDirectory();
   string getConfigFileName();
@@ -98,6 +99,7 @@ private:
   string getMattabDirectory_();
   string getIrradiationDirectory_();
   string getDefaultMaterialsDirectory_();
+  string getDetIdSchemesDirectory_();
   string getStandardIncludeDirectory_();
   string getGeometriesDirectory_();
 

--- a/src/DetectorModule.cpp
+++ b/src/DetectorModule.cpp
@@ -39,6 +39,12 @@ void DetectorModule::build() {
       s->myid(i+1);
       s->store(propertyTree());
       if (sensorNode.count(i+1) > 0) s->store(sensorNode.at(i+1));
+      if (numSensors() == 1) s->innerOuter(SensorPosition::NO);
+      else {
+	if (i == 0) s->innerOuter(SensorPosition::LOWER);
+	else if (i == 1) s->innerOuter(SensorPosition::UPPER);
+	else s->innerOuter(SensorPosition::NO);
+      }
       s->build();
       sensors_.push_back(s);
       materialObject_.sensorChannels[i+1]=s->numChannels();
@@ -47,6 +53,7 @@ void DetectorModule::build() {
     Sensor* s = GeometryFactory::make<Sensor>();  // fake sensor to avoid defensive programming when iterating over the sensors and the module is empty
     s->parent(this);
     s->myid(1);
+    s->innerOuter(SensorPosition::NO);
     s->build();
     sensors_.push_back(s);
   }
@@ -467,6 +474,7 @@ void BarrelModule::build() {
     rAxis_ = normal();
     tiltAngle_ = 0.;
     skewAngle_ = 0.;
+    for (auto& s : sensors_) { s.subdet(ModuleSubdetector::BARREL); }
   }
   catch (PathfulException& pe) { pe.pushPath(*this, myid()); throw; }
   cleanup();
@@ -497,6 +505,7 @@ void EndcapModule::build() {
     rAxis_ = (basePoly().getVertex(0) + basePoly().getVertex(3)).Unit();
     tiltAngle_ = M_PI/2.;
     skewAngle_ = 0.;
+    for (auto& s : sensors_) { s.subdet(ModuleSubdetector::ENDCAP); }
   }
   catch (PathfulException& pe) { pe.pushPath(*this, myid()); throw; }
   cleanup();

--- a/src/GeometricModule.cpp
+++ b/src/GeometricModule.cpp
@@ -144,7 +144,7 @@ void RectangularModule::build() {
     check();
 
     float l = length(), w = width();
-    basePoly_ << XYZVector( l/2, w/2, 0) 
+    basePoly_ << XYZVector( l/2, w/2, 0)
               << XYZVector(-l/2, w/2, 0)
               << XYZVector(-l/2,-w/2, 0)
               << XYZVector( l/2,-w/2, 0);

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -319,7 +319,7 @@ void Layer::buildStraight(bool isFlatPart) {
   bool isPlusBigDeltaRod = (bigParity() > 0);
   first->build(rodTemplate, isPlusBigDeltaRod);
   first->translateR(placeRadius_ + (isPlusBigDeltaRod ? bigDelta() : -bigDelta()));
-  if (!isFlatPart) { rods_.push_back(first); }
+  if (!isFlatPart) { rods_.push_back(first); buildNumModulesFlat(first->numModulesSide(1)); }
   else { flatPartRods_.push_back(first); }
 
   // SECOND ROD : assign other properties, build and store 
@@ -558,7 +558,7 @@ void Layer::build() {
 
     if (!isTilted()) {
       buildStraight(false);
-      buildNumModulesFlat(buildNumModules());
+      if (buildNumModules() > 0 ) buildNumModulesFlat(buildNumModules());
       buildNumModulesTilted(0);
     }
     else buildTilted();

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -63,4 +63,17 @@ double Sensor::maxPitch() const { return parent_->maxWidth() / (double)numStrips
 double Sensor::pitch() const { return parent_->meanWidth() / (double)numStripsAcrossEstimate(); }
 double Sensor::stripLength() const { return parent_->length() / numSegmentsEstimate(); }
 
+void Sensor::buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts) {
+  detIdRef_ = refs;
+  for (int i = 0; i < schemeShifts.size(); i++) {
+    uint32_t ref = refs.at(i);
+    int shift = schemeShifts.at(i);
+    if (ref <= pow(2, shift) ) {
+      myDetId_ << shift;
+      myDetId_ |= ref;
+    }
+    else logWARNING("Sensor::buildDetId : At rank " + any2str(i) + ", ref number " + any2str(ref) + " is reached, while size allocated by the DetId scheme is 2^" + any2str(shift) + ".");
+  }
+}
+
 define_enum_strings(SensorType) = { "pixel", "largepix", "strip" };

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -69,8 +69,10 @@ void Sensor::buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShi
     uint32_t ref = refs.at(i);
     int shift = schemeShifts.at(i);
     if (ref <= pow(2, shift) ) {
-      myDetId_ << shift;
+      myDetId_ <<= shift;
       myDetId_ |= ref;
+      //std::bitset<32> test(myDetId_);
+      //std::cout << "detid_ = " << test << std::endl;
     }
     else logWARNING("Sensor::buildDetId : At rank " + any2str(i) + ", ref number " + any2str(ref) + " is reached, while size allocated by the DetId scheme is 2^" + any2str(shift) + ".");
   }

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -63,7 +63,7 @@ double Sensor::maxPitch() const { return parent_->maxWidth() / (double)numStrips
 double Sensor::pitch() const { return parent_->meanWidth() / (double)numStripsAcrossEstimate(); }
 double Sensor::stripLength() const { return parent_->length() / numSegmentsEstimate(); }
 
-void Sensor::buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts) {
+/*void Sensor::buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts) {
   detIdRef_ = refs;
   for (int i = 0; i < schemeShifts.size(); i++) {
     uint32_t ref = refs.at(i);
@@ -76,6 +76,6 @@ void Sensor::buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShi
     }
     else logWARNING("Sensor::buildDetId : At rank " + any2str(i) + ", ref number " + any2str(ref) + " is reached, while size allocated by the DetId scheme is 2^" + any2str(shift) + ".");
   }
-}
+  }*/
 
 define_enum_strings(SensorType) = { "pixel", "largepix", "strip" };

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -63,19 +63,4 @@ double Sensor::maxPitch() const { return parent_->maxWidth() / (double)numStrips
 double Sensor::pitch() const { return parent_->meanWidth() / (double)numStripsAcrossEstimate(); }
 double Sensor::stripLength() const { return parent_->length() / numSegmentsEstimate(); }
 
-/*void Sensor::buildDetId(std::map<int, uint32_t> refs, std::vector<int> schemeShifts) {
-  detIdRef_ = refs;
-  for (int i = 0; i < schemeShifts.size(); i++) {
-    uint32_t ref = refs.at(i);
-    int shift = schemeShifts.at(i);
-    if (ref <= pow(2, shift) ) {
-      myDetId_ <<= shift;
-      myDetId_ |= ref;
-      //std::bitset<32> test(myDetId_);
-      //std::cout << "detid_ = " << test << std::endl;
-    }
-    else logWARNING("Sensor::buildDetId : At rank " + any2str(i) + ", ref number " + any2str(ref) + " is reached, while size allocated by the DetId scheme is 2^" + any2str(shift) + ".");
-  }
-  }*/
-
 define_enum_strings(SensorType) = { "pixel", "largepix", "strip" };

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -193,7 +193,7 @@ void Tracker::build() {
     int numModules;
 
   public:
-    EndcapDetIdBuilder(std::string barrelScheme, std::vector<int> shifts, std::map< std::pair<std::string, int>, int > disksIds) : schemeName(name), schemeShifts(shifts), sortedDisksIds(disksIds) {}
+    EndcapDetIdBuilder(std::string name, std::vector<int> shifts, std::map< std::pair<std::string, int>, int > disksIds) : schemeName(name), schemeShifts(shifts), sortedDisksIds(disksIds) {}
 
     void visit(Endcap& e) {
       detIdRefs.insert(std::make_pair(0, 1));
@@ -229,7 +229,7 @@ void Tracker::build() {
     }
  
     void visit(EndcapModule& m) {
-      uint32_t phiRef = 1 + (uint32_t)(femod(m.Phi(), 2*M_PI) / (2*M_PI)) * numModules;
+      uint32_t phiRef = 1 + (uint32_t)(femod(m.center().Phi(), 2*M_PI) / (2*M_PI)) * numModules;
       detIdRefs.insert(std::make_pair(7, phiRef));
     }
 
@@ -264,7 +264,7 @@ void Tracker::build() {
 }
 
 
-std::map<std::string, std::vector<int> > Layer::detIdSchemes() {
+std::map<std::string, std::vector<int> > Tracker::detIdSchemes() {
   std::map<std::string, std::vector<int> > schemes;
 
   std::ifstream schemesStream(mainConfigHandler::instance().getDetIdSchemesDirectory() + "/" + insur::default_detidschemesfile);

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -80,6 +80,216 @@ void Tracker::build() {
 
   accept(cntNameVisitor);
 
+
+  std::vector< std::pair<const Layer*, std::string> > sortedLayers;
+  std::string barrelId;
+  for (auto& b : barrels_) {
+    barrelId = b.myid();
+    for (const auto& l : b.layers()) { sortedLayers.push_back(std::make_pair(&l, barrelId)); }
+  }
+  std::sort(sortedLayers.begin(), sortedLayers.end(), [&] (std::pair<const Layer*, std::string> l1, std::pair<const Layer*, std::string> l2) { return l1.first->minR() < l2.first->minR(); });
+  std::map< std::pair<std::string, int>, int > sortedLayersIds;
+  int i = 1;
+  for (const auto& l : sortedLayers) { sortedLayersIds.insert(std::make_pair(std::make_pair(l.second, l.first->myid()), i)); i++; }
+
+  std::vector< std::pair<const Disk*, std::string> > sortedDisks;
+  std::string endcapId;
+  for (auto& e : endcaps_) {
+    endcapId = e.myid();
+    for (const auto& d : e.disks()) { sortedDisks.push_back(std::make_pair(&d, endcapId)); }
+  }
+  std::sort(sortedDisks.begin(), sortedDisks.end(), [&] (std::pair<const Disk*, std::string> d1, std::pair<const Disk*, std::string> d2) { return d1.first->averageZ() < d2.first->averageZ(); });
+  std::map< std::pair<std::string, int>, int > sortedDisksIds;
+  i = 1;
+  for (const auto& d : sortedDisks) { sortedDisksIds.insert(std::make_pair(std::make_pair(d.second, d.first->myid()), i)); i++; }
+
+
+
+
+
+  class BarrelDetIdBuilder : public SensorGeometryVisitor {
+  private:
+    std::string schemeName;
+    std::vector<int> schemeShifts;
+    std::map< std::pair<std::string, int>, int > sortedLayersIds;
+
+    std::map<int, uint32_t> detIdRefs;
+
+    std::string barrelName;
+    int numRods;
+    int numFlatRings;
+    int numRings;
+
+  public:
+    BarrelDetIdBuilder(std::string name, std::vector<int> shifts, std::map< std::pair<std::string, int>, int > layersIds) : schemeName(name), schemeShifts(shifts), sortedLayersIds(layersIds) {}
+
+    void visit(Barrel& b) {
+      barrelName = b.myid();
+
+      detIdRefs.insert(std::make_pair(0, 1));
+
+      detIdRefs.insert(std::make_pair(1, 205 % 100));
+			   
+      detIdRefs.insert(std::make_pair(2, 0));
+    }
+
+    void visit(Layer& l) {
+      std::pair<std::string, int> layerId;
+      layerId = std::make_pair(barrelName, l.myid());
+      l.layerNumber(sortedLayersIds.at(layerId));
+
+      detIdRefs.insert(std::make_pair(3, l.layerNumber()));
+
+      numRods = l.numRods();
+      numFlatRings = l.buildNumModulesFlat();
+      numRings = l.buildNumModules();
+    }
+
+    void visit(RodPair& r) {
+      uint32_t phiRef = 1 + (uint32_t)(femod(r.Phi(), 2*M_PI) / (2*M_PI)) * numRods;
+      detIdRefs.insert(std::make_pair(5, phiRef));
+    }
+
+    void visit(BarrelModule& m) {
+      bool side = (m.minZ() > 0 ? 1 : 0);
+      uint32_t ringRef;
+
+      if (!m.isTilted()) {
+	detIdRefs.insert(std::make_pair(4, 3));
+
+	ringRef = (side ? m.uniRef().ring : 1 + m.uniRef().ring - numFlatRings);
+      }
+
+      else {
+	uint32_t category = (side == 1 ? 2 : 1);
+	detIdRefs.insert(std::make_pair(4, category));
+
+	ringRef = (side ? m.uniRef().ring : 1 + m.uniRef().ring - numRings);
+      }
+      detIdRefs.insert(std::make_pair(6, ringRef));
+    }
+
+    void visit(Sensor& s) {
+      uint32_t sensorRef = (s.innerOuter() == SensorPosition::LOWER ? 1 : 2);
+      if (s.subdet() == ModuleSubdetector::BARREL) {
+	detIdRefs.insert(std::make_pair(7, sensorRef));
+	s.buildDetId(detIdRefs, schemeShifts);
+      }  
+    }
+
+  };
+
+
+  class EndcapDetIdBuilder : public SensorGeometryVisitor {
+  private:
+    std::string schemeName;
+    std::vector<int> schemeShifts;
+    std::map< std::pair<std::string, int>, int > sortedDisksIds;
+
+    std::map<int, uint32_t> detIdRefs;
+
+    std::string endcapName;
+    int numEmptyRings;
+    int numModules;
+
+  public:
+    EndcapDetIdBuilder(std::string barrelScheme, std::vector<int> shifts, std::map< std::pair<std::string, int>, int > disksIds) : schemeName(name), schemeShifts(shifts), sortedDisksIds(disksIds) {}
+
+    void visit(Endcap& e) {
+      detIdRefs.insert(std::make_pair(0, 1));
+
+      detIdRefs.insert(std::make_pair(1, 204 % 100));
+    }
+
+    void visit(Disk& d) {
+      std::pair<std::string, int> diskId;
+      diskId = std::make_pair(endcapName, d.myid());
+      d.diskNumber(sortedDisksIds.at(diskId));
+
+      bool side = (d.minZ() > 0);
+
+      uint32_t sideRef = (side ? 2 : 1);
+      detIdRefs.insert(std::make_pair(2, sideRef));
+
+      detIdRefs.insert(std::make_pair(3, 0));
+
+      uint32_t diskRef = d.diskNumber();
+      detIdRefs.insert(std::make_pair(4, diskRef));
+
+      numEmptyRings = d.numEmptyRings();
+    }
+   
+    void visit(Ring& r) {
+      uint32_t ringRef = r.myid() - numEmptyRings;
+      detIdRefs.insert(std::make_pair(5, ringRef));
+
+      detIdRefs.insert(std::make_pair(6, 1));
+
+      numModules = r.numModules();
+    }
+ 
+    void visit(EndcapModule& m) {
+      uint32_t phiRef = 1 + (uint32_t)(femod(m.Phi(), 2*M_PI) / (2*M_PI)) * numModules;
+      detIdRefs.insert(std::make_pair(7, phiRef));
+    }
+
+    void visit(Sensor& s) {
+      uint32_t sensorRef = (s.innerOuter() == SensorPosition::LOWER ? 1 : 2);
+      if (s.subdet() == ModuleSubdetector::ENDCAP) {
+	detIdRefs.insert(std::make_pair(8, sensorRef));
+	s.buildDetId(detIdRefs, schemeShifts);
+      }
+    }
+
+  };
+
+
+  if (!isPixelTracker()) {
+    if (barrelDetIdScheme() == "Phase2Subdetector5" && detIdSchemes_.count("Phase2Subdetector5") != 0) {
+      BarrelDetIdBuilder v(barrelDetIdScheme(), detIdSchemes_["Phase2Subdetector5"], sortedLayersIds);
+      accept(v);
+    }
+    else logWARNING("barrelDetIdScheme = " + barrelDetIdScheme() + ". This barrel detId scheme is empty or incorrect or not currently implemented within tkLayout. No detId for Barrel sensors will be calculated.");
+
+    if (endcapDetIdScheme() == "Phase2Subdetector4" && detIdSchemes_.count("Phase2Subdetector4") != 0) {
+      EndcapDetIdBuilder v(endcapDetIdScheme(), detIdSchemes_["Phase2Subdetector4"], sortedDisksIds);
+      accept(v);
+    }
+    else logWARNING("endcapDetIdScheme = " + endcapDetIdScheme() + ". This endcap detId scheme is empty or incorrect or not currently implemented within tkLayout. No detId for Endcap sensors will be calculated.");
+  }
+
+
   cleanup();
   builtok(true);
+}
+
+
+std::map<std::string, std::vector<int> > Layer::detIdSchemes() {
+  std::map<std::string, std::vector<int> > schemes;
+
+  std::ifstream schemesStream(mainConfigHandler::instance().getDetIdSchemesDirectory() + "/" + insur::default_detidschemesfile);
+
+  if (schemesStream.good()) {
+    std::string line;
+    while(getline(schemesStream, line).good()) {
+      if (line.empty()) continue;
+      auto schemeData = split(line, " ");
+      std::string schemeName = schemeData.at(0);
+      if (schemeData.size() < 2) logWARNING("DetId scheme " + schemeName + " : no data was entered." );
+      else {
+	std::vector<int> detIdShifts;
+	int sum;
+	for (int i = 1; i < schemeData.size(); i++) {
+	  int shift = str2any<int>(schemeData.at(i));
+	  detIdShifts.push_back(shift);
+	  sum += shift; 
+	}
+	if (sum != 32) logWARNING("DetId scheme " + schemeName + " : The sum of Det Id shifts is not equal to 32." );
+	else schemes.insert(std::make_pair(schemeName, detIdShifts));
+      }
+    }
+    schemesStream.close();
+  } else logWARNING("No file defining a detId scheme has been found.");
+
+  return schemes;
 }

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -127,9 +127,8 @@ void Tracker::build() {
     int numRods;
     int numFlatRings;
     int numRings;
+    bool isCentered;
     uint32_t phiRef;
-
-    std::ostringstream out;
 
   public:
     BarrelDetIdBuilder(std::string name, std::vector<int> shifts, std::map< std::pair<std::string, int>, int > layersIds) : schemeName(name), schemeShifts(shifts), sortedLayersIds(layersIds) {}
@@ -155,11 +154,14 @@ void Tracker::build() {
       numRods = l.numRods();
       numFlatRings = l.buildNumModulesFlat();
       numRings = l.buildNumModules();
+      if (!isTiltedLayer) numRings = numFlatRings;
     }
 
     void visit(RodPair& r) {
       double startAngle = femod( r.Phi(), (2 * M_PI / numRods));
       phiRef = 1 + round(femod(r.Phi() - startAngle, 2*M_PI) / (2*M_PI) * numRods);
+
+      isCentered = (r.startZMode() == RodPair::StartZMode::MODULECENTER);
     }
 
     void visit(BarrelModule& m) {
@@ -170,7 +172,7 @@ void Tracker::build() {
 	detIdRefs[4] = 3;
 	detIdRefs[5] = phiRef;
 
-	if (isTiltedLayer) ringRef = (side > 0 ? (m.uniRef().ring + numFlatRings - 1) : (1 + numFlatRings - m.uniRef().ring));
+	if (isCentered) ringRef = (side > 0 ? (m.uniRef().ring + numFlatRings - 1) : (1 + numFlatRings - m.uniRef().ring));
 	else ringRef = (side > 0 ? (m.uniRef().ring + numFlatRings) : (1 + numFlatRings - m.uniRef().ring));
 	detIdRefs[6] = ringRef;
       }
@@ -184,6 +186,15 @@ void Tracker::build() {
 
 	detIdRefs[6] = phiRef;
       }
+
+      uint32_t sensorRef = 0;
+      detIdRefs[7] = sensorRef;
+      m.buildDetId(detIdRefs, schemeShifts);
+
+      //std::bitset<32> test(m.myDetId());
+      //std::cout << m.myDetId() << " " << test << " " << "rho = " << m.center().Rho() << " z = " <<  m.center().Z() << " phi = " <<  (m.center().Phi() * 180. / M_PI) << std::endl;
+
+
       
       //out.str("");
       //out << "rho = " <<  m.center().Rho() << " z = " << m.center().Z() << " phi = " << (m.center().Phi() * 180. / M_PI);
@@ -203,9 +214,8 @@ void Tracker::build() {
 	  }*/
 
 	s.buildDetId(detIdRefs, schemeShifts);
-	std::bitset<32> test(s.myDetId());
-	//std::cout << s.myDetId() << " " << test << " " << out.str() << std::endl;
-	std::cout << s.myDetId() << " " << test << " " << out.str() << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
+	//std::bitset<32> test(s.myDetId());
+	//std::cout << s.myDetId() << " " << test << " " << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
       }  
     }
 
@@ -223,8 +233,6 @@ void Tracker::build() {
     std::string endcapName;
     int numEmptyRings;
     int numModules;
-
-    std::ostringstream out;
 
   public:
     EndcapDetIdBuilder(std::string name, std::vector<int> shifts, std::map< std::tuple<std::string, int, bool>, int > disksIds) : schemeName(name), schemeShifts(shifts), sortedDisksIds(disksIds) {}
@@ -269,6 +277,14 @@ void Tracker::build() {
       uint32_t phiRef = 1 + round(femod(m.center().Phi() - startAngle, 2*M_PI) / (2*M_PI) * numModules);
       detIdRefs[7] = phiRef;
 
+      uint32_t sensorRef = 0;
+      detIdRefs[8] = sensorRef;
+      m.buildDetId(detIdRefs, schemeShifts);
+
+      //std::bitset<32> test(m.myDetId());
+      //std::cout << m.myDetId() << " " << test << " " << "rho = " << m.center().Rho() << " z = " <<  m.center().Z() << " phi = " <<  (m.center().Phi() * 180. / M_PI) << std::endl;
+
+
       //std::cout << "disk = " << m.uniRef().layer << "ring = " <<  m.uniRef().ring << "side = " << m.uniRef().side << std::endl;
     }
 
@@ -287,8 +303,8 @@ void Tracker::build() {
 
 	s.buildDetId(detIdRefs, schemeShifts);
 
-	std::bitset<32> test(s.myDetId());
-	std::cout << s.myDetId() << " " << test << " " << out.str() << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
+	//std::bitset<32> test(s.myDetId());
+	//std::cout << s.myDetId() << " " << test << " " << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
       }
     }
 

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -81,7 +81,7 @@ void Tracker::build() {
   accept(cntNameVisitor);
 
 
-  // THis is uglyy, need to be worked on
+  // THis is uglyy, sorry i will completely rewrite this
   std::vector< std::pair<const Layer*, std::string> > sortedLayers;
   std::string barrelId;
   for (auto& b : barrels_) {
@@ -110,7 +110,9 @@ void Tracker::build() {
   for (const auto& d : sortedZPlusDisks) { sortedDisksIds.insert(std::make_pair(std::make_tuple(d.second, d.first->myid(), d.first->side()), i)); i++; }
   i = 1;
   for (const auto& d : sortedZMinusDisks) { sortedDisksIds.insert(std::make_pair(std::make_tuple(d.second, d.first->myid(), d.first->side()), i)); i++; }
-  // End of the ugly part ;p
+  // END OF THE UGLY PART
+
+
 
 
 
@@ -189,16 +191,8 @@ void Tracker::build() {
 
       uint32_t sensorRef = 0;
       detIdRefs[7] = sensorRef;
+
       m.buildDetId(detIdRefs, schemeShifts);
-
-      //std::bitset<32> test(m.myDetId());
-      //std::cout << m.myDetId() << " " << test << " " << "rho = " << m.center().Rho() << " z = " <<  m.center().Z() << " phi = " <<  (m.center().Phi() * 180. / M_PI) << std::endl;
-
-
-      
-      //out.str("");
-      //out << "rho = " <<  m.center().Rho() << " z = " << m.center().Z() << " phi = " << (m.center().Phi() * 180. / M_PI);
-      //std::cout << "layer = " << m.uniRef().layer << "ring = " <<  m.uniRef().ring << "side = " << m.uniRef().side << std::endl;
     }
 
     void visit(Sensor& s) {
@@ -206,16 +200,7 @@ void Tracker::build() {
       if (s.subdet() == ModuleSubdetector::BARREL) {
 	detIdRefs[7] = sensorRef;
 
-	/*for (int a = 0; a < detIdRefs.size(); a++) {
-	  std::cout << "values = " << std::endl;
-	  std::cout << detIdRefs.at(a) << std::endl;
-	  std::cout << "scheme = " << std::endl;
-	  std::cout << schemeShifts.at(a) << std::endl;
-	  }*/
-
 	s.buildDetId(detIdRefs, schemeShifts);
-	//std::bitset<32> test(s.myDetId());
-	//std::cout << s.myDetId() << " " << test << " " << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
       }  
     }
 
@@ -280,10 +265,6 @@ void Tracker::build() {
       uint32_t sensorRef = 0;
       detIdRefs[8] = sensorRef;
       m.buildDetId(detIdRefs, schemeShifts);
-
-      //std::bitset<32> test(m.myDetId());
-      //std::cout << m.myDetId() << " " << test << " " << "rho = " << m.center().Rho() << " z = " <<  m.center().Z() << " phi = " <<  (m.center().Phi() * 180. / M_PI) << std::endl;
-
 
       //std::cout << "disk = " << m.uniRef().layer << "ring = " <<  m.uniRef().ring << "side = " << m.uniRef().side << std::endl;
     }

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -81,6 +81,7 @@ void Tracker::build() {
   accept(cntNameVisitor);
 
 
+  // THis is uglyy, need to be worked on
   std::vector< std::pair<const Layer*, std::string> > sortedLayers;
   std::string barrelId;
   for (auto& b : barrels_) {
@@ -109,7 +110,7 @@ void Tracker::build() {
   for (const auto& d : sortedZPlusDisks) { sortedDisksIds.insert(std::make_pair(std::make_tuple(d.second, d.first->myid(), d.first->side()), i)); i++; }
   i = 1;
   for (const auto& d : sortedZMinusDisks) { sortedDisksIds.insert(std::make_pair(std::make_tuple(d.second, d.first->myid(), d.first->side()), i)); i++; }
-
+  // End of the ugly part ;p
 
 
 
@@ -127,6 +128,8 @@ void Tracker::build() {
     int numFlatRings;
     int numRings;
     uint32_t phiRef;
+
+    std::ostringstream out;
 
   public:
     BarrelDetIdBuilder(std::string name, std::vector<int> shifts, std::map< std::pair<std::string, int>, int > layersIds) : schemeName(name), schemeShifts(shifts), sortedLayersIds(layersIds) {}
@@ -182,6 +185,8 @@ void Tracker::build() {
 	detIdRefs[6] = phiRef;
       }
       
+      //out.str("");
+      //out << "rho = " <<  m.center().Rho() << " z = " << m.center().Z() << " phi = " << (m.center().Phi() * 180. / M_PI);
       //std::cout << "layer = " << m.uniRef().layer << "ring = " <<  m.uniRef().ring << "side = " << m.uniRef().side << std::endl;
     }
 
@@ -198,8 +203,9 @@ void Tracker::build() {
 	  }*/
 
 	s.buildDetId(detIdRefs, schemeShifts);
-	//std::bitset<32> test(s.myDetId());
-	//std::cout << "detid_ = " << test << std::endl;
+	std::bitset<32> test(s.myDetId());
+	//std::cout << s.myDetId() << " " << test << " " << out.str() << std::endl;
+	std::cout << s.myDetId() << " " << test << " " << out.str() << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
       }  
     }
 
@@ -217,6 +223,8 @@ void Tracker::build() {
     std::string endcapName;
     int numEmptyRings;
     int numModules;
+
+    std::ostringstream out;
 
   public:
     EndcapDetIdBuilder(std::string name, std::vector<int> shifts, std::map< std::tuple<std::string, int, bool>, int > disksIds) : schemeName(name), schemeShifts(shifts), sortedDisksIds(disksIds) {}
@@ -279,8 +287,8 @@ void Tracker::build() {
 
 	s.buildDetId(detIdRefs, schemeShifts);
 
-	//std::bitset<32> test(s.myDetId());
-	//std::cout << "detid_ = " << test << std::endl;
+	std::bitset<32> test(s.myDetId());
+	std::cout << s.myDetId() << " " << test << " " << out.str() << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
       }
     }
 

--- a/src/mainConfigHandler.cpp
+++ b/src/mainConfigHandler.cpp
@@ -388,6 +388,11 @@ string mainConfigHandler::getDefaultMaterialsDirectory() {
   return getDefaultMaterialsDirectory_();
 }
 
+string mainConfigHandler::getDetIdSchemesDirectory() {
+  getConfiguration();
+  return getDetIdSchemesDirectory_();
+}
+
 string mainConfigHandler::getStandardIncludeDirectory() {
   getConfiguration();
   return getStandardIncludeDirectory_();
@@ -406,6 +411,7 @@ string mainConfigHandler::getXmlDirectory_() { return standardDirectory_+"/"+ins
 string mainConfigHandler::getMattabDirectory_() { return standardDirectory_+"/"+insur::default_mattabdir; }
 string mainConfigHandler::getIrradiationDirectory_() { return standardDirectory_+"/"+insur::default_irradiationdir; }
 string mainConfigHandler::getDefaultMaterialsDirectory_() { return standardDirectory_+"/"+insur::default_materialsdir; }
+string mainConfigHandler::getDetIdSchemesDirectory_() { return standardDirectory_+"/"+insur::default_detidschemesdir; }
 string mainConfigHandler::getStandardIncludeDirectory_() { return standardDirectory_+"/"+insur::default_configdir+"/"+insur::default_stdincludedir; }
 string mainConfigHandler::getGeometriesDirectory_() { return standardDirectory_+"/"+insur::default_geometriesdir; }
 


### PR DESCRIPTION
DetId schemes presently in  CMSSW_8_1_X, that is to say Phase2Subdetector5 and Phase2Subdetector4, are now implemented in tkLayout.

Now that the structure is there, it is possible to easily add a new DetId scheme if needed. 

For getting DetIds, the user needs to specify in a Tracker cfg file the DetId schemes that he wants.
For example : 
_Tracker Outer {
barrelDetIdScheme Phase2Subdetector5
endcapDetIdScheme Phase2Subdetector4
}_

DetIds are then accessible in an intuitive way : 
- for each DetectorModule m :  with m->myDetId().
- for each Sensor s :  with s->myDetId().

Please check the warning tab on the website each time you are generating DetIds, in case of problem there might be useful information in there !

As a convention, the last 2 bits are set to : 
- 0 in case of a module DetId;
- 1 in case of a lower sensor DetId;
- 2 in case of a upper sensor DetId;

Results are fully tested with layout OT_Tilted_362_200_Pixel_4021.cfg only for the moment.
Notably, the DetIds + coordinates have been compared with the CMSSW ones, and a perfect match (without taking into account several numerical approximations) has been observed for this layout.
Which confirms there is no bug in the XML export :)

NB : This code is debug style, there are several things I want to improve in it. So this work is not completely finished :)