### PR TITLE
Latest devs in the XML export in sync with CMSSW + Added layout FlatTracker4026

### DIFF
--- a/geometries/CMS_Phase2/FlatTracker4026.cfg
+++ b/geometries/CMS_Phase2/FlatTracker4026.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Flat/OT_V0_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_6.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Flat/OT_V0_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/OT_V0_200.cfg
@@ -1,0 +1,26 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V0_200.cfg
+  @include TB2S_V360_200.cfg
+  @include TEDD1_V351_200.cfg
+  @include TEDD2_V351_200.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Flat/TB2S_V360_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/TB2S_V360_200.cfg
@@ -1,0 +1,40 @@
+// TB2S 3.5.1
+
+Barrel TB2S {
+  phiOverlap 0.9
+  bigParity 1
+  phiSegments 6
+  smallParity 1
+  barrelRotation 1.57079632680
+
+  @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+  @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  @includestd CMS_Phase2/OuterTracker/Materials/rodPt2S
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTB2S
+
+  dsDistance 1.8
+  Layer 1 { triggerWindow 9 }
+  Layer 2 { triggerWindow 12 }
+  Layer 3 { triggerWindow 15 }
+
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTB2S.cfg
+  bigDelta 15.8   // Antti 2015-02-18
+  smallDelta 2.25 // Antti 2015-02-18
+  numLayers 3
+  numModules 12
+  startZMode moduleedge
+  innerRadiusFixed true
+  outerRadiusFixed true
+  innerRadius 687  // ideal = 687.134 for overlap = 1.0 (690.9 for overlap=0.5)
+  Layer 2 {
+    radiusMode fixed
+    placeRadiusHint 860 // ideal = 860.0 for overlap = 1.0 (864.7 for overlap=0.5)
+  }
+  outerRadius 1108 // ideal = 1119 for for overlap = 1.0 (1125.4 for overlap=0.5)
+  sameRods true
+  compressed false
+
+  // Due to module mount on TB2S rod
+  forbiddenRange 91-95
+
+}

