### PR TITLE
Prepare XML export for new geometries

### DIFF
--- a/geometries/CMS_Phase2/Pixel/Supports/IT_Support_Tube_V1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Supports/IT_Support_Tube_V1_0.cfg
@@ -1,12 +1,12 @@
-// Pixel support tube: BPIX+FPIX section
+// Pixel support tube: BPIX section (horizontal)
 Support {
   type custom
   customZMin 0
   customRMin 188
-  customLength 1602
+  customLength 226.99
   customDir horizontal
   Component {
-    componentName "BPIXFPIX_IT Support tube" 
+    componentName "BPIX_IT Support tube" 
     Element {
       elementName Al
       quantity 0.050
@@ -25,7 +25,34 @@ Support {
   }
 }
 
-// Pixel support tube: flange
+// Pixel support tube: FPIX1 section (horizontal)
+Support {
+  type custom
+  customZMin 227.01
+  customRMin 188
+  customLength 1374.99
+  customDir horizontal
+  Component {
+    componentName "FPIX1_IT Support tube" 
+    Element {
+      elementName Al
+      quantity 0.050
+      unit mm
+    }
+    Element {
+      elementName Kevlar
+      quantity 0.250
+      unit mm
+    }
+    Element {
+      elementName CF
+      quantity 1.85
+      unit mm
+    }
+  }
+}
+
+// Pixel support tube: flange (vertical)
 Support {
   type custom
   customZMin 1602.01
@@ -52,12 +79,12 @@ Support {
   }
 }
 
-// Pixel support tube: EXT section 
+// Pixel support tube: FPIX2 section (horizontal)
 Support {
   type custom
   customZMin 1604.02
   customRMin 284
-  customLength 1050 // ...
+  customLength 1050
   customDir horizontal
   Component {
     componentName "Extension_IT Support tube" 

--- a/include/XMLWriter.h
+++ b/include/XMLWriter.h
@@ -43,7 +43,7 @@ namespace insur {
     const std::string& getSimpleHeader() const { return simpleHeader_; }
   protected:
     void trackerLogicalVolume(std::ostringstream& stream, std::istream& instream); // takes the stream containing the tracker logical volume template and outputs it to the outstream
-    void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, XmlTags& trackerXmlTags);
+    void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, bool isPixelTracker);
     void rotationSection(std::map<std::string,Rotation>& r, std::string label, std::ostringstream& stream);
     void logicalPartSection(std::vector<LogicalInfo>& l, std::string label,  std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
     void solidSection(std::vector<ShapeInfo>& s, std::vector<ShapeOperationInfo>& so, std::string label, std::ostringstream& stream, std::istream& trackerVolumeTemplate, bool notobtid, bool isPixelTracker, bool wt = false);
@@ -52,7 +52,7 @@ namespace insur {
     void algorithm(std::string name, std::string parent, std::vector<std::string>& params, std::ostringstream& stream);
     void elementaryMaterial(std::string tag, double density, int a_number, double a_weight, std::ostringstream& stream);
     void compositeMaterial(std::string name, double density, CompType method,
-			   std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream, XmlTags& trackerXmlTags);
+			   std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream);
     void logicalPart(std::string name, std::string solid, std::string material, std::ostringstream& stream);
     void box(std::string name, double dx, double dy, double dz, std::ostringstream& stream);
     void trapezoid(std::string name, double dx, double dxx, double dy, double dyy, double dz, std::ostringstream& stream);

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -859,7 +859,7 @@ namespace insur {
 	    // LogicalPartSection
             logic.name_tag = shape.name_tag;
             logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;
-            logic.material_tag = trackerXmlTags.nspace + ":" + xml_tkLayout_material + xml_sensor_silicon;
+            logic.material_tag = xml_fileident + ":" + xml_tkLayout_material + xml_sensor_silicon;
             l.push_back(logic);
 
 	    // PosPart section
@@ -1613,7 +1613,7 @@ namespace insur {
 
 	      logic.name_tag = shape.name_tag;
 	      logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;
-	      logic.material_tag = trackerXmlTags.nspace + ":" + xml_tkLayout_material + xml_sensor_silicon;
+	      logic.material_tag = xml_fileident + ":" + xml_tkLayout_material + xml_sensor_silicon;
 	      l.push_back(logic);
 
 	      if (iiter->getModule().numSensors() == 2) pos.parent_tag = trackerXmlTags.nspace + ":" + mname.str() + xml_base_lowerupper + xml_base_waf;
@@ -1645,7 +1645,7 @@ namespace insur {
 
 		logic.name_tag = shape.name_tag;
 		logic.shape_tag = trackerXmlTags.nspace + ":" + logic.name_tag;
-		logic.material_tag = trackerXmlTags.nspace + ":" + xml_tkLayout_material + xml_sensor_silicon;
+		logic.material_tag = xml_fileident + ":" + xml_tkLayout_material + xml_sensor_silicon;
 		l.push_back(logic);
 
 		pos.parent_tag = trackerXmlTags.nspace + ":" + mname.str() + xml_base_lowerupper + xml_base_waf;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -109,7 +109,7 @@ namespace insur {
     buffer << xml_definition;
     if (wt) {
       buffer << xml_new_const_section;
-      materialSection(xml_newtrackerfile, e, c, buffer, trackerXmlTags);
+      materialSection(xml_newtrackerfile, e, c, buffer, isPixelTracker);
       rotationSection(r, xml_newtrackerfile, buffer);
       logicalPartSection(l, xml_newtrackerfile, buffer, isPixelTracker, trackerXmlTags, true);
       solidSection(s, so, xml_newtrackerfile, buffer, trackerVolumeTemplate, true, isPixelTracker, true);
@@ -117,7 +117,7 @@ namespace insur {
     }
     else {
       if (!isPixelTracker) buffer << xml_const_section;
-      materialSection(trackerXmlTags.trackerfile, e, c, buffer, trackerXmlTags);
+      materialSection(trackerXmlTags.trackerfile, e, c, buffer, isPixelTracker);
       rotationSection(r, trackerXmlTags.trackerfile, buffer);
       logicalPartSection(l, trackerXmlTags.trackerfile, buffer, isPixelTracker, trackerXmlTags);
       solidSection(s, so, trackerXmlTags.trackerfile, buffer, trackerVolumeTemplate, true, isPixelTracker);
@@ -393,10 +393,14 @@ namespace insur {
      * @param c A reference to the vector containing a series of composite material definitions
      * @param stream A reference to the output buffer
      */
-    void XMLWriter::materialSection(std::string name , std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, XmlTags& trackerXmlTags) {
+    void XMLWriter::materialSection(std::string name , std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, bool isPixelTracker) {
         stream << xml_material_section_open << name << xml_general_inter;
-        for (unsigned int i = 0; i < e.size(); i++) elementaryMaterial(e.at(i).tag, e.at(i).density, e.at(i).atomic_number, e.at(i).atomic_weight, stream);
-        for (unsigned int i = 0; i < c.size(); i++) compositeMaterial(c.at(i).name, c.at(i).density, c.at(i).method, c.at(i).elements, stream, trackerXmlTags);
+	// Elementary materials (only in tracker.xml)
+	if (!isPixelTracker) {
+            for (unsigned int i = 0; i < e.size(); i++) elementaryMaterial(e.at(i).tag, e.at(i).density, e.at(i).atomic_number, e.at(i).atomic_weight, stream);
+	}
+	// Composite materials
+        for (unsigned int i = 0; i < c.size(); i++) compositeMaterial(c.at(i).name, c.at(i).density, c.at(i).method, c.at(i).elements, stream);
         stream << xml_material_section_close;
     }
     
@@ -555,7 +559,7 @@ namespace insur {
      * @param stream A reference to the output buffer
      */
     void XMLWriter::elementaryMaterial(std::string tag, double density, int a_number, double a_weight, std::ostringstream& stream) {
-      stream << xml_elementary_material_open << xml_tkLayout_material << tag << xml_elementary_material_first_inter << xml_tkLayout_material << tag;
+        stream << xml_elementary_material_open << xml_tkLayout_material << tag << xml_elementary_material_first_inter << tag;
         stream << xml_elementary_material_second_inter << a_number << xml_elementary_material_third_inter;
         stream << a_weight << xml_elementary_material_fourth_inter << density;
         stream << xml_elementary_material_close;
@@ -571,7 +575,7 @@ namespace insur {
      * @param stream A reference to the output buffer
      */
     void XMLWriter::compositeMaterial(std::string name,
-				      double density, CompType method, std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream, XmlTags& trackerXmlTags) {
+				      double density, CompType method, std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream) {
         stream << xml_composite_material_open << name << xml_composite_material_first_inter;
         stream << density << xml_composite_material_second_inter ;
         switch (method) {
@@ -587,7 +591,7 @@ namespace insur {
         stream << xml_general_inter;
         for (unsigned int i = 0; i < es.size(); i++) {
             stream << xml_material_fraction_open << es.at(i).second << xml_material_fraction_inter;
-            stream << trackerXmlTags.nspace << ":" << xml_tkLayout_material << es.at(i).first << xml_material_fraction_close;
+            stream << xml_fileident << ":" << xml_tkLayout_material << es.at(i).first << xml_material_fraction_close;
         }
         stream << xml_composite_material_close;
     }


### PR DESCRIPTION
- Elementary materials not duplicated in pixel.xml

- Solved all overlaps for new geometry OT365_200_IT4025 : 
There was an extrusion of freshly added IT support tube. By simply splitting it in 2 in cfg file, problem solved.

0 overlap remaining, checked by : 
- Fireworks
- Geant4 tool