### PR TITLE
Corrected ommission in straight rod module placement, in particular case where zEnd < zError and the build is upwards 

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Resolutions/README.txt
+++ b/config/stdinclude/CMS_Phase2/Pixel/Resolutions/README.txt
@@ -1,5 +1,5 @@
-This is to simulate resolution on pixel modules local coordinates X and Y.
-resolutionLocalX or Y are either nominal values, either values calculated from parameterized models.
+This is to simulate resolution on pixel modules local coordinates X and Y with tkLayout.
+2 modes are avaialble : either resolutionLocalX or Y are set as nominal values, either they are calculated from parameterized models.
 
 
 
@@ -38,17 +38,17 @@ resolutionLocalYEndcap = resolutionLocalYBarrelParam0 + resolutionLocalYBarrelPa
 
 
 
-NB on geometry (common to nominal and parametric cases) :
+NB on geometry :
 In the plane of any module, local Y axis is always along the strips, and local X axis is the axis orthogonal to it.
 As a result : 
-Barrel modules : Local X axis is in RPhi, Local Y axis is along Z.
-Endcap modules : Local X axis is in RPhi, Local Y axis is along R.
+Barrel modules : Local X axis is along RPhi, Local Y axis is along Z.
+Endcap modules : Local X axis is along RPhi, Local Y axis is along R.
 
-Specific to parametric case : Alpha and beta angles are the reference notation angles for a track hitting a pixel module.
+Specific to parametric case : alpha and beta angles are the reference notation angles for a track hitting a pixel module.
 They are defined in Figure 7 from [3]. 
 
 
 
 [1] Parametrization of the spatial resolution of the reconstructed hits in the Inner Pixel for HL-LHC studies, E. Migliore and M. Musich, 2015/09/18
 [2] Summary of available parametrizations, E. Migliore, Torino, 2016/06/13
-[3] Commissioning and Performance of the CMS Pixel Tracker with Cosmic Ray Muons, The CMS Collaboration, 2010/02/02.
+[3] Commissioning and Performance of the CMS Pixel Tracker with Cosmic Ray Muons, The CMS Collaboration, 2010/02/02

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -10,17 +10,25 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
   StraightRodPair* minusBigDeltaRod = (bigParity > 0 ? flatPartRods.at(1) : flatPartRods.front());
   const auto& minusBigDeltaModules = minusBigDeltaRod->modules().first;
   StraightRodPair* plusBigDeltaRod = (bigParity > 0 ? flatPartRods.front() : flatPartRods.at(1));
-  const auto& plusBigDeltaModules = plusBigDeltaRod->modules().first;
+  const auto& plusBigDeltaModules = plusBigDeltaRod->modules().first;  
 
   int i = 0;
   double rStartInner;
   double zStartInner_REAL;
   double rEndInner;
   double zEndInner_REAL;