--- a/geometries/CMS_Phase2/OuterTracker/Flat/TBPS_V0_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/TBPS_V0_200.cfg
@@ -1,0 +1,38 @@
+Barrel TBPS {
+      @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_flat.cfg
+      barrelRotation 1.57079632679   
+      
+      smallParity 1
+      phiOverlap 0.5
+      bigDelta 12
+      Layer 1 { smallDelta 3.65 }
+      Layer 2,3 { smallDelta 3.15 }
+      numLayers 3
+      maxZ 1150
+      startZMode modulecenter
+      innerRadius 230
+      outerRadius 508
+      phiSegments 2
+
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+      @includestd CMS_Phase2/OuterTracker/Materials/rodPtPS
+      @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS
+      
+      Layer 1 { 
+        triggerWindow 5
+        dsDistance 2.6 
+        @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_26
+      }
+      Layer 2 { 
+        triggerWindow 5
+        dsDistance 1.6 
+        @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_16
+      }
+      Layer 3 { 
+        triggerWindow 7
+        dsDistance 1.6 
+        @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_16
+     }
+}
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Flat/TEDD1_V351_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/TEDD1_V351_200.cfg
@@ -1,0 +1,122 @@
+Endcap TEDD_1 {
+  smallParity 1
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1_TEDD_1.cfg
+
+  // Layout construction parameters
+  zOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.95 // NICK 2015
+  smallDelta 7.4 // NICK 2015
+  phiSegments 4
+  numDisks 2
+  phiOverlap 0
+  numRings 15
+  outerRadius 1095
+  // barrelGap 180.
+  minZ 1356.779
+  maxZ 1550.00
+  //Disk 2 { placeZ 1550.00 }
+  bigParity 1
+  Ring 15 { ringOuterRadius 1095.000 }
+  Ring 14 { ringOuterRadius 1031.981 }
+  Ring 13 { ringOuterRadius 928.198 }
+  Ring 12 { ringOuterRadius 859.614 }
+  Ring 11 { ringOuterRadius 757.251 }
+  Ring 10 { ringOuterRadius 683.138 }
+  Ring 9 { ringOuterRadius 581.516 }
+  Ring 8 { ringOuterRadius 555.904 }
+  Ring 7 { ringOuterRadius 508.510 }
+  Ring 6 { ringOuterRadius 480.182 }
+  Ring 5 { ringOuterRadius 433.104 }
+  Ring 4 { ringOuterRadius 402.019 }
+  Ring 3 { ringOuterRadius 355.268 }
+  Ring 2 { ringOuterRadius 321.339 }
+  Ring 1 { ringOuterRadius 274.925 }
+  alignEdges false
+  moduleShape rectangular
+  Ring 10-12 { smallDelta 8.85 } // NICK
+  Ring 13-15 { smallDelta 7.95 } // NICK
+  Ring 1-9 {
+  @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+  }
+  Ring 10-15 {
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+  }
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+  
+  Disk 1 {
+    Ring 1-9 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+    }
+    Ring 10 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 11-15 {
+      smallDelta 7.95 // NICK
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 3 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 6 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 8 }
+    Ring 10 { triggerWindow 10 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 9 }
+    Ring 14 { triggerWindow 11 }
+    Ring 15 { triggerWindow 12 }
+  }
+  
+  Disk 2 {
+    Ring 1-9 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+    }
+    Ring 10 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 11-15 {
+      smallDelta 7.95 // NICK
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 7 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 9 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 8 }
+    Ring 14 { triggerWindow 10 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)      
+  Disk 1-2 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Flat/TEDD2_V351_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/TEDD2_V351_200.cfg
@@ -1,0 +1,149 @@
+Endcap TEDD_2 {
+  smallParity 1
+  // Layout construction parameters
+  zOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.95 // NICK 2015
+  smallDelta 7.4 // NICK 2015
+  phiSegments 4
+  numDisks 3
+  phiOverlap 0
+  numRings 15
+  outerRadius 1095
+  minZ 1853.400
+  Disk 2 { placeZ 2216.190 }
+  maxZ 2650.000
+  bigParity 1
+  Ring 15 { ringOuterRadius 1095.000 }
+  Ring 14 { ringOuterRadius 1031.981 }
+  Ring 13 { ringOuterRadius 928.198 }
+  Ring 12 { ringOuterRadius 859.614 }
+  Ring 11 { ringOuterRadius 757.251 }
+  Ring 10 { ringOuterRadius 683.138 }
+  Ring 9 { ringOuterRadius 581.516 }
+  Ring 8 { ringOuterRadius 555.904 }
+  Ring 7 { ringOuterRadius 508.510 }
+  Ring 6 { ringOuterRadius 480.182 }
+  Ring 5 { ringOuterRadius 433.104 }
+  Ring 4 { ringOuterRadius 402.019 }
+  Ring 3 { ringOuterRadius 355.268 }
+  Ring 2 { ringOuterRadius 355.268 }
+  Ring 1 { ringOuterRadius 355.268 }
+  Ring 1 { removeModule true }
+  Ring 2 { removeModule true }
+  alignEdges false
+  moduleShape rectangular
+  Ring 10-12 { smallDelta 8.85 } // NICK
+  Ring 13-15 { smallDelta 7.95 } // NICK
+  Ring 1-9 {
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+  }
+  Ring 10-15 {
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+  }
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+
+  Disk 1 {
+    Ring 1-9 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+    }
+    Ring 10-11 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 12-15 {
+      smallDelta 7.95 // NICK
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 8 }
+    Ring 11 { triggerWindow 10 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 9 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  Disk 2 {
+    Ring 1-9 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+    }
+    Ring 10-11 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 12-15 {
+      smallDelta 7.95 // NICK
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 7 }
+    Ring 11 { triggerWindow 9 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 8 }
+    Ring 15 { triggerWindow 9 }
+  }
+
+  Disk 3 {
+    Ring 1-9 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+    }
+    Ring 10-12 {
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 13-15 {
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 3 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 5 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 6 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 8 }
+    Ring 13 { triggerWindow 6 }
+    Ring 14 { triggerWindow 7 }
+    Ring 15 { triggerWindow 8 }
+  }
+ 
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)
+  Disk 1-3 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/include/XMLWriter.h
+++ b/include/XMLWriter.h
@@ -23,8 +23,6 @@
 
 namespace insur {
 
-  typedef std::tuple<double, CompType, std::vector<std::pair<std::string, double > > > CompoInfo;
-
   /**
    * @class XMLWriter
    * @brief This class bundles the output functions that write tracker information from a series of internal collections to CMSSW XML files.
@@ -55,8 +53,7 @@ namespace insur {
     void specParSection(std::vector<SpecParInfo>& t, std::string label, std::ostringstream& stream);
     void algorithm(std::string name, std::string parent, std::vector<std::string>& params, std::ostringstream& stream);
     void elementaryMaterial(std::string tag, double density, int a_number, double a_weight, std::ostringstream& stream);
-    void compositeMaterial(std::string name, double density, CompType method,
-			   std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream, XmlTags& trackerXmlTags);
+    void compositeMaterial(Composite& comp, std::ostringstream& stream, XmlTags& trackerXmlTags);
     void logicalPart(std::string name, std::string solid, std::string material, std::ostringstream& stream, XmlTags& trackerXmlTags);
     void box(std::string name, double dx, double dy, double dz, std::ostringstream& stream);
     void trapezoid(std::string name, double dx, double dxx, double dy, double dyy, double dz, std::ostringstream& stream);
@@ -75,7 +72,7 @@ namespace insur {
     void specPar(std::string name, std::vector<SpecParInfo>& t, std::ofstream& stream, XmlTags& trackerXmlTags);
     void specParROC(std::vector<std::string>& partsel, std::vector<ModuleROCInfo>& minfo, std::pair<std::string, std::string> param, std::ofstream& stream, bool isPixelTracker);
   private:
-    std::vector<std::pair<std::string, CompoInfo> > printedComposites_;
+    std::vector<Composite> printedComposites_;
     std::map<std::string, std::string> compositeNames_;
     std::vector<PathInfo>& buildPaths(std::vector<SpecParInfo>& specs, std::vector<PathInfo>& blocks, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
     bool endcapsInTopology(std::vector<SpecParInfo>& specs);

--- a/include/XMLWriter.h
+++ b/include/XMLWriter.h
@@ -16,6 +16,7 @@
 #include <tk2CMSSW_datatypes.h>
 #include <tk2CMSSW_strings.h>
 #include <global_constants.h>
+#include <Property.h>
 #include <iostream>
 #include <sstream>
 #include <fstream>

--- a/include/XMLWriter.h
+++ b/include/XMLWriter.h
@@ -73,8 +73,9 @@ namespace insur {
     void specPar(std::string name, std::vector<SpecParInfo>& t, std::ofstream& stream, XmlTags& trackerXmlTags);
     void specParROC(std::vector<std::string>& partsel, std::vector<ModuleROCInfo>& minfo, std::pair<std::string, std::string> param, std::ofstream& stream, bool isPixelTracker);
   private:
-    std::vector<Composite> printedComposites_;
-    std::map<std::string, std::string> compositeNames_;
+    std::vector<Composite> printedComposites_; // List of composites whose materials are printed in the XMLs.
+    std::map<std::string, std::string> mapCompoToPrintedCompo_; // This maps each existing composite to a composite which has same materials. 
+                                                                // Only the PrintedCompo materials are printed in the XMLs.
     std::vector<PathInfo>& buildPaths(std::vector<SpecParInfo>& specs, std::vector<PathInfo>& blocks, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
     bool endcapsInTopology(std::vector<SpecParInfo>& specs);
     int findNumericPrefixSize(std::string s);

--- a/include/XMLWriter.h
+++ b/include/XMLWriter.h
@@ -19,8 +19,12 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <algorithm>
 
 namespace insur {
+
+  typedef std::tuple<double, CompType, std::vector<std::pair<std::string, double > > > CompoInfo;
+
   /**
    * @class XMLWriter
    * @brief This class bundles the output functions that write tracker information from a series of internal collections to CMSSW XML files.
@@ -43,7 +47,7 @@ namespace insur {
     const std::string& getSimpleHeader() const { return simpleHeader_; }
   protected:
     void trackerLogicalVolume(std::ostringstream& stream, std::istream& instream); // takes the stream containing the tracker logical volume template and outputs it to the outstream
-    void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, bool isPixelTracker);
+    void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags);
     void rotationSection(std::map<std::string,Rotation>& r, std::string label, std::ostringstream& stream);
     void logicalPartSection(std::vector<LogicalInfo>& l, std::string label,  std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
     void solidSection(std::vector<ShapeInfo>& s, std::vector<ShapeOperationInfo>& so, std::string label, std::ostringstream& stream, std::istream& trackerVolumeTemplate, bool notobtid, bool isPixelTracker, bool wt = false);
@@ -52,8 +56,8 @@ namespace insur {
     void algorithm(std::string name, std::string parent, std::vector<std::string>& params, std::ostringstream& stream);
     void elementaryMaterial(std::string tag, double density, int a_number, double a_weight, std::ostringstream& stream);
     void compositeMaterial(std::string name, double density, CompType method,
-			   std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream);
-    void logicalPart(std::string name, std::string solid, std::string material, std::ostringstream& stream);
+			   std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream, XmlTags& trackerXmlTags);
+    void logicalPart(std::string name, std::string solid, std::string material, std::ostringstream& stream, XmlTags& trackerXmlTags);
     void box(std::string name, double dx, double dy, double dz, std::ostringstream& stream);
     void trapezoid(std::string name, double dx, double dxx, double dy, double dyy, double dz, std::ostringstream& stream);
     void tubs(std::string name, double rmin, double rmax, double dz, std::ostringstream& stream);
@@ -71,6 +75,8 @@ namespace insur {
     void specPar(std::string name, std::vector<SpecParInfo>& t, std::ofstream& stream, XmlTags& trackerXmlTags);
     void specParROC(std::vector<std::string>& partsel, std::vector<ModuleROCInfo>& minfo, std::pair<std::string, std::string> param, std::ofstream& stream, bool isPixelTracker);
   private:
+    std::vector<std::pair<std::string, CompoInfo> > printedComposites_;
+    std::map<std::string, std::string> compositeNames_;
     std::vector<PathInfo>& buildPaths(std::vector<SpecParInfo>& specs, std::vector<PathInfo>& blocks, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
     bool endcapsInTopology(std::vector<SpecParInfo>& specs);
     int findNumericPrefixSize(std::string s);

--- a/include/global_constants.h
+++ b/include/global_constants.h
@@ -26,7 +26,7 @@ namespace insur {
 
   static const double geom_epsilon                    = 0.1;
   static const double geom_inactive_volume_width      = 2.0;     // mm
-  static const double geom_conversion_station_width    = 2.0;     // mm
+  static const double geom_conversion_station_width   = 2.0;     // mm
   static const double geom_inner_pixel_radius         = 30.0;    // mm
   static const double geom_inner_strip_radius         = 150.0;   // mm
   static const double geom_outer_strip_radius         = 1200.0;  // mm

--- a/include/tk2CMSSW_datatypes.h
+++ b/include/tk2CMSSW_datatypes.h
@@ -8,7 +8,9 @@
 
 #include <string>
 #include <vector>
-#include<map>
+#include <map>
+#include <math.h> 
+#include <tk2CMSSW_strings.h>
 
 namespace insur {
     /**
@@ -70,6 +72,9 @@ namespace insur {
         int atomic_number;
         double atomic_weight;
     };
+
+    typedef std::vector<std::pair<std::string, double> > ElementsComposition;
+
     /**
      * @struct Composite
      * @brief This struct collects some global properties and the chemical elements that make up a composite material.
@@ -83,6 +88,20 @@ namespace insur {
         double density;
         CompType method;
         std::vector<std::pair<std::string, double> > elements;
+
+      bool operator==(const Composite& comp) const {
+	bool ans = true;
+	if (fabs(density - comp.density) > xml_composite_density_tolerance) ans = false;
+	if (method != comp.method) ans = false;
+	if (elements.size() != comp.elements.size()) ans = false;
+	else {
+	  for (int i = 0; i < elements.size(); i++) {
+	    if (elements.at(i).first != comp.elements.at(i).first) ans = false;
+	    if (fabs(elements.at(i).second - comp.elements.at(i).second) > xml_composite_ratio_tolerance) ans = false;
+	  }
+	}
+	return ans;
+      }
     };
     /**
      * @struct LogicalInfo

--- a/include/tk2CMSSW_datatypes.h
+++ b/include/tk2CMSSW_datatypes.h
@@ -72,35 +72,36 @@ namespace insur {
         int atomic_number;
         double atomic_weight;
     };
-
-    typedef std::vector<std::pair<std::string, double> > ElementsComposition;
-
     /**
      * @struct Composite
      * @brief This struct collects some global properties and the chemical elements that make up a composite material.
      * @param name The name of the composite material
      * @param density The overall density of the composite material (in g/cm3)
      * @param method The type of mixture: by weight, by volume or by atomic proportion
-     * @param elements A list of pairs indicating the elements in the compound by name and fraction of the whole
+     * @param elements A list of elements in the compound, key = name of the element, value = massic fraction of the whole
      */
     struct Composite {
         std::string name;
         double density;
         CompType method;
-        std::vector<std::pair<std::string, double> > elements;
+        std::map<std::string, double> elements;
 
-      bool operator==(const Composite& comp) const {
-	bool ans = true;
-	if (fabs(density - comp.density) > xml_composite_density_tolerance) ans = false;
-	if (method != comp.method) ans = false;
-	if (elements.size() != comp.elements.size()) ans = false;
-	else {
-	  for (int i = 0; i < elements.size(); i++) {
-	    if (elements.at(i).first != comp.elements.at(i).first) ans = false;
-	    if (fabs(elements.at(i).second - comp.elements.at(i).second) > xml_composite_ratio_tolerance) ans = false;
+        // This is to avoid the duplicated descriptions of composite materials in the XMLs (very significant effect on total XML size)
+        // 2 components are said equal if they have same total density, same mixture method, and exactly same composing elements.
+        // No matter the name of the component !
+        bool operator==(const Composite& otherComp) const {
+	  if ((fabs(density - otherComp.density) > xml_composite_density_tolerance)  // not same density ?
+	      || (method != otherComp.method)  // not same mixture method ?
+	      || (elements.size() != otherComp.elements.size())) {  // not same number of elements ?
+	    return false;
+  	  }
+	  for (const auto& elem : otherComp.elements) {  // for a given element :
+	    if ((elements.find(elem.first) == elements.end())  // not found in the composite ?
+	        || (fabs(elements.at(elem.first) - elem.second) > xml_composite_ratio_tolerance)) { // not same massic ratio ?
+	      return false;
 	  }
 	}
-	return ans;
+	return true;
       }
     };
     /**

--- a/include/tk2CMSSW_strings.h
+++ b/include/tk2CMSSW_strings.h
@@ -12,15 +12,11 @@ namespace insur {
     /**
      * Numeric constants
      */
-    static const int xml_prec = 3;
-    static const int xml_roc_rows = 128;
-    static const int xml_roc_cols = 1;
-    //static const double xml_z_pixfwd = 325.0;
-    static const double xml_z_pixfwd = 291.0; // should be equal to ZPixelForward defined statically in pixfwd.xml !!
-    static const double xml_epsilon = 0.01;
-    static const double xml_pixel_layeroffset = 1.65;
-    static const double xml_composite_density_tolerance = 0.0000001;
-    static const double xml_composite_ratio_tolerance = 0.0000001;
+    static const double xml_z_pixfwd = 291.0; // VERY IMPORTANT : xml_z_pixfwd defines the offset of the Pixel Forward container volume. 
+    // It should be equal to ZPixelForward defined statically in pixfwd.xml. Otherwise, anything contained by Pixel Forward will have wrong Z in XMLs !!
+    static const double xml_epsilon = 0.01; // Added to virtual geometrical mother volume to avoid extrusion of what it contains.
+    static const double xml_composite_density_tolerance = 1E-07;
+    static const double xml_composite_ratio_tolerance = 1E-07;
     /**
      * XML tags and attributes
      */

--- a/include/tk2CMSSW_strings.h
+++ b/include/tk2CMSSW_strings.h
@@ -19,6 +19,8 @@ namespace insur {
     static const double xml_z_pixfwd = 291.0; // should be equal to ZPixelForward defined statically in pixfwd.xml !!
     static const double xml_epsilon = 0.01;
     static const double xml_pixel_layeroffset = 1.65;
+    static const double xml_composite_density_tolerance = 0.0000001;
+    static const double xml_composite_ratio_tolerance = 0.0000001;
     /**
      * XML tags and attributes
      */

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -1898,12 +1898,10 @@ namespace insur {
       if ((iter->getZOffset() + iter->getZLength()) > 0) c.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter));
 #else
       matname << xml_base_serfcomp << "R" << (int)(iter->getInnerRadius()) << "Z" << (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0));
-
       shapename << xml_base_serf << "R" << (int)(iter->getInnerRadius()) << "Z" << (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0));
       if ((iter->getZOffset() + iter->getZLength()) > 0 ) {
         if ( iter->getLocalMasses().size() ) {
           c.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter));
-	  if ((int)(iter->getInnerRadius()) == 270 && (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0)) == 2567) { std::cout << "R" << iter->getInnerRadius() << "Z" << fabs(iter->getZOffset() + iter->getZLength() / 2.0) << std::endl; }
 
 	  // TO DO : CALCULATION OF OUTERMOST SHAPES BOUNDARIES
 	  double startEndcaps;

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -1898,10 +1898,12 @@ namespace insur {
       if ((iter->getZOffset() + iter->getZLength()) > 0) c.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter));
 #else
       matname << xml_base_serfcomp << "R" << (int)(iter->getInnerRadius()) << "Z" << (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0));
