### PR TITLE
New tracker model and alpha parameter fixed

### DIFF
--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -11,11 +11,14 @@ SimParms {
     operatingTemp -20
     referenceTemp 20
     chargeDepletionVoltage 600
-    alphaParam 4.28e-17
+    alphaParm 4.28e-17
     pixelEfficiency 1
 
     numTriggerTowersEta 6
     numTriggerTowersPhi 8
     triggerPtCut 2
     triggerEtaCut 2.2
+
+
+    Gabie IsAHero           // inside joke. forget about it
 }

--- a/geometries/CMS_Phase2/OT_Tilted_362_200_Pixel_4023.cfg
+++ b/geometries/CMS_Phase2/OT_Tilted_362_200_Pixel_4023.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V362_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_3.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_2.cfg
@@ -59,12 +59,12 @@
     Disk 7 { placeZ 1094.57 }
     Disk 8 { placeZ 1400.00 }
 
-    Disk 1  { destination FPIX1 }
-    Disk 2  { destination FPIX2 }
-    Disk 3  { destination FPIX3 }
-    Disk 4  { destination FPIX4 }
-    Disk 5  { destination FPIX5 }
-    Disk 6  { destination FPIX6 }
-    Disk 7  { destination FPIX7 }
-    Disk 8  { destination FPIX8 }
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_2_3.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_2_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2650
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1850.00 }
+    Disk 2 { placeZ 2085.43 }
+    Disk 3 { placeZ 2350.83 }
+    Disk 4 { placeZ 2650.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_3.cfg
@@ -1,0 +1,24 @@
+
+Tracker Pixels {
+
+  phiSegments 4
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include BPIX_4_0_0.cfg
+  @include FPIX1_4_0_2.cfg
+  @include FPIX2_4_0_2_3.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/stations_FPIX_2_2_Service_Cylinder_near
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/stations_FPIX_2_2_Service_Cylinder_near
@@ -1,0 +1,31 @@
+// Pixel endcap second-station conversions (service cylinder)
+// twisted pairs->GBT
+
+Station {
+  stationName FPIX9
+  type second
+  minZ 1870.00
+  maxZ 1920.00
+  @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
+}
+Station {
+  stationName FPIX10
+  type second
+  minZ 2105.43
+  maxZ 2155.43
+  @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
+}
+Station {
+  stationName FPIX11
+  type second
+  minZ 2370.83
+  maxZ 2420.83
+  @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
+}
+Station {
+  stationName FPIX12
+  type second
+  minZ 2670.00
+  maxZ 2720.00
+  @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -67,4 +67,7 @@ OT_Tilted_462_200_Pixel_4021.cfg     OT Version 4.6.2 <- like 3.6.2 but Avi-styl
 
 Baseline_tilted_200_Pixel_4_1_0.cfg  Like 4_0_0, but with tilted BPIX
 
+OT_Tilted_362_200_Pixel_4023.cfg     OT Version 3.6.2
+                                     Pixel version 4.0.2.3 <- like 4.0.2.1 but with 8 FPIX_1 disks and 4 FPIX_2 disks
+
 


### PR DESCRIPTION
Creating pixel version 4.0.2.3 (=4.0.2.1 but with 8 FPIX disks and keeping 4 EXT disks)
Fixing alpha parameter, which was wrongly typed (the default value of 4.0e-17 was always used)