### PR TITLE
Additional preparation of XML export

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V362_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V362_200.cfg
@@ -53,12 +53,12 @@ Barrel TBPS {
     }
 
     Ring 5 {
-      //ringInnerZ 170.363034
-      ringZOverlap 0.5
+      ringInnerZ 170.363034
+      //ringZOverlap 0.5
     }
     Ring 6 {
-      //ringInnerZ 220.475945
-      ringZOverlap 6.5636
+      ringInnerZ 220.475945
+      //ringZOverlap 6.5636
     }
     Ring 7 {
       ringInnerZ 273.883184

--- a/include/tk2CMSSW_strings.h
+++ b/include/tk2CMSSW_strings.h
@@ -54,6 +54,7 @@ namespace insur {
     static const std::string xml_algorithm_vector_close = "</Vector>\n";
     static const std::string xml_algorithm_value = "\" value=\"";
     static const std::string xml_algorithm_close = "</Algorithm>\n";
+    static const std::string xml_tkLayout_material = "tkLayout_";
     static const std::string xml_elementary_material_open = "<ElementaryMaterial name=\"";
     static const std::string xml_elementary_material_first_inter = "\" symbol=\"";
     static const std::string xml_elementary_material_second_inter = "\" atomicNumber=\"";

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -616,7 +616,6 @@ namespace insur {
 	  //std::cout << 
 	}
       }
-      std::cout << flatPartOneBeforeLastModuleMaxZ << std::endl;
 
       if ((rmax - rmin) == 0.0) continue;
 
@@ -1006,12 +1005,11 @@ namespace insur {
       if (isTilted) shape.dz = flatPartMaxZ + xml_epsilon;
       s.push_back(shape);
 
-      // TO DO : IMPROVE THIS !!
       // Subtraction of an air volume from the flat part rod container volume, to avoid collision with first tilted ring
       if (isTilted && flatPartNumModules >= 2) {
 	shape.name_tag = rodname.str() + "Air";
 	shape.dx = shape.dx / 2.0;
-	//shape.dz = 10.; // To be calculated with maxZ of the 'one before last' module of the flat part rod
+	shape.dy = shape.dy + xml_epsilon;
 	shape.dz = (shape.dz - flatPartOneBeforeLastModuleMaxZ) / 2.;
 	s.push_back(shape);
 	
@@ -1021,9 +1019,7 @@ namespace insur {
 	shapeOp.rSolid2 = rodname.str() + "Air";
 	shapeOp.trans.dx = shape.dx + xml_epsilon;
 	shapeOp.trans.dy = 0.;
-	//shapeOp.trans.dz = flatPartMaxZ + xml_epsilon - shape.dz / 2.0;
 	shapeOp.trans.dz = flatPartMaxZ + xml_epsilon - shape.dz + xml_epsilon;
-	std::cout << shapeOp.trans.dz << std::endl;
 	so.push_back(shapeOp);
 
 	shapeOp.name_tag = rodname.str();

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -538,6 +538,9 @@ namespace insur {
       // is the layer tilted ?
       bool isTilted = lagg.getBarrelLayers()->at(layer - 1)->isTilted();
      
+      // TO DO : NOT THAT EXTREMA OF MODULES WITH HYBRIDS HAVE BEEN INTRODUCED INTO DETECTORMODULE (USED TO BE IN MODULE COMPLEX CLASS ONLY)
+      // ALL THIS SHOULD BE DELETED AND REPLACED BY module->minRwithHybrids() GETTERS.
+
       // Calculate geometrical extrema of rod (straight layer), or of rod part + tilted ring (tilted layer)
       // straight layer : x and y extrema of rod
       double xmin = std::numeric_limits<double>::max();
@@ -557,6 +560,9 @@ namespace insur {
       double flatPartMaxZ = 0;
       double flatPartMinR = std::numeric_limits<double>::max();
       double flatPartMaxR = 0;
+      // tilted layer : z extrema of one before last module of flat part
+      int flatPartNumModules = lagg.getBarrelLayers()->at(layer - 1)->buildNumModulesFlat();
+      double flatPartOneBeforeLastModuleMaxZ = 0;
       // straight or tilted layer : radii of rods (straight layer) or of rod parts (tilted layer)
       double RadiusIn = 0;
       double RadiusOut = 0;
@@ -602,13 +608,15 @@ namespace insur {
 	    flatPartMaxZ = MAX(flatPartMaxZ, modcomplex.getZmax());
 	    flatPartMinR = MIN(flatPartMinR, modcomplex.getRmin());
 	    flatPartMaxR = MAX(flatPartMaxR, modcomplex.getRmax());
+	    if (flatPartNumModules >= 2 && modRing == (flatPartNumModules - 1)) { flatPartOneBeforeLastModuleMaxZ = MAX(flatPartOneBeforeLastModuleMaxZ, modcomplex.getZmax()); }
 	  }
 	  // both modRings 1 and 2 have to be taken into account because of small delta
 	  if (iiter->getModule().uniRef().phi == 1 && (modRing == 1 || modRing == 2)) { RadiusIn = RadiusIn + iiter->getModule().center().Rho() / 2; }
 	  if (iiter->getModule().uniRef().phi == 2 && (modRing == 1 || modRing == 2)) { RadiusOut = RadiusOut + iiter->getModule().center().Rho() / 2; }
+	  //std::cout << 
 	}
       }
-
+      std::cout << flatPartOneBeforeLastModuleMaxZ << std::endl;
 
       if ((rmax - rmin) == 0.0) continue;
 
@@ -1000,10 +1008,11 @@ namespace insur {
 
       // TO DO : IMPROVE THIS !!
       // Subtraction of an air volume from the flat part rod container volume, to avoid collision with first tilted ring
-      if (isTilted) {
+      if (isTilted && flatPartNumModules >= 2) {
 	shape.name_tag = rodname.str() + "Air";
 	shape.dx = shape.dx / 2.0;
-	shape.dz = 10.; // To be calculated with maxZ of the 'one before last' module of the flat part rod
+	//shape.dz = 10.; // To be calculated with maxZ of the 'one before last' module of the flat part rod
+	shape.dz = (shape.dz - flatPartOneBeforeLastModuleMaxZ) / 2.;
 	s.push_back(shape);
 	
 	shapeOp.name_tag = rodname.str() + "SubtractionIntermediate";
@@ -1012,7 +1021,9 @@ namespace insur {
 	shapeOp.rSolid2 = rodname.str() + "Air";
 	shapeOp.trans.dx = shape.dx + xml_epsilon;
 	shapeOp.trans.dy = 0.;
-	shapeOp.trans.dz = flatPartMaxZ + xml_epsilon - shape.dz / 2.0;
+	//shapeOp.trans.dz = flatPartMaxZ + xml_epsilon - shape.dz / 2.0;
+	shapeOp.trans.dz = flatPartMaxZ + xml_epsilon - shape.dz + xml_epsilon;
+	std::cout << shapeOp.trans.dz << std::endl;
 	so.push_back(shapeOp);
 
 	shapeOp.name_tag = rodname.str();
@@ -1711,8 +1722,6 @@ namespace insur {
           ri.push_back(ril);
         }
 
-	double rminStepInForwadestDisc = 0;
-
         // rings
         shape.type = tb;
         shape.dx = 0.0;
@@ -1730,8 +1739,6 @@ namespace insur {
             shape.rmax = rinfo[*siter].rmax + xml_epsilon;
 	    shape.dz = (rinfo[*siter].zmax - rinfo[*siter].zmin) / 2.0 + xml_epsilon;
             s.push_back(shape);
-	    // Quick and dirty
-	    if (dname.str() == "Disc11" && *siter == 2) { rminStepInForwadestDisc = shape.rmin - xml_epsilon; }
 
             logic.name_tag = shape.name_tag;
             logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -859,7 +859,7 @@ namespace insur {
 	    // LogicalPartSection
             logic.name_tag = shape.name_tag;
             logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;
-            logic.material_tag = trackerXmlTags.nspace + ":" + xml_sensor_silicon;
+            logic.material_tag = trackerXmlTags.nspace + ":" + xml_tkLayout_material + xml_sensor_silicon;
             l.push_back(logic);
 
 	    // PosPart section
@@ -1613,7 +1613,7 @@ namespace insur {
 
 	      logic.name_tag = shape.name_tag;
 	      logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;
-	      logic.material_tag = trackerXmlTags.nspace + ":" + xml_sensor_silicon;
+	      logic.material_tag = trackerXmlTags.nspace + ":" + xml_tkLayout_material + xml_sensor_silicon;
 	      l.push_back(logic);
 
 	      if (iiter->getModule().numSensors() == 2) pos.parent_tag = trackerXmlTags.nspace + ":" + mname.str() + xml_base_lowerupper + xml_base_waf;
@@ -1645,7 +1645,7 @@ namespace insur {
 
 		logic.name_tag = shape.name_tag;
 		logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;
-		logic.material_tag = trackerXmlTags.nspace + ":" + xml_sensor_silicon;
+		logic.material_tag = trackerXmlTags.nspace + ":" + xml_tkLayout_material + xml_sensor_silicon;
 		l.push_back(logic);
 
 		pos.parent_tag = trackerXmlTags.nspace + ":" + mname.str() + xml_base_lowerupper + xml_base_waf;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -555,7 +555,7 @@ namespace insur {
      * @param stream A reference to the output buffer
      */
     void XMLWriter::elementaryMaterial(std::string tag, double density, int a_number, double a_weight, std::ostringstream& stream) {
-        stream << xml_elementary_material_open << tag << xml_elementary_material_first_inter << tag;
+      stream << xml_elementary_material_open << xml_tkLayout_material << tag << xml_elementary_material_first_inter << xml_tkLayout_material << tag;
         stream << xml_elementary_material_second_inter << a_number << xml_elementary_material_third_inter;
         stream << a_weight << xml_elementary_material_fourth_inter << density;
         stream << xml_elementary_material_close;
@@ -587,7 +587,7 @@ namespace insur {
         stream << xml_general_inter;
         for (unsigned int i = 0; i < es.size(); i++) {
             stream << xml_material_fraction_open << es.at(i).second << xml_material_fraction_inter;
-            stream << trackerXmlTags.nspace << ":" << es.at(i).first << xml_material_fraction_close;
+            stream << trackerXmlTags.nspace << ":" << xml_tkLayout_material << es.at(i).first << xml_material_fraction_close;
         }
         stream << xml_composite_material_close;
     }

--- a/xml/pixelProdCuts.xml
+++ b/xml/pixelProdCuts.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <!-- WARNING : ARE THE VALUES FOR ProdCutsForElectrons, ProdCutsForPositrons AND ProdCutsForGamma CORRECT IN THIS FILE ? -->
   <SpecParSection label="trackerProdCuts.xml" eval="true">
     <SpecPar name="tracker-dead-pixel">
       <PartSelector path="//pixbar:Phase1PixelBarrel"/>
@@ -11,14 +12,14 @@
     </SpecPar>
     
     <SpecPar name="tracker-sens-pixel">
-    <!--mid point marker-->
-    <Parameter name="CMSCutsRegion" value="TrackerPixelSensRegion" eval="false"/>
-    <Parameter name="ProdCutsForElectrons" value="0.01*mm"/>
-    <Parameter name="ProdCutsForPositrons" value="0.01*mm"/>
-    <Parameter name="ProdCutsForGamma" value="0.01*mm"/>
-  </SpecPar>
+      <!--mid point marker-->
+      <Parameter name="CMSCutsRegion" value="TrackerPixelSensRegion" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="0.01*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="0.01*mm"/>
+      <Parameter name="ProdCutsForGamma" value="0.01*mm"/>
+    </SpecPar>
 
-</SpecParSection>
+  </SpecParSection>
 </DDDefinition>
 
 

--- a/xml/trackerProdCuts.xml
+++ b/xml/trackerProdCuts.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <!-- WARNING : ARE THE VALUES FOR ProdCutsForElectrons, ProdCutsForPositrons AND ProdCutsForGamma CORRECT IN THIS FILE ? -->
   <SpecParSection label="trackerProdCuts.xml" eval="true">
     <SpecPar name="tracker-dead">
       <PartSelector path="//Tracker"/>
@@ -14,15 +15,23 @@
       <Parameter name="ProdCutsForPositrons" value="0.01*mm"/>
       <Parameter name="ProdCutsForGamma" value="0.01*mm"/>
     </SpecPar>
-    <SpecPar name="tracker-sens-pixel">
-    <!--mid point marker-->
-    <Parameter name="CMSCutsRegion" value="TrackerPixelSensRegion" eval="false"/>
-    <Parameter name="ProdCutsForElectrons" value="0.01*mm"/>
-    <Parameter name="ProdCutsForPositrons" value="0.01*mm"/>
-    <Parameter name="ProdCutsForGamma" value="0.01*mm"/>
-  </SpecPar>
+    <SpecPar name="tracker-dead-outer">
+      <PartSelector path="//Phase2OTBarrel"/>
+      <PartSelector path="//Phase2OTForward"/>
+      <Parameter name="CMSCutsRegion" value="TrackerOuterDeadRegion" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="1*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="1*mm"/>
+      <Parameter name="ProdCutsForGamma" value="1*mm"/>
+    </SpecPar>   
+    <SpecPar name="tracker-sens-outer">
+      <!--mid point marker-->
+      <Parameter name="CMSCutsRegion" value="TrackerOuterSensRegion" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="0.01*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="0.01*mm"/>
+      <Parameter name="ProdCutsForGamma" value="0.01*mm"/>
+    </SpecPar>
 
-</SpecParSection>
+  </SpecParSection>
 </DDDefinition>
 
 


### PR DESCRIPTION
- Automatized in the XML export recent fixes which were 'done by hand' on trackerProdCuts.xml in CMSSW.
- Envelope of straight rod at interface flat / tilted is now fully automatic (removed hardcoded 10 mm). This was due to more stringent conditions at the flat / tilted interface (choice of parallelepiped volume for flat part rod became not sufficient to avoid overlap).
- Removed unused variable.
- All elementary materials in the XML export have now 'tkLayout_' before their names or symbol, for safety reasons.