+
       shapename << xml_base_serf << "R" << (int)(iter->getInnerRadius()) << "Z" << (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0));
       if ((iter->getZOffset() + iter->getZLength()) > 0 ) {
         if ( iter->getLocalMasses().size() ) {
           c.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter));
+	  if ((int)(iter->getInnerRadius()) == 270 && (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0)) == 2567) { std::cout << "R" << iter->getInnerRadius() << "Z" << fabs(iter->getZOffset() + iter->getZLength() / 2.0) << std::endl; }
 
 	  // TO DO : CALCULATION OF OUTERMOST SHAPES BOUNDARIES
 	  double startEndcaps;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -608,7 +608,7 @@ namespace insur {
 
       if (compositeNames_.find(idName) != compositeNames_.end()) {
 	//throw PathfulException("Found several composite materials with same name");
-	std::cout << idName << std::endl;
+	std::cout << "VOLUME " << idName << "IS DUPLICATED !!!!!!!!!!" << std::endl;
       }
       printedComposites_.push_back(comp); 
       compositeNames_.insert(std::make_pair(idName, name));

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -606,6 +606,10 @@ namespace insur {
       }
       stream << xml_composite_material_close;
 
+      if (compositeNames_.find(idName) != compositeNames_.end()) {
+	//throw PathfulException("Found several composite materials with same name");
+	std::cout << idName << std::endl;
+      }
       printedComposites_.push_back(comp); 
       compositeNames_.insert(std::make_pair(idName, name));
     }
