### PR TITLE
Quick changes to automatize the recent 'by hand' updates in XML reco material

### DIFF
--- a/include/tk2CMSSW_strings.h
+++ b/include/tk2CMSSW_strings.h
@@ -152,12 +152,14 @@ namespace insur {
     static const std::string xml_PX_trackersensfile = "pixelsens.xml";
     static const std::string xml_recomatfile = "trackerRecoMaterial.xml";
     static const std::string xml_newrecomatfile = "newTrackerRecoMaterial.xml";
-    static const std::string xml_PX_recomatfile = "pixelRecoMaterial.xml";
+    //static const std::string xml_PX_recomatfile = "pixelRecoMaterial.xml";
     static const std::string xml_tmppath = "tmp";
     /**
      * Naming conventions and variable names
      */
     static const std::string xml_insert_marker = "<!--mid point marker-->";
+    static const std::string xml_OT_insert_marker = "<!--Outer Tracker info marker-->";
+    static const std::string xml_PX_insert_marker = "<!--Pixel info marker-->";
     static const std::string xml_specpars_label = "spec-pars2.xml";
     static const std::string xml_base_act = "active";
     static const std::string xml_base_Act = "Active";
@@ -339,7 +341,8 @@ namespace insur {
 	topologyfile(!isPixelTracker ? xml_topologyfile : xml_PX_topologyfile),
 	prodcutsfile(!isPixelTracker ? xml_prodcutsfile : xml_PX_prodcutsfile),
 	trackersensfile(!isPixelTracker ? xml_trackersensfile : xml_PX_trackersensfile),
-	recomatfile(!isPixelTracker ? xml_recomatfile : xml_PX_recomatfile),
+	recomatfile(xml_recomatfile),  // For users convinience, reco material info is stored in only one file for both OT and PX.
+	insert_marker(!isPixelTracker ? xml_OT_insert_marker : xml_PX_insert_marker),
 
 	topo_barrel_name(!isPixelTracker ? xml_OT_topo_barrel_name : xml_PX_topo_barrel_name),
 	topo_barrel_value(!isPixelTracker ? xml_OT_topo_barrel_value : xml_PX_topo_barrel_value),
@@ -373,7 +376,8 @@ namespace insur {
       const std::string topologyfile;
       const std::string prodcutsfile;
       const std::string trackersensfile;
-      const std::string recomatfile;       
+      const std::string recomatfile;
+      const std::string insert_marker;      
 
       const std::string topo_barrel_name;
       const std::string topo_barrel_value;

--- a/include/tk2CMSSW_strings.h
+++ b/include/tk2CMSSW_strings.h
@@ -240,7 +240,7 @@ namespace insur {
     static const std::string xml_det_ring = "TIDRing";
     static const std::string xml_det_tiddet = "TIDDet";
     static const std::string xml_tid_subdet = "TIDSubDet";
-    static const std::string xml_subdet_2OT_wheel = "Phase2OTEndcapDisk";   
+    static const std::string xml_subdet_2OT_wheel = "Phase2OTEndcapDisk";
     static const std::string xml_subdet_tiddet = "PixelEndcapDet";
     static const std::string xml_apv_head = "TrackerAPVNumber";
     static const std::string xml_subdet_lower_detectors = "LowerDetectors";
@@ -251,10 +251,11 @@ namespace insur {
     static const std::string xml_roc_rows_name = "PixelROCRows";
     static const std::string xml_roc_cols_name = "PixelROCCols";
     static const std::string xml_par_tail = "Par";
-    static const std::string xml_OT_reco_layer_name = "TrackerRecMaterialTOB";
-    static const std::string xml_PX_reco_layer_name = "TrackerRecMaterialPhase1";
-    static const std::string xml_OT_reco_disc_name = "TrackerRecMaterialTIDDisk";
-    static const std::string xml_PX_reco_disc_name = "TrackerRecMaterialPhase2PixelEndcapDisk";
+    static const std::string xml_reco = "TrackerRecMaterial";
+    static const std::string xml_OT_reco_layer_name = "Phase2OTBarrelLayer";
+    static const std::string xml_PX_reco_layer_name = "Phase1PixelBarrelLayer";
+    static const std::string xml_OT_reco_disc_name = "Phase2OTForwardDisk";
+    static const std::string xml_PX_reco_disc_name = "Phase2PixelForwardDisk";
     static const std::string xml_forward = "Fw";
     static const std::string xml_backward = "Bw";
     static const std::string xml_places_unflipped_mod_in_rod = "HCZ2YX";
@@ -360,8 +361,8 @@ namespace insur {
 	topo_emodule_name(!isPixelTracker ? xml_OT_topo_emodule_name : xml_PX_topo_emodule_name),
 	topo_emodule_value(!isPixelTracker ? xml_OT_topo_emodule_value : xml_PX_topo_emodule_value),
 
-	reco_layer_name(!isPixelTracker ? xml_OT_reco_layer_name : xml_PX_reco_layer_name),
-	reco_disc_name(!isPixelTracker ? xml_OT_reco_disc_name : xml_PX_reco_disc_name)
+	reco_layer_name(xml_reco + (!isPixelTracker ? xml_OT_reco_layer_name : xml_PX_reco_layer_name)),
+	reco_disc_name(xml_reco + (!isPixelTracker ? xml_OT_reco_disc_name : xml_PX_reco_disc_name))
       {};
 
       const std::string nspace;

--- a/include/tk2CMSSW_strings.h
+++ b/include/tk2CMSSW_strings.h
@@ -15,7 +15,6 @@ namespace insur {
     static const int xml_prec = 3;
     static const int xml_roc_rows = 128;
     static const int xml_roc_cols = 1;
-    static const int xml_reco_material_disc_offset = 3;
     //static const double xml_z_pixfwd = 325.0;
     static const double xml_z_pixfwd = 291.0; // should be equal to ZPixelForward defined statically in pixfwd.xml !!
     static const double xml_epsilon = 0.01;

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -3014,7 +3014,10 @@ namespace insur {
 	if ( el->targetVolume() == PixelModuleSensor ) {
 	  continue; // Still to skip sensors, in case not detected by the component name.
 	}
-
+	else if ( el->targetVolume() != PixelModuleHybrid &&
+		  el->targetVolume() != PixelModuleChip ) {
+	  throw PathfulException("!!!! ERROR !!!! : Found unexpected targetVolume, not supported for Pixel Barrel modules.");
+	}
 	moduleMassWithoutSensors_expected += el->quantityInGrams(module);
 
 	if ( el->targetVolume() == PixelModuleHybrid   ||

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -340,9 +340,12 @@ namespace insur {
         b = buildPaths(t, b, isPixelTracker, trackerXmlTags, wt);
         if (!b.empty()) {
             std::string line;
-            while (std::getline(in, line) && (line.find(xml_preamble_concise) == std::string::npos)) out << line << std::endl; // scan for preamble
-            out << line << std::endl << getSimpleHeader(); // output the preamble followed by the header
-            while (std::getline(in, line) && (line.find(xml_insert_marker) == std::string::npos)) out << line << std::endl;
+	    // preamble only once, when OT info is printed.
+	    if (!isPixelTracker) {
+                while (std::getline(in, line) && (line.find(xml_preamble_concise) == std::string::npos)) out << line << std::endl; // scan for preamble
+                out << line << std::endl << getSimpleHeader(); // output the preamble followed by the header
+	    }
+            while (std::getline(in, line) && (line.find(trackerXmlTags.insert_marker) == std::string::npos)) out << line << std::endl;
             std::vector<PathInfo>::iterator iter, guard = b.end();
             for (iter = b.begin(); iter != guard; iter++) {
                 unsigned int id;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -910,14 +910,14 @@ namespace insur {
 	    rnumber = rnumber.substr(0, findNumericPrefixSize(rnumber));
 	    compstr = rcurrent.substr(rcurrent.find(xml_layer) + xml_layer.size());
 	  }
-	  else { 
+	  else {
 	    std::cerr << "While building paths for trackerRecoMaterial.xml, neither " << xml_rod << " nor " << xml_ring << " can be found in " << rcurrent << "." << std::endl; 
 	  }
 	  compstr = compstr.substr(0, findNumericPrefixSize(compstr));
 
 	  // taking the rod or (if any) tilted ring matching the current layer
 	  if (lnumber == compstr) {
-	    spname = trackerXmlTags.reco_layer_name + xml_pixbar + xml_layer + lnumber;
+	    spname = trackerXmlTags.reco_layer_name + lnumber;
 	    layer = atoi(lnumber.c_str());
 	    if (!isPixelTracker) prefix = trackerXmlTags.bar + "/" + trackerXmlTags.nspace + ":" + xml_layer + lnumber + "/";
 	    else prefix = xml_pixbarident + ":" + trackerXmlTags.bar + "/" + trackerXmlTags.nspace + ":" + xml_layer + lnumber + "/";
@@ -994,8 +994,7 @@ namespace insur {
 	if (!isPixelTracker) index << (xml_reco_material_disc_offset + i / 2);  // TO DO : WHAT IS THIS ???
 	else index << 1 + i; // disc numbering starts from 1
 	layer = atoi(dnumber.c_str());
-	if (!isPixelTracker) spname = trackerXmlTags.reco_disc_name + index.str();
-	else spname = trackerXmlTags.reco_disc_name + index.str() + "Fw";
+	spname = trackerXmlTags.reco_disc_name + index.str();
 
 	//if (plus) spname = spname + xml_forward;
 	//else spname = spname + xml_backward;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -358,8 +358,14 @@ namespace insur {
                     }
                     if (id < ri.size()) {
                         out << xml_spec_par_parameter_first << xml_recomat_radlength << xml_spec_par_parameter_second;
-                        out << ri.at(id).rlength << xml_general_endline << xml_spec_par_parameter_first << xml_recomat_xi;
-                        out << xml_spec_par_parameter_second << ri.at(id).ilength;
+                        out << ri.at(id).rlength << xml_general_endline; // RadLength associated to tracking group
+			out << xml_spec_par_parameter_first << xml_recomat_xi << xml_spec_par_parameter_second;
+			out << ri.at(id).rlength / 500.; // Energy loss associated to tracking group
+			// WARNING  : Radlength / 500. is a temporary estimate of energy loss !!!
+			// Energy loss is not calculated by tkLayout for the moment.
+			// TO DO : 
+			// Energy loss estimates should be incorporated in the core of the code for the material in tkLayout.
+			// Results should then be exported here, using a new equivalent of ri.at(id).ilength (like re.at(id).energyLoss).
                     }
                     else {
                         std::cerr << "WARNING: no RILengthInfo entry found for SpecPar block " << iter->block_name;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -991,8 +991,7 @@ namespace insur {
 	//CUIDADO if (plus) dnumber = dnumber.substr(0, dnumber.size() - xml_plus.size());
 	//else dnumber = dnumber.substr(0, dnumber.size() - xml_minus.size());
 	std::ostringstream index;
-	if (!isPixelTracker) index << (xml_reco_material_disc_offset + i / 2);  // TO DO : WHAT IS THIS ???
-	else index << 1 + i; // disc numbering starts from 1
+	index << i + 1; // disc numbering starts from 1
 	layer = atoi(dnumber.c_str());
 	spname = trackerXmlTags.reco_disc_name + index.str();
 

--- a/src/tk2CMSSW.cc
+++ b/src/tk2CMSSW.cc
@@ -123,9 +123,14 @@ namespace insur {
             outstream.clear();
             std::cout << "CMSSW sensor surface output has been written to " << xmlOutputPath << trackerXmlTags.trackersensfile << std::endl;
 
-	    if (wt) instream.open((xmlDirectoryPath + "/" + xml_newrecomatfile).c_str());
-	    else instream.open((xmlDirectoryPath + "/" + xml_recomatfile).c_str());
-	    outstream.open((xmlOutputPath + trackerXmlTags.recomatfile).c_str());
+	    if (!isPixelTracker) {
+	      instream.open((xmlDirectoryPath + "/" + xml_recomatfile).c_str()); // for OT, takes template file.
+	      outstream.open((xmlDirectoryPath + "/" + xml_tmppath + xml_recomatfile).c_str());
+	    }
+	    else {
+	      instream.open((xmlDirectoryPath + "/" + xml_tmppath + xml_recomatfile).c_str()); // for PX, takes output file from OT already created.
+	      outstream.open((xmlOutputPath + trackerXmlTags.recomatfile).c_str());
+	    }
             if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the recomaterial files.");
             //writeSimpleHeader(outstream);
             wr.recomaterial(data.specs, data.lrilength, instream, outstream, isPixelTracker, trackerXmlTags, wt);

--- a/xml/trackerRecoMaterial.xml
+++ b/xml/trackerRecoMaterial.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
   <SpecParSection label="spec-pars2.xml">
-    <!--mid point marker-->
 
+    <!--Pixel info marker-->
+
+    <!--Outer Tracker info marker-->
   </SpecParSection>
 </DDDefinition>


### PR DESCRIPTION
- updated tracking group names.
- updated tracking groups gathering.
- put Pixel and OT info in one file.
- off topic : warnings in extractor for wrong targetVolumes