### PR TITLE
New alpha parameter 5.3E-17 -> 4.28E-17

### DIFF
--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -11,7 +11,7 @@ SimParms {
     operatingTemp -20
     referenceTemp 20
     chargeDepletionVoltage 600
-    alphaParam 5.3e-17
+    alphaParam 4.28e-17
     pixelEfficiency 1
 
     numTriggerTowersEta 6


### PR DESCRIPTION
As per Duccio's slides here: https://indico.cern.ch/event/536254/ (CoolingMargins)