@@ -621,7 +625,6 @@ namespace insur {
      */
   void XMLWriter::logicalPart(std::string name, std::string solid, std::string material, std::ostringstream& stream, XmlTags& trackerXmlTags) {
       stream << xml_logical_part_open << name << xml_logical_part_first_inter << solid;
-      std::cout << "logical name = " << material << std::endl;
       auto newMaterialName = compositeNames_.find(material);
       if (newMaterialName != compositeNames_.end()) {
 	stream << xml_logical_part_second_inter << trackerXmlTags.nspace << ":" << (*newMaterialName).second << xml_logical_part_close;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -578,7 +578,7 @@ namespace insur {
 				      double density, CompType method, std::vector<std::pair<std::string, double> >& es, std::ostringstream& stream, XmlTags& trackerXmlTags) {
 
       std::string idName = trackerXmlTags.nspace + ":" + name;
-      auto foundComp = std::find_if(printedComposites_.begin(), printedComposites_.end(), [&](std::pair<std::string, CompoInfo> i) { return (std::get<0>(i.second) == density && std::get<1>(i.second) == method && std::get<2>(i.second) == es); });
+      auto foundComp = std::find_if(printedComposites_.begin(), printedComposites_.end(), [&](std::pair<std::string, CompoInfo> i) { return (fabs(std::get<0>(i.second) - density) < 0.0000001 && std::get<1>(i.second) == method ); });
 
       if (foundComp == printedComposites_.end()) {
 	CompoInfo myCompoInfo = std::make_tuple(density, method, es);

--- a/src/tk2CMSSW.cc
+++ b/src/tk2CMSSW.cc
@@ -166,8 +166,8 @@ namespace insur {
                 default: std::cout << "unknown method";
             }
             std::cout << std::endl << "elements: ";
-            std::vector<std::pair<std::string, double> >& elems = data.composites.at(i).elements;
-            for (unsigned int j = 0; j < elems.size(); j++) std::cout << "(" << elems.at(j).first << ", " << elems.at(j).second << ") ";
+            std::map<std::string, double>& elements = data.composites.at(i).elements;
+            for (const auto& elem : elements) std::cout << "(" << elem.first << ", " << elem.second << ") ";
             std::cout << std::endl;
         }
         std::cout << "rotations: " << data.rots.size() << " entries." << std::endl;

--- a/xml/pixfwd.xml
+++ b/xml/pixfwd.xml
@@ -8,7 +8,6 @@
  <!--<Constant name="RootRadius"     value="20.1*cm"/>-->
  <Constant name="RootRadius1"     value="19.65*cm"/>
  <Constant name="RootRadius2"     value="28.8*cm"/> <!-- For Pixel 1_1_1 : RootRadius2 = RootRadius1 -->
- <Constant name="RootHalfLength" value="[pixfwdCylinder:CylindersOuterLength]/2.+ [pixfwdCylinder:CylindersEndFlangeLength]/2.+[Zextension]/2."/>
 
  <Constant name="AnchorZ"        value="0.*mm"/>
  <Constant name="ZPixelForward"  value="291.*mm"/>
@@ -17,7 +16,6 @@
  <Constant name="RootMidZ1"      value="[cms:TrackLumiZ1]-[ZPixelForward]"/>
  <Constant name="RootMidZ2"      value="[cms:TrackLumiZ2]-[ZPixelForward]"/>
  <Constant name="RootMidZ3"      value="[cms:TrackBeamZ1]-[ZPixelForward]"/>
- <Constant name="RootEndZ"       value="2*[RootHalfLength]"/>
  <Constant name="Zextension"      value="273.11*mm"/>
  <Constant name="ZextensionCables"      value="203.5*mm"/>
 

--- a/xml/trackerProdCuts.xml
+++ b/xml/trackerProdCuts.xml
@@ -7,7 +7,7 @@
       <Parameter name="CMSCutsRegion" value="TrackerDeadRegion" eval="false"/>
       <Parameter name="ProdCutsForElectrons" value="1*mm"/>
       <Parameter name="ProdCutsForPositrons" value="1*mm"/>
-      <Parameter name="ProdCutsForGamma" value="10*cm"/>
+      <Parameter name="ProdCutsForGamma" value="1*mm"/>
     </SpecPar>
     <SpecPar name="tracker-sens">
       <Parameter name="CMSCutsRegion" value="TrackerSensRegion" eval="false"/>


### PR DESCRIPTION
After the merge of these commits, the code in tkLayout/dev_gabie will be in the exact state of what was used for the XML export of FlatTracker4026 and TiltedTracker4026 to CMSSW.

Updates in the XML export : 
Worked on the materials XML export.
- 'Elementary' materials : 
They are now in tracker.xml only (they were duplicated in pixel.xml).
They are prefixed by "tkLayout_" for additional safety reasons.

- Composite materials (that is to say, all the other materials !) : 
They used to be a lot of composites with different names but same actual materials compositions. Redundancies have been deleted.
Design has been chosen towards the safest solution : scan the composite materials once they are created, and print the duplicated materials only once in the XMLs.
First glance solution that module materials could be categorized (category 'module type + dsDistance' for example, or similar), turned out to be impossible from the materials point of view, and is also much less safe.

Other changes in the XML export : 
- updated one constant in trackerProdCuts.xml, after question to Vladimir.
- deleted a few obsolete references to Phase 1 Pixel.


Added FlatTracker4026.
The soup recipe is the following : 
- TBPS from Flat/OT_200.cfg
- TB2S, TEDD from OT_Tilted_365
- Pixel is Pixel4026