+  int smallParity = minusBigDeltaRod->zPlusParity();
   for (const auto& m : minusBigDeltaModules) {
     if (i > 0) {
-      rStartInner = m.center().Rho() - 0.5 * m.dsDistance();
       zStartInner_REAL = m.planarMinZ();
+      // Special case where ring has been built going upwards, and with zEndInner_REAL < zError
+      if ((zStartInner_REAL < zEndInner_REAL) && (smallParity > 0)) {
+	rEndInner -= m.dsDistance(); 
+	rStartInner = m.center().Rho() + 0.5 * m.dsDistance();
+      }
+	else { // Standard case
+	rStartInner = m.center().Rho() - 0.5 * m.dsDistance();
+      }
 
       if (rStartInner != rEndInner) {
 	double fact = (((rStartInner - rEndInner) > 0) ? 1. : -1.);
@@ -48,9 +56,11 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
 
     }
 
-    rEndInner = m.center().Rho() + 0.5 * m.dsDistance();
     zEndInner_REAL = m.planarMaxZ();
+    rEndInner = m.center().Rho() + 0.5 * m.dsDistance();
+   
     i++;
+    smallParity = -smallParity;
   }
 
   i = 0;
@@ -58,10 +68,17 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
   double zStartOuter_REAL;
   double rEndOuter;
   double zEndOuter_REAL;
+  smallParity = plusBigDeltaRod->zPlusParity();
   for (const auto& m : plusBigDeltaModules) {
     if (i > 0) {
-      rStartOuter = m.center().Rho() - 0.5 * m.dsDistance();
       zStartOuter_REAL = m.planarMinZ();
+      if ((zStartOuter_REAL < zEndOuter_REAL) && (smallParity > 0)) {
+	  rEndOuter -= m.dsDistance(); 
+	  rStartOuter = m.center().Rho() + 0.5 * m.dsDistance();
+	}
+	else {
+	  rStartOuter = m.center().Rho() - 0.5 * m.dsDistance();
+	}
 
       if (rStartOuter != rEndOuter) {
 	double fact = (((rStartOuter - rEndOuter) > 0) ? 1. : -1.);
@@ -83,10 +100,12 @@ void FlatRingsGeometryInfo::calculateFlatRingsGeometryInfo(std::vector<StraightR
       }
 
     }
-
-    rEndOuter = m.center().Rho() + 0.5 * m.dsDistance();
+ 
     zEndOuter_REAL = m.planarMaxZ();
+    rEndOuter = m.center().Rho() + 0.5 * m.dsDistance();
+
     i++;
+    smallParity = -smallParity;
   }  
 }
 

--- a/src/RodPair.cpp
+++ b/src/RodPair.cpp
@@ -205,9 +205,9 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
   double newZ = lastZ;
   if (!beamSpotCover()) dz = 0;
   if (direction == BuildDir::RIGHT) {
+    double newZA = (newZ - ov) * newRA/lastRA; // newZ associated to case A
     double originZ = parity > 0 ? dz : -dz;
-    double newZA = (newZ - ov) * newRA/lastRA;
-    double newZB = (newZ - originZ) * newRB/lastRB + originZ;
+    double newZB = (newZ - originZ) * newRB/lastRB + originZ; // newZ associated to case B
     if (beamSpotCover()) newZ = MIN(newZA, newZB); // Take the most stringent of cases A and B
     else newZ = newZA;
     if (forbiddenRange.state()) {
@@ -226,9 +226,9 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
     }
   } 
   else {
+    double newZA = (newZ + ov) * newRA/lastRA; // newZ associated to case A
     double originZ = parity > 0 ? -dz : dz;
-    double newZA = (newZ + ov) * newRA/lastRA;
-    double newZB = (newZ - originZ) * newRB/lastRB + originZ;
+    double newZB = (newZ - originZ) * newRB/lastRB + originZ; // newZ associated to case B
     if (beamSpotCover()) newZ = MAX(newZA, newZB); // Take the most stringent of cases A and B
     else newZ = newZA;
     if (forbiddenRange.state()) {

--- a/src/RodPair.cpp
+++ b/src/RodPair.cpp
@@ -206,10 +206,10 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
   if (!beamSpotCover()) dz = 0;
   if (direction == BuildDir::RIGHT) {
     double originZ = parity > 0 ? dz : -dz;
-    double newZorigin = (newZ - ov) * newRA/lastRA;
-    double newZshifted = (newZ - originZ) * newRB/lastRB + originZ;
-    if (beamSpotCover()) newZ = MIN(newZorigin, newZshifted); // Take the most stringent of cases A and B
-    else newZ = newZorigin;
+    double newZA = (newZ - ov) * newRA/lastRA;
+    double newZB = (newZ - originZ) * newRB/lastRB + originZ;
+    if (beamSpotCover()) newZ = MIN(newZA, newZB); // Take the most stringent of cases A and B
+    else newZ = newZA;
     if (forbiddenRange.state()) {
       double forbiddenRange_begin,forbiddenRange_end; 
       forbiddenRange_begin=(forbiddenRange[0]+forbiddenRange[1])/2;
@@ -227,10 +227,10 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
   } 
   else {
     double originZ = parity > 0 ? -dz : dz;
-    double newZorigin = (newZ + ov) * newRA/lastRA;
-    double newZshifted = (newZ - originZ) * newRB/lastRB + originZ;
-    if (beamSpotCover()) newZ = MAX(newZorigin, newZshifted); // Take the most stringent of cases A and B
-    else newZ = newZorigin;
+    double newZA = (newZ + ov) * newRA/lastRA;
+    double newZB = (newZ - originZ) * newRB/lastRB + originZ;
+    if (beamSpotCover()) newZ = MAX(newZA, newZB); // Take the most stringent of cases A and B
+    else newZ = newZA;
     if (forbiddenRange.state()) {
       double forbiddenRange_begin,forbiddenRange_end;              
       forbiddenRange_begin=(forbiddenRange[0]+forbiddenRange[1])/2;

--- a/src/RodPair.cpp
+++ b/src/RodPair.cpp
@@ -174,12 +174,33 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
   double minr = minBuildRadius();
  
   // Case A : zOverlap is considered for computing next Z
-  double newRA = (parity > 0 ? maxr + d : minr - d) - newDsDistance/2;
-  double lastRA = (parity > 0 ? maxr - d : minr + d) + lastDsDistance/2;
+  double lastRA;
+  double newRA;
+  if (parity > 0) { // Going upwards
+    lastRA = maxr - d + lastDsDistance/2;
+    newRA = maxr + d - newDsDistance/2; // use of maxr because outer rod wins, from -d to +d because going upwards
+  } else { // Going downwards
+    lastRA = minr + d + lastDsDistance/2;
+    newRA = minr - d - newDsDistance/2; // use of minr because inner rod wins, from +d to -d because going downwards
+  }
 
   // Case B : zError is considered for computing next Z
-  double newRB = (parity > 0 ? (((direction == BuildDir::RIGHT && lastZ > dz) || (direction == BuildDir::LEFT && lastZ < -dz)) ? maxr + d : minr + d) : minr - d) - newDsDistance/2;
-  double lastRB = (parity > 0 ? (((direction == BuildDir::RIGHT && lastZ > dz) || (direction == BuildDir::LEFT && lastZ < -dz)) ? maxr - d : minr - d) : minr + d) + lastDsDistance/2;
+  double lastRB;
+  double newRB; 
+  if (parity > 0) { // Going upwards
+    if ((direction == BuildDir::RIGHT && lastZ > dz) || (direction == BuildDir::LEFT && lastZ < -dz)) { // lastZ is not in [-zError; zError]
+      lastRB = maxr - d + lastDsDistance/2;
+      newRB = maxr + d - newDsDistance/2;  // use of maxr because outer rod wins, from -d to +d because going upwards
+    }
+    else { // lastZ is in [-zError; zError] : special case which is often forgotten
+      lastRB = minr - d - lastDsDistance/2;
+      newRB = minr + d + newDsDistance/2; // use of minr because inner rod wins, from -d to +d because going upwards
+    }
+  }
+  else { // Going downwards
+    lastRB = minr + d + lastDsDistance/2;
+    newRB = minr - d - newDsDistance/2; // use of minr because inner rod wins, from +d to -d because going downwards
+  }
 
   double newZ = lastZ;
   if (!beamSpotCover()) dz = 0;


### PR DESCRIPTION
This is a subtle diff in the straight rod module placement, when building ring (i+1) with respect to ring (i) considering the zError constraint.
In the particular case where zEnd of the module in ring (i) < zError, and the build is upwards, one needs to consider : 
* -dsdistance/2. for ring (i)
* +dsdistance/2. for ring (i+1)
Indeed, this corresponds to the most stringent situation.

For all other cases, one needs to consider (and this was already the case) : 
* +dsdistance/2. for ring (i)
* -dsdistance/2. for ring (i+1)

The effect of this, for example on the flat part of TBPS, is (example with OT 364) : 
- Layer 1 : ~ 120 um shorter.
- Layer 2 : ~ 26 um shorter.
- Layer 3 : ~ 13 um shorter.

This is negligible, but incorporated at this point in time for safety reasons.