### PR TITLE
Added a split between rods located at +bigDelta or -bigDelta in sensors irradiation power results

### DIFF
--- a/include/AnalyzerVisitors/IrradiationPower.h
+++ b/include/AnalyzerVisitors/IrradiationPower.h
@@ -14,6 +14,8 @@
 #include "SummaryTable.h"
 
 typedef std::tuple<bool, bool, std::string, int, int> ModuleRef;
+// Used to identify a module.
+// bool isBarrel, bool isOuterRadiusRod, std::string barrel/endcap name, int layer/disk number, int ring number
 
 class IrradiationPowerVisitor : public GeometryVisitor {
   double timeIntegratedLumi_;
@@ -29,7 +31,7 @@ class IrradiationPowerVisitor : public GeometryVisitor {
   bool isOuterRadiusRod_;
   std::map<ModuleRef, double> sensorsIrradiationPowerMean_;
   std::map<ModuleRef, double> sensorsIrradiationPowerMax_;
-  std::map<ModuleRef, int> sensorsCounter_;
+  std::map<ModuleRef, int> modulesCounter_;
 
 public:
   MultiSummaryTable sensorsIrradiationPowerSummary;

--- a/include/AnalyzerVisitors/IrradiationPower.h
+++ b/include/AnalyzerVisitors/IrradiationPower.h
@@ -13,6 +13,8 @@
 #include "Visitor.h"
 #include "SummaryTable.h"
 
+typedef std::tuple<bool, bool, std::string, int, int> ModuleRef;
+
 class IrradiationPowerVisitor : public GeometryVisitor {
   double timeIntegratedLumi_;
   double referenceTemp_;
@@ -23,13 +25,21 @@ class IrradiationPowerVisitor : public GeometryVisitor {
   const double computeSensorsIrradiationPower(const double& irradiation, const double& timeIntegratedLumi,
 					      const double& alphaParam, const double& volume, const double& referenceTemp,
 					      const double& operatingTemp, const double& biasVoltage) const;
+  bool isBarrel_;
+  bool isOuterRadiusRod_;
+  std::map<ModuleRef, double> sensorsIrradiationPowerMean_;
+  std::map<ModuleRef, double> sensorsIrradiationPowerMax_;
+  std::map<ModuleRef, int> sensorsCounter_;
+
 public:
   MultiSummaryTable sensorsIrradiationPowerSummary;
   void preVisit();
   void visit(SimParms& sp);
   void visit(Barrel& b);
+  void visit(RodPair& r);
   void visit(Endcap& e);
   void visit(DetectorModule& m);
+  void postVisit();
 };
 
 

--- a/include/AnalyzerVisitors/IrradiationPower.h
+++ b/include/AnalyzerVisitors/IrradiationPower.h
@@ -24,6 +24,7 @@ class IrradiationPowerVisitor : public GeometryVisitor {
   double alphaParam_;
   double biasVoltage_;
   const IrradiationMapsManager* irradiationMap_;
+  std::pair<double, double> getModuleIrradiationMeanMax(const IrradiationMapsManager* irradiationMap, const DetectorModule& m);
   const double computeSensorsIrradiationPower(const double& irradiation, const double& timeIntegratedLumi,
 					      const double& alphaParam, const double& volume, const double& referenceTemp,
 					      const double& operatingTemp, const double& biasVoltage) const;

--- a/include/AnalyzerVisitors/IrradiationPower.h
+++ b/include/AnalyzerVisitors/IrradiationPower.h
@@ -14,7 +14,7 @@
 #include "SummaryTable.h"
 
 typedef std::tuple<bool, bool, std::string, int, int> ModuleRef;
-// Used to identify a module.
+// Used to identify an irradiated module : all info which matters in that respect.
 // bool isBarrel, bool isOuterRadiusRod, std::string barrel/endcap name, int layer/disk number, int ring number
 
 class IrradiationPowerVisitor : public GeometryVisitor {

--- a/include/RodPair.h
+++ b/include/RodPair.h
@@ -53,6 +53,7 @@ public:
   Property<double, Computable> minZwithHybrids, maxZwithHybrids, minRwithHybrids, maxRwithHybrids;
   ReadonlyProperty<double, Computable> maxModuleThickness;
   Property<bool, Default> beamSpotCover;
+  Property<bool, NoDefault> isOuterRadiusRod;
 
   RodPair() :
       materialObject_(MaterialObject::ROD),

--- a/src/Analyzer.cpp
+++ b/src/Analyzer.cpp
@@ -1097,8 +1097,10 @@ void Analyzer::computeTriggerProcessorsBandwidth(Tracker& tracker) {
 
 void Analyzer::computeIrradiationPowerConsumption(Tracker& tracker) {
   IrradiationPowerVisitor v;
+  v.preVisit();
   simParms_->accept(v);
   tracker.accept(v);
+  v.postVisit();
 
   sensorsIrradiationPowerSummary_ = v.sensorsIrradiationPowerSummary;
 }

--- a/src/AnalyzerVisitors/IrradiationPower.cpp
+++ b/src/AnalyzerVisitors/IrradiationPower.cpp
@@ -12,11 +12,18 @@ void IrradiationPowerVisitor::visit(SimParms& sp) {
 }
 
 void IrradiationPowerVisitor::visit(Barrel& b) {
+  isBarrel_ = true;
   sensorsIrradiationPowerSummary[b.myid()].setHeader("Layer", "Ring");
   sensorsIrradiationPowerSummary[b.myid()].setPrecision(3);        
 }
 
+void IrradiationPowerVisitor::visit(RodPair& r) {
+  isOuterRadiusRod_ = r.isOuterRadiusRod();     
+}
+
 void IrradiationPowerVisitor::visit(Endcap& e) {
+  isBarrel_ = false;
+  isOuterRadiusRod_ = false;
   sensorsIrradiationPowerSummary[e.myid()].setHeader("Disk", "Ring");
   sensorsIrradiationPowerSummary[e.myid()].setPrecision(3);        
 }
@@ -65,11 +72,25 @@ void IrradiationPowerVisitor::visit(DetectorModule& m) {
   m.sensorsIrradiationPowerMean(sensorsIrradiationPowerMean);
   m.sensorsIrradiationPowerMax(sensorsIrradiationPowerMax);
 
-  TableRef tref = m.tableRef();
+
+
+  TableRef tableRef = m.tableRef();
+  ModuleRef moduleRef = std::make_tuple(isBarrel_, isOuterRadiusRod_, tableRef.table, tableRef.row, tableRef.col);
+  sensorsIrradiationPowerMean_[moduleRef] += sensorsIrradiationPowerMean;
+
+
+
   std::ostringstream values;
   values.str("");
   values << std::dec << std::fixed << std::setprecision(3) << sensorsIrradiationPowerMean << "," << sensorsIrradiationPowerMax;
   sensorsIrradiationPowerSummary[tref.table].setCell(tref.row, tref.col, values.str());
+  std::cout << "tref.table = " << tref.table << std::endl;
+  std::cout << "tref.ref = " << tref.row << std::endl;
+  std::cout << "tref.col = " << tref.col << std::endl;
+}
+
+void IrradiationPowerVisitor::postVisit() {
+  
 }
 
 

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -338,6 +338,7 @@ void Layer::buildStraight(bool isFlatPart) {
 
   // FIRST ROD : build and store
   bool isPlusBigDeltaRod = (bigParity() > 0);
+  first->isOuterRadiusRod(isPlusBigDeltaRod);
   first->build(rodTemplate, isPlusBigDeltaRod);
   first->translateR(placeRadius_ + (isPlusBigDeltaRod ? bigDelta() : -bigDelta()));
   if (!isFlatPart) { rods_.push_back(first); buildNumModulesFlat(first->numModulesSide(1)); }
@@ -346,6 +347,7 @@ void Layer::buildStraight(bool isFlatPart) {
   // SECOND ROD : assign other properties, build and store 
   if (!sameParityRods()) second->zPlusParity(first->zPlusParity()*-1);
   isPlusBigDeltaRod = (bigParity() < 0);
+  second->isOuterRadiusRod(isPlusBigDeltaRod);
   second->build(rodTemplate, isPlusBigDeltaRod);
   second->translateR(placeRadius_ + (isPlusBigDeltaRod ? bigDelta() : -bigDelta()));
   second->rotateZ(rodPhiRotation);
@@ -542,12 +544,14 @@ void Layer::buildTilted() {
 
   TiltedRodPair* first = GeometryFactory::make<TiltedRodPair>();
   first->myid(1);
+  first->isOuterRadiusRod(false);
   first->store(propertyTree());
   first->build(rodTemplate, tmspecsi, 1);
   rods_.push_back(first);
 
   TiltedRodPair* second = GeometryFactory::make<TiltedRodPair>();
   second->myid(2);
+  first->isOuterRadiusRod(true);
   second->store(propertyTree());
   second->build(rodTemplate, tmspecso, 0);
   second->rotateZ(rodPhiRotation);

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -551,7 +551,7 @@ void Layer::buildTilted() {
 
   TiltedRodPair* second = GeometryFactory::make<TiltedRodPair>();
   second->myid(2);
-  first->isOuterRadiusRod(true);
+  second->isOuterRadiusRod(true);
   second->store(propertyTree());
   second->build(rodTemplate, tmspecso, 0);
   second->rotateZ(rodPhiRotation);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6187,8 +6187,8 @@ namespace insur {
       void visit(const Barrel& b) { sectionName_ = b.myid(); }
       void visit(const Endcap& e) { sectionName_ = e.myid(); }
       void visit(const Layer& l)  { layerId_ = l.myid(); }
-      void visit(const RodPair& r)  { isOuterRadiusRod_ = r.isOuterRadius(); }
-      void visit(const Disk& d)  { isOuterRadiusRod_ = false; layerId_ = d.myid(); }
+      void visit(const RodPair& r)  { isOuterRadiusRod_ = r.isOuterRadiusRod(); }
+      void visit(const Disk& d)  { isOuterRadiusRod_ = false; layerId_ = d.myid(); } // no rod here !
       void visit(const Module& m) {
         output_ << sectionName_ << ", "
 		<< layerId_ << ", "

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6179,18 +6179,21 @@ namespace insur {
       std::stringstream output_;
       string sectionName_;
       int layerId_;
+      bool isOuterRadiusRod_;
     public:
       void preVisit() {
-        output_ << "Section, Layer, Ring, operatingTemperature_Celsius, biasVoltage_V, meanWidth_mm, length_mm, sensorThickness_mm, sensor(s)Volume(totalPerModule)_mm3, sensorsIrradiationMean_W, sensorsIrradiationMax_W" << std::endl;
+        output_ << "Section, Layer, Ring, isOuterRadiusRod_bool, operatingTemperature_Celsius, biasVoltage_V, meanWidth_mm, length_mm, sensorThickness_mm, sensor(s)Volume(totalPerModule)_mm3, sensorsIrradiationMean_W, sensorsIrradiationMax_W" << std::endl;
       }
       void visit(const Barrel& b) { sectionName_ = b.myid(); }
       void visit(const Endcap& e) { sectionName_ = e.myid(); }
       void visit(const Layer& l)  { layerId_ = l.myid(); }
-      void visit(const Disk& d)  { layerId_ = d.myid(); }
+      void visit(const RodPair& r)  { isOuterRadiusRod_ = r.isOuterRadius(); }
+      void visit(const Disk& d)  { isOuterRadiusRod_ = false; layerId_ = d.myid(); }
       void visit(const Module& m) {
         output_ << sectionName_ << ", "
 		<< layerId_ << ", "
 		<< m.moduleRing() << ", "
+		<< isOuterRadiusRod_ << ", "
 		<< std::fixed << std::setprecision(6)
 		<< m.operatingTemp() << ", "
 		<< m.biasVoltage() << ", "


### PR DESCRIPTION
Until now, irradiation results for a given barrel layer, was not taking into account whether the rods are located at +bigDelta or -bigDelta.
It was randomly either of the 2 rods which was used for the results in tables on the website.

Even if the uncertainty on FLUKA data, which is used for the results, is 10% anyway, we have here a too strong simplification.
The new, more detailed, results (split tables by inner radius / outer radius rods) show :  
In the worse case (central ring of the lowest layer) : 
TB2S : -6%
TBPS : ~ +17%
Pixel barrel :  ~+19% 
(In the worse case, the diff is big enough to be worth being taken into consideration).

In the best case : 
TB2S : -1%
TBPS : ~ +2%
Pixel barrel :  ~+2% 
(In the best case, diff has no interest).


