### PR TITLE
Calculating Z and A from radiation length and nuclear interaction length by Stefano (code just copied pasted here).

### DIFF
--- a/include/Extractor.h
+++ b/include/Extractor.h
@@ -111,10 +111,9 @@ namespace insur {
     double compositeDensity(ModuleCap& mc, bool nosensors = false);
     double compositeDensity(InactiveElement& ie);
     double fromRim(double r, double w);
-    //int Z(double x0, double A);
-    double compute_X0(int pZ, double pA);
-    int findClosest_Z(double pA, double radiationLength);
     std::pair<double, int> getAZ(double radiationLength, double interactionLength);
+    int findClosest_Z(double pA, double radiationLength);
+    double compute_X0(int pZ, double pA); 
   };
 
 #if defined(__FLIPSENSORS_IN__) || defined(__FLIPSENSORS_OUT__)

--- a/include/Extractor.h
+++ b/include/Extractor.h
@@ -111,7 +111,10 @@ namespace insur {
     double compositeDensity(ModuleCap& mc, bool nosensors = false);
     double compositeDensity(InactiveElement& ie);
     double fromRim(double r, double w);
-    int Z(double x0, double A);
+    //int Z(double x0, double A);
+    double compute_X0(int pZ, double pA);
+    int findClosest_Z(double pA, double radiationLength);
+    std::pair<double, int> getAZ(double radiationLength, double interactionLength);
   };
 
 #if defined(__FLIPSENSORS_IN__) || defined(__FLIPSENSORS_OUT__)

--- a/include/MaterialTable.h
+++ b/include/MaterialTable.h
@@ -3,7 +3,7 @@
 // Author: ndemaio
 //
 // Created on October 14, 2008, 10:53 AM
-//
+// MaterialTable is nearly not used and was replaced by MaterialTab. This should be reworked.
 
 /**
  * @file MaterialTable.h

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -2482,7 +2482,6 @@ namespace insur {
       d = 1000 * m / d;
     }
     else d = 1000 * mc.getTotalMass() / d;
-    std::cout << "composite d = " << std::endl;
     return d;
   }
 

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -178,6 +178,87 @@ namespace insur {
     std::cout << "Analysis done." << std::endl;
   }
 
+
+
+
+  double Extractor::compute_X0(int pZ, double pA) {
+    double Z = pZ;
+    const double alpha = 1/137.035999139;
+    double a = alpha*Z;
+    double a_2 = a*a;
+    double a_3 = a*a*a;
+    double a_4 = a_2*a_2;
+    double a_6 = a_3*a_3;
+    double f_Z = a_2*(1/(1+a_2)+0.20206-0.0369*a_3+0.0083*a_4-0.002*a_6);
+    double L_Z, L_prime_Z;
+    switch (pZ) {
+    case 1:
+      // H
+      L_Z       = 5.31;
+      L_prime_Z = 6.144;
+      break;
+    case 2:
+      // He
+      L_Z       = 4.79;
+      L_prime_Z = 5.621;
+      break;
+    case 3:
+      // Li
+      L_Z       = 4.74;
+      L_prime_Z = 5.805;
+      break;
+    case 4:
+      // Be:
+      L_Z       = 4.71;
+      L_prime_Z = 5.924;
+      break;
+    default:
+      // Z >4
+      L_Z = log(184.15) - 1/3. * log(Z);
+      L_prime_Z = log(1194) - 2/3. * log(Z);
+    }
+    
+    // X_0
+    return 716.408 * pA / (Z*Z*(L_Z-f_Z) + Z*L_prime_Z);
+  }
+
+  int Extractor::findClosest_Z(double pA, double radiationLength) {
+    double distance = fabs(radiationLength - compute_X0(1, pA));
+    int closest_Z = 1;
+    for (int i=2; i<85; ++i) {
+      double aDistance = fabs(radiationLength-compute_X0(i, pA));
+      if (aDistance<distance) distance = aDistance , closest_Z=i;
+    }
+    return closest_Z;
+  }
+
+  std::pair<double, int> Extractor::getAZ(double radiationLength, double interactionLength) {
+    const double A_a = 31.645;
+    const double A_b = 11.57238;
+    double A_estimate = pow((interactionLength-A_b)/A_a,3);
+    int Z = findClosest_Z(A_estimate, radiationLength);
+    double radEstimate = compute_X0(Z, A_estimate);
+    // correct A to obtain the right radLength, but leave 1/3 of the
+    // correction aside, given the relative dependencies
+    A_estimate /= pow(radEstimate/radiationLength, 2/3.);
+
+    radEstimate = compute_X0(Z, A_estimate);  
+    double intEstimate = pow(A_estimate, 1./3.)*A_a+A_b;
+
+    /*cout << radiationLength << "\t"
+	 << interactionLength << "\t"
+	 << A_estimate << "\t"
+	 << Z << "\t"
+	 << radEstimate << "\t"
+	 << intEstimate << "\t"
+	 << (radEstimate-radiationLength)/radiationLength << "\t"
+	 << (intEstimate-interactionLength)/interactionLength << endl;*/
+
+    std::pair<double, int> AZ = std::make_pair(A_estimate, Z);
+    return AZ;
+  }
+
+
   //protected
   /**
    * This is one of the smaller analysis functions that provide the core functionality of this class. It goes through
@@ -193,8 +274,9 @@ namespace insur {
       MaterialRow& r = mattab.getMaterial(i);
       e.tag = r.tag;
       e.density = r.density;
-      e.atomic_weight = pow((r.ilength / 35.), 3); // magic!
-      e.atomic_number = Z(r.rlength, e.atomic_weight);
+      std::pair<double, int> AZ = getAZ(r.rlength, r.ilength);
+      e.atomic_weight = AZ.first;
+      e.atomic_number = AZ.second;
       elems.push_back(e);
     }
   }
@@ -2481,6 +2563,7 @@ namespace insur {
       d = 1000 * m / d;
     }
     else d = 1000 * mc.getTotalMass() / d;
+    std::cout << "composite d = " << std::endl;
     return d;
   }
 
@@ -2515,13 +2598,13 @@ namespace insur {
    * @param A The atomic weight
    * @return The atomic number
    */
