### PR TITLE
Bug fix in the calculation of the eta coverage of trigger tower

### DIFF
--- a/src/AnalyzerVisitors/TriggerProcessorBandwidth.cpp
+++ b/src/AnalyzerVisitors/TriggerProcessorBandwidth.cpp
@@ -122,8 +122,8 @@ bool AnalyzerHelpers::isModuleInEtaSector(const SimParms& simParms, const Tracke
   double etaSliceZ1 = maxR/tan(2*atan(exp(-eta)));
   double etaSliceZ2 = maxR/tan(2*atan(exp(-eta-etaSlice)));
 
-  double etaDist1 =  modMaxZ - ((etaSliceZ1 >= 0 ? modMinR : modMaxR)*(etaSliceZ1 + zError)/maxR - zError); // if etaDists are positive it means the module is in the slice
-  double etaDist2 = -modMinZ + ((etaSliceZ2 >= 0 ? modMaxR : modMinR)*(etaSliceZ2 - zError)/maxR + zError); 
+  double etaDist1 =  modMaxZ - ((etaSliceZ1 >= -zError ? modMinR : modMaxR)*(etaSliceZ1 + zError)/maxR - zError); // if etaDists are positive it means the module is in the slice
+  double etaDist2 = -modMinZ + ((etaSliceZ2 >= zError ? modMaxR : modMinR)*(etaSliceZ2 - zError)/maxR + zError); 
 
   return etaDist1 > 0 && etaDist2 > 0;
 }


### PR DESCRIPTION
Let's discuss this in real, maybe there is no bug and I am mistaking, but it looks like it.
NB : This has absolutely nothing to do with the extension up to 2.4, which is done on another branch.

This is about the code which calculates the eta coverage of each trigger tower.
More precisely, this is about whether MINR or MAXR of a module should be considered to check whether this module belongs to a given trigger tower.

In practice, this is a very subtle diff, and the effect of this is null on the present OT_Tilted_362_Pixel_4021 geometry and for the choice of zError=70mm.
It is unlikely that this has affected the eta coverage of trigger towers in other geometries, but not for granted at all either though.