-  int Extractor::Z(double x0, double A) {
+  /*int Extractor::Z(double x0, double A) {
     // TODO: understand this: why do we need to
     // get an integer value as output?
     double d = 4 - 4 * (1.0 - 181.0 * A / x0);
     if (d > 0) return int(floor((sqrt(d) - 2.0) / 2.0 + 0.5));
     else return -1;
-  }
+    }*/
 
 
   const double ModuleComplex::kmm3Tocm3 = 1e-3;

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -178,87 +178,6 @@ namespace insur {
     std::cout << "Analysis done." << std::endl;
   }
 
-
-
-
-  double Extractor::compute_X0(int pZ, double pA) {
-    double Z = pZ;
-    const double alpha = 1/137.035999139;
-    double a = alpha*Z;
-    double a_2 = a*a;
-    double a_3 = a*a*a;
-    double a_4 = a_2*a_2;
-    double a_6 = a_3*a_3;
-    double f_Z = a_2*(1/(1+a_2)+0.20206-0.0369*a_3+0.0083*a_4-0.002*a_6);
-    double L_Z, L_prime_Z;
-    switch (pZ) {
-    case 1:
-      // H
-      L_Z       = 5.31;
-      L_prime_Z = 6.144;
-      break;
-    case 2:
-      // He
-      L_Z       = 4.79;
-      L_prime_Z = 5.621;
-      break;
-    case 3:
-      // Li
-      L_Z       = 4.74;
-      L_prime_Z = 5.805;
-      break;
-    case 4:
-      // Be:
-      L_Z       = 4.71;
-      L_prime_Z = 5.924;
-      break;
-    default:
-      // Z >4
-      L_Z = log(184.15) - 1/3. * log(Z);
-      L_prime_Z = log(1194) - 2/3. * log(Z);
-    }
-    
-    // X_0
-    return 716.408 * pA / (Z*Z*(L_Z-f_Z) + Z*L_prime_Z);
-  }
-
-  int Extractor::findClosest_Z(double pA, double radiationLength) {
-    double distance = fabs(radiationLength - compute_X0(1, pA));
-    int closest_Z = 1;
-    for (int i=2; i<85; ++i) {
-      double aDistance = fabs(radiationLength-compute_X0(i, pA));
-      if (aDistance<distance) distance = aDistance , closest_Z=i;
-    }
-    return closest_Z;
-  }
-
-  std::pair<double, int> Extractor::getAZ(double radiationLength, double interactionLength) {
-    const double A_a = 31.645;
-    const double A_b = 11.57238;
-    double A_estimate = pow((interactionLength-A_b)/A_a,3);
-    int Z = findClosest_Z(A_estimate, radiationLength);
-    double radEstimate = compute_X0(Z, A_estimate);
-    // correct A to obtain the right radLength, but leave 1/3 of the
-    // correction aside, given the relative dependencies
-    A_estimate /= pow(radEstimate/radiationLength, 2/3.);
-
-    radEstimate = compute_X0(Z, A_estimate);  
-    double intEstimate = pow(A_estimate, 1./3.)*A_a+A_b;
-
-    /*cout << radiationLength << "\t"
-	 << interactionLength << "\t"
-	 << A_estimate << "\t"
-	 << Z << "\t"
-	 << radEstimate << "\t"
-	 << intEstimate << "\t"
-	 << (radEstimate-radiationLength)/radiationLength << "\t"
-	 << (intEstimate-interactionLength)/interactionLength << endl;*/
-
-    std::pair<double, int> AZ = std::make_pair(A_estimate, Z);
-    return AZ;
-  }
-
-
   //protected
   /**
    * This is one of the smaller analysis functions that provide the core functionality of this class. It goes through
@@ -2593,19 +2512,98 @@ namespace insur {
   }
 
   /**
-   * Calculate the atomic number of an elementary material from its radiation length and atomic weight.
-   * @param x0 The radiation length
-   * @param A The atomic weight
-   * @return The atomic number
+   * Calculate estimated atomic number and atomic weight from radiation and nuclear interaction length.
+   * @param radiationLength
+   * @param interactionLength
+   * @return Estimated atomic number and atomic weight.
    */
-  /*int Extractor::Z(double x0, double A) {
-    // TODO: understand this: why do we need to
-    // get an integer value as output?
-    double d = 4 - 4 * (1.0 - 181.0 * A / x0);
-    if (d > 0) return int(floor((sqrt(d) - 2.0) / 2.0 + 0.5));
-    else return -1;
-    }*/
+  std::pair<double, int> Extractor::getAZ(double radiationLength, double interactionLength) {
+    const double A_a = 31.645;
+    const double A_b = 11.57238;
+    double A_estimate = pow((interactionLength-A_b)/A_a,3);
+    int Z = findClosest_Z(A_estimate, radiationLength);
+    double radEstimate = compute_X0(Z, A_estimate);
+    // correct A to obtain the right radLength, but leave 1/3 of the
+    // correction aside, given the relative dependencies
+    A_estimate /= pow(radEstimate/radiationLength, 2/3.);
 
+    radEstimate = compute_X0(Z, A_estimate);  
+    double intEstimate = pow(A_estimate, 1./3.)*A_a+A_b;
+
+    /*cout << radiationLength << "\t"
+      << interactionLength << "\t"
+      << A_estimate << "\t"
+      << Z << "\t"
+      << radEstimate << "\t"
+      << intEstimate << "\t"
+      << (radEstimate-radiationLength)/radiationLength << "\t"
+      << (intEstimate-interactionLength)/interactionLength << endl;*/
+
+    std::pair<double, int> AZ = std::make_pair(A_estimate, Z);
+    return AZ;
+  }
+
+  /**
+   * Calculate the closest atomic number corresponding to a given estimated atomic weight and radiation length.
+   * @param pA Estimated atomic weight
+   * @param radiationLength
+   * @return Closest atomic number.
+   */
+  int Extractor::findClosest_Z(double pA, double radiationLength) {
+    double distance = fabs(radiationLength - compute_X0(1, pA));
+    int closest_Z = 1;
+    for (int i=2; i<85; ++i) {
+      double aDistance = fabs(radiationLength-compute_X0(i, pA));
+      if (aDistance<distance) distance = aDistance , closest_Z=i;
+    }
+    return closest_Z;
+  }
+
+  /**
+   * Calculate the estimated radiation length associated to an estimated atomic number Z and estimated atomic weight A.
+   */
+  double Extractor::compute_X0(int pZ, double pA) {
+    double Z = pZ;
+    const double alpha = 1/137.035999139;
+    double a = alpha*Z;
+    double a_2 = a*a;
+    double a_3 = a*a*a;
+    double a_4 = a_2*a_2;
+    double a_6 = a_3*a_3;
+    double f_Z = a_2*(1/(1+a_2)+0.20206-0.0369*a_3+0.0083*a_4-0.002*a_6);
+    double L_Z, L_prime_Z;
+    switch (pZ) {
+    case 1:
+      // H
+      L_Z       = 5.31;
+      L_prime_Z = 6.144;
+      break;
+    case 2:
+      // He
+      L_Z       = 4.79;
+      L_prime_Z = 5.621;
+      break;
+    case 3:
+      // Li
+      L_Z       = 4.74;
+      L_prime_Z = 5.805;
+      break;
+    case 4:
+      // Be:
+      L_Z       = 4.71;
+      L_prime_Z = 5.924;
+      break;
+    default:
+      // Z >4
+      L_Z = log(184.15) - 1/3. * log(Z);
+      L_prime_Z = log(1194) - 2/3. * log(Z);
+    }
+    
+    // X_0
+    return 716.408 * pA / (Z*Z*(L_Z-f_Z) + Z*L_prime_Z);
+  }
+
+ 
 
   const double ModuleComplex::kmm3Tocm3 = 1e-3;
 

--- a/src/MaterialTable.cc
+++ b/src/MaterialTable.cc
@@ -94,7 +94,7 @@ namespace insur {
 
   double ElementaryMaterial::getRadiationLength() {
     if (rlength_ <= 0) {
-      rlength_ = 716.4*a_/(z_*(z_+1)+log(287/sqrt(z_)));
+      rlength_ = 716.4*a_/(z_*(z_+1)*log(287/sqrt(z_)));
     }
     return rlength_;
   }


### PR DESCRIPTION
This is temporary, as this aspect of the code for the material will be reworked anyway.
In the meantime, it provides Z and A in an acceptable range of uncertainty.

Plus Fixed merge-ability conflict of dev_gabie into dev