### PR TITLE
Updating the TEDD design according to indications by Nick (2017-02-02)

### DIFF
--- a/geometries/CMS_Phase2/OT366_200_IT4025.cfg
+++ b/geometries/CMS_Phase2/OT366_200_IT4025.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V366_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_5.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V366_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V366_200.cfg
@@ -1,0 +1,28 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+  
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V366_200.cfg
+  @include TB2S_V360_200.cfg
+  @include TEDD1_V366_200.cfg
+  @include TEDD2_V366_200.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V366_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V366_200.cfg
@@ -1,0 +1,305 @@
+// Tilted barrel version 3.6.6
+// By Stefano 2017-02-03
+
+Barrel TBPS {
+  barrelRotation 1.5707963268
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
+  @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS
+
+  numLayers 3
+  startZMode modulecenter
+
+  //////////////////////////
+  /// FLAT PART GEOMETRY ///
+  //////////////////////////
+  bigDelta 11.9 // as in 3.6.5 
+  Layer 1 { smallDelta 3.5625 } // Incorporating CML new plank thickness
+  Layer 2,3 { smallDelta 3.0625 } // Incorporating CML new plank thickness
+  radiusMode fixed
+  innerRadius 233 // as in 3.6.5 
+  Layer 2 { placeRadiusHint 361.7 } // as in 3.6.5 
+  outerRadius 514 // as in 3.6.5
+  // NB : for the z placement of modules within the flat part, the most stringent of zError and zOverlap is used
+
+
+  ////////////////////////////
+  /// TILTED PART GEOMETRY ///
+  ////////////////////////////
+  Layer 1 {
+    isTilted true
+    isTiltedAuto true
+    numModulesFlat 4
+    numModulesTilted 11
+
+    numRods 18
+
+    Ring 5-7 {
+      ringInnerRadius 252.0
+      ringOuterRadius 265.0
+      tiltAngle 47.0
+      theta_g 53.0
+    }
+    Ring 8-11 {
+      ringInnerRadius 249.0
+      ringOuterRadius 259.0
+      tiltAngle 60.0
+      theta_g 40.0
+    }
+    Ring 12-15 {
+      ringInnerRadius 248.0
+      ringOuterRadius 254.0
+      tiltAngle 74.0
+      theta_g 26.0
+    }
+	
+    Ring 5 {
+      // zOverlap adjustment from 3.6.3 16 -> 15.5
+      ringZOverlap 8.5
+    }
+    Ring 6 {
+      ringZOverlap 8.5
+    }
+    Ring 7 {
+      ringZOverlap 7.4
+    }
+    Ring 8 {
+      ringZOverlap 5.75
+    }
+    Ring 9 {
+      ringZOverlap 7.15
+    }
+    Ring 10 {
+      ringZOverlap 5.9
+    }
+    Ring 11 {
+      ringZOverlap 4.9
+    }
+    Ring 12 {
+      ringZOverlap 4.1
+    }
+    Ring 13 {
+      ringZOverlap 4.5
+    }
+    Ring 14 {
+      ringZOverlap 3.7
+    }
+    Ring 15 {
+      ringZOverlap 3.1
+    }
+  }
+
+  //////////////////
+  /// FULL LAYER ///
+  //////////////////
+  Layer 1 {
+    Ring 1-6 { triggerWindow 5 }
+    Ring 7   { triggerWindow 4 }
+    Ring 8-9 { triggerWindow 5 }
+    Ring 10-11 { triggerWindow 4 }
+    Ring 12-13 { triggerWindow 3 }
+    Ring 14-15 { triggerWindow 2 }
+    Ring 1-3 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_flat_200_26
+      dsDistance 2.6
+    }
+    Ring 4 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_lastFlat_200_26
+      dsDistance 2.6
+    }
+    Ring 5-7 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_tilted_200_26
+      dsDistance 2.6
+    }
+    Ring 8-15 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_tilted_200_40
+      dsDistance 4.0
+    }
+  }
+
+
+  ////////////////////////////
+  /// TILTED PART GEOMETRY ///
+  ////////////////////////////
+  Layer 2 {
+    isTilted true
+    isTiltedAuto true
+    numModulesFlat 6
+    numModulesTilted 12
+
+    numRods 26
+
+    Ring 7-9 {
+      ringInnerRadius 375.0
+      ringOuterRadius 388.0
+      tiltAngle 40.0
+      theta_g 60.0
+    }
+    Ring 10-13 {
+      ringInnerRadius 372.0
+      ringOuterRadius 381.0
+      tiltAngle 55.0
+      theta_g 45.0
+    }
+
+    Ring 14-18 {
+      ringInnerRadius 372.0
+      ringOuterRadius 379.0
+      tiltAngle 68.0
+      theta_g 32.0
+    }
+	
+    Ring 7 {
+      // zOverlap adjustment from 3.6.2 1.0 -> 16.0 -> 12.5
+      ringZOverlap 6.0
+    }
+    Ring 8 {
+      ringZOverlap 8.0
+    }
+    Ring 9 {
+      ringZOverlap 6.25
+    }
+    Ring 10 {
+      ringZOverlap 4.0
+    }
+    Ring 11 {
+      ringZOverlap 5.5
+    }
+    Ring 12 {
+      ringZOverlap 5.5
+    }
+    Ring 13 {
+      ringZOverlap 5.0
+    }
+    Ring 14 {
+      ringZOverlap 5.0
+    }
+    Ring 15 {
+      ringZOverlap 6.0
+    }
+    Ring 16 {
+      ringZOverlap 6.5
+    }
+    Ring 17 {
+      ringZOverlap 5.5
+    }
+    Ring 18 {
+      ringZOverlap 5.5
+    }
+  }
+
+  //////////////////
+  /// FULL LAYER ///
+  //////////////////
+  Layer 2 {
+    Ring 1-11 { triggerWindow 5 }
+    Ring 12-13 { triggerWindow 4 }
+    Ring 14-18 { triggerWindow 7 }
+    Ring 1-5 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_flat_200_16
+      dsDistance 1.6
+    }
+    Ring 6 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_lastFlat_200_16
+      dsDistance 1.6
+    }
+    Ring 7-13 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_tilted_200_26
+      dsDistance 2.6
+    }
+    Ring 14-18 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_tilted_200_40
+      dsDistance 4.0
+    }
+  }
+
+
+  ////////////////////////////
+  /// TILTED PART GEOMETRY ///
+  ////////////////////////////
+  Layer 3 {
+    isTilted true
+    isTiltedAuto true
+    numModulesFlat 8
+    numModulesTilted 12
+
+    numRods 36
+
+    Ring 9-14 {
+      ringInnerRadius 525.0
+      ringOuterRadius 537.0
+      tiltAngle 44.0
+      theta_g 56.0
+    }
+    Ring 15-20 {
+
+      ringInnerRadius 523.0
+      ringOuterRadius 531.0
+      tiltAngle 60.0
+      theta_g 40.0
+    }
+	
+    Ring 9 {
+      // zOverlap adjustment from 3.6.2 1.0 -> 17.0 -> 8.5
+      ringZOverlap 3.6
+    }
+    Ring 10 {
+      ringZOverlap 4.5
+    }
+    Ring 11 {
+      ringZOverlap 4.5
+    }
+    Ring 12 {
+      ringZOverlap 3.5
+    }
+    Ring 13 {
+      ringZOverlap 3.2
+    }
+    Ring 14 {
+      ringZOverlap 3.2
+    }
+    Ring 15 {
+      ringZOverlap 3.0
+    }
+    Ring 16 {
+      ringZOverlap 4.0
+    }
+    Ring 17 {
+      ringZOverlap 3.5
+    }
+    Ring 18 {
+      ringZOverlap 3.5
+    }
+    Ring 19 {
+      ringZOverlap 3.0
+    }
+    Ring 20 {
+      ringZOverlap 3.0
+    }
+  }
+
+  //////////////////
+  /// FULL LAYER ///
+  //////////////////
+  Layer 3 {
+    Ring 1-8 { triggerWindow 7 }
+    Ring 9-10 { triggerWindow 8 }
+    Ring 11-13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 6 }
+    Ring 15 { triggerWindow 6 }
+    Ring 16-20 { triggerWindow 5 }
+    Ring 21 { triggerWindow 4 }
+    Ring 1-7 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L3_flat_200_16
+      dsDistance 1.6
+    }
+    Ring 8 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L3_lastFlat_200_16
+      dsDistance 1.6
+    }
+    Ring 9-20 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L3_tilted_200_26
+      dsDistance 2.6
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V366_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V366_200.cfg
@@ -1,0 +1,149 @@
+Endcap TEDD_1 {
+  smallParity 1
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1_TEDD_1.cfg
+
+  // Layout construction parameters
+  zOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 15.35 // NICK 2017
+  smallDelta 7.42 // PS NICK 2017
+  phiSegments 4
+  numDisks 2
+  phiOverlap 0
+  numRings 15
+  outerRadius 1103.36
+  minZ 1326.80
+  maxZ 1550.00
+  bigParity 1
+  
+  // Nick 2017-02-02 new deltas and positions
+  // ring positions obtained with a single end-cap
+  // spanning from 1326.8 to 2650.0 for rings 15 -> 3
+  // using 4.0 2S modules in ring 10 alone for the first disk
+  // using 4.0 2S modules in rings 10->12 for the last disk
+  // (leaving rings 1-2 to be optimized for disk 1-2
+  // alone): that is
+  
+  // Disk 1 z=1326.80
+  //  TEDD_1-D1       1       7.42
+  //  TEDD_1-D1       2       7.42
+  //  TEDD_1-D1       3       7.42
+  //  TEDD_1-D1       4       7.42
+  //  TEDD_1-D1       5       7.42
+  //  TEDD_1-D1       6       7.42
+  //  TEDD_1-D1       7       7.42
+  //  TEDD_1-D1       8       7.42
+  //  TEDD_1-D1       9       7.42
+  //  TEDD_1-D1       10      10.05
+  //  TEDD_1-D1       11      7.45
+  //  TEDD_1-D1       12      7.45
+  //  TEDD_1-D1       13      7.45
+  //  TEDD_1-D1       14      7.45
+  //  TEDD_1-D1       15      7.45
+  //  Disk 2 z=2650.00
+  //  TEDD_1-D2       1       7.42
+  //  TEDD_1-D2       2       7.42
+  //  TEDD_1-D2       3       7.42
+  //  TEDD_1-D2       4       7.42
+  //  TEDD_1-D2       5       7.42
+  //  TEDD_1-D2       6       7.42
+  //  TEDD_1-D2       7       7.42
+  //  TEDD_1-D2       8       7.42
+  //  TEDD_1-D2       9       7.42
+  //  TEDD_1-D2       10      10.05
+  //  TEDD_1-D2       11      8.55
+  //  TEDD_1-D2       12      8.55
+  //  TEDD_1-D2       13      7.45
+  //  TEDD_1-D2       14      7.45
+  //  TEDD_1-D2       15      7.45
+
+  // As a result of 2017-02-03 optimization we fix these radii for all disks (TEDD1 and TEDD2)
+  Ring 15 { ringOuterRadius 1103.36 }  // =  + 8.360   w.r.t. 3.5.1=3.6.5
+  Ring 14 { ringOuterRadius 1041.41 }  // =  + 9.429   w.r.t. 3.5.1=3.6.5
+  Ring 13 { ringOuterRadius 936.947 }  // =  + 8.749   w.r.t. 3.5.1=3.6.5
+  Ring 12 { ringOuterRadius 869.346 }  // =  + 9.732   w.r.t. 3.5.1=3.6.5
+  Ring 11 { ringOuterRadius 766.425 }  // =  + 9.174   w.r.t. 3.5.1=3.6.5
+  Ring 10 { ringOuterRadius 694.141 }  // = + 11.003   w.r.t. 3.5.1=3.6.5
+  Ring 9 { ringOuterRadius 592.572 }   // = + 11.056   w.r.t. 3.5.1=3.6.5
+  Ring 8 { ringOuterRadius 568.279 }   // = + 12.375   w.r.t. 3.5.1=3.6.5
+  Ring 7 { ringOuterRadius 520.684 }   // = + 12.174   w.r.t. 3.5.1=3.6.5
+  Ring 6 { ringOuterRadius 493.513 }   // = + 13.331   w.r.t. 3.5.1=3.6.5
+  Ring 5 { ringOuterRadius 446.251 }   // = + 13.147   w.r.t. 3.5.1=3.6.5
+  Ring 4 { ringOuterRadius 416.248 }   // = + 14.229   w.r.t. 3.5.1=3.6.5
+  Ring 3 { ringOuterRadius 369.331 }   // = + 14.063   w.r.t. 3.5.1=3.6.5
+  // Ring 2 { ringOuterRadius 336.402 }   // <- this position would be hermetic up to 2650
+  // Ring 1 { ringOuterRadius 289.842 }   // <- this position would be hermetic up to 2650
+  // Leaving these two for optimization actually recovers only 1mm on ring 1...
+
+  alignEdges false
+  moduleShape rectangular
+  Ring 1-9 {
+    smallDelta 7.42
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+    @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+  }
+  Ring 10 {
+    smallDelta 10.05
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+  }
+  Ring 11-15 {
+    smallDelta 7.45       
+    dsDistance 1.8
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  }
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+  
+  Disk 1 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 3 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 6 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 8 }
+    Ring 10 { triggerWindow 10 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 9 }
+    Ring 14 { triggerWindow 11 }
+    Ring 15 { triggerWindow 12 }
+  }
+  
+  Disk 2 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 7 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 9 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 8 }
+    Ring 14 { triggerWindow 10 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)      
+  Disk 1-2 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V366_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V366_200.cfg
@@ -1,0 +1,149 @@
+Endcap TEDD_2 {
+  smallParity 1
+  // Layout construction parameters
+  zOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.95 // NICK 2015
+  smallDelta 7.4 // NICK 2015
+  phiSegments 4
+  numDisks 3
+  phiOverlap 0
+  numRings 15
+  outerRadius 1103.36
+  minZ 1853.400
+  Disk 2 { placeZ 2216.190 }
+  maxZ 2650.000
+  bigParity 1
+
+  // As a result of 2017-02-03 optimization we fix these radii for all disks (TEDD1 and TEDD2)
+  Ring 15 { ringOuterRadius 1103.36 }  // =  + 8.360   w.r.t. 3.5.1=3.6.5
+  Ring 14 { ringOuterRadius 1041.41 }  // =  + 9.429   w.r.t. 3.5.1=3.6.5
+  Ring 13 { ringOuterRadius 936.947 }  // =  + 8.749   w.r.t. 3.5.1=3.6.5
+  Ring 12 { ringOuterRadius 869.346 }  // =  + 9.732   w.r.t. 3.5.1=3.6.5
+  Ring 11 { ringOuterRadius 766.425 }  // =  + 9.174   w.r.t. 3.5.1=3.6.5
+  Ring 10 { ringOuterRadius 694.141 }  // = + 11.003   w.r.t. 3.5.1=3.6.5
+  Ring 9 { ringOuterRadius 592.572 }   // = + 11.056   w.r.t. 3.5.1=3.6.5
+  Ring 8 { ringOuterRadius 568.279 }   // = + 12.375   w.r.t. 3.5.1=3.6.5
+  Ring 7 { ringOuterRadius 520.684 }   // = + 12.174   w.r.t. 3.5.1=3.6.5
+  Ring 6 { ringOuterRadius 493.513 }   // = + 13.331   w.r.t. 3.5.1=3.6.5
+  Ring 5 { ringOuterRadius 446.251 }   // = + 13.147   w.r.t. 3.5.1=3.6.5
+  Ring 4 { ringOuterRadius 416.248 }   // = + 14.229   w.r.t. 3.5.1=3.6.5
+  Ring 3 { ringOuterRadius 369.331 }   // = + 14.063   w.r.t. 3.5.1=3.6.5
+  Ring 1 { removeModule true }
+  Ring 2 { removeModule true }
+  
+  alignEdges false
+  moduleShape rectangular
+  Ring 10-12 { smallDelta 8.85 } // NICK
+  Ring 13-15 { smallDelta 7.95 } // NICK
+  Ring 1-9 {
+    smallDelta 7.42
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
+    @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+  }
+  Ring 10 {
+    smallDelta 10.05
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+  }
+  Ring 11 {
+    smallDelta 8.55
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+  }
+  Ring 13-15 {
+    smallDelta 7.45
+    dsDistance 1.8
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  }
+
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+
+  // Only ring 12 differs between disks
+  Disk 1-2 {
+    Ring 12 {
+      smallDelta 7.45
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+  }
+  Disk 3 {
+    Ring 12 {
+      smallDelta 8.55
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+  }
+
+  Disk 1 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 8 }
+    Ring 11 { triggerWindow 10 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 9 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  Disk 2 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 7 }
+    Ring 11 { triggerWindow 9 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 8 }
+    Ring 15 { triggerWindow 9 }
+  }
+
+  Disk 3 {
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 3 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 5 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 6 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 8 }
+    Ring 13 { triggerWindow 6 }
+    Ring 14 { triggerWindow 7 }
+    Ring 15 { triggerWindow 8 }
+  }
+ 
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)
+  Disk 1-3 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -101,3 +101,22 @@ OT365_200_IT4025.cfg                 OT Version 3.6.5
 OT365_200_IT4026.cfg                 OT Version 3.6.5
                                      Inner tracker version 4.0.2.6 <- based one 4.0.2.5 but with 7 FPIX disks
 
+OT366_200_IT4025.cfg                 OT Version 3.6.6 <- like 365, but with adjusted TBPS flat part
+                                     bigDelta = 11.9 (unchanged) smallDelta=3.5625 (from CML) 
+                                     New TEDD following Nick's indications:
+                                     Outer Physical envelope = 1125 -- Considering 20.54 mm 2S FEH + 1.1 mm sensor margin => outerRadius 1103.36 (+8.36 mm w.r.t v3.5.1)
+                                     Inner Physical envelope = 215/315 -- Considering 10.65 mm PS FEH + 1.45 mm sensor margin => 227/327 mm inner envelope for sensors
+                                     Disk    z [mm]
+                                     1_1(1)  1326.8
+                                     1_2(2)  1550.0
+                                     2_1(3)  1853.4
+                                     2_2(4)  2216.2
+                                     2_3(5)  2650.0
+                                        bigDelta =30.7/2=15.35
+                                        Module/ring            smallDelta:
+                                        2S 4.0mm rings 11-12   17.10/2 =  8.55 mm
+                                        2S 4.0mm ring  10      20.10/2 = 10.05 mm
+                                        2S 1.8mm rings (11-15) 14.90/2 =  7.45 mm
+                                        PS 4.0mm all rings     14.84/2 =  7.42 mm
+                                     IT version 4.0.2.5
+


### PR DESCRIPTION
Zd = 30.7mm
ZmPS4.0 = 14.84mm
Zm2S4.0 = 17.1mm
Zm2S4.0_R10 = 20.1mm
Zm2S1.8 = 14.9mm

No artificial gaps between rings.

Ring 15/ r_high = 1103mm
Ring 1/ r_min = 227mm disks 1-2
Ring 1/r_min = 327mm disks 3-5

Disk 1 Z = 1326.8mm
Disk 2 Z = 1550mm
Disk 3 Z = 1853.4mm
Disk 4 Z = 2216.2mm
Disk 5 Z = 2650mm

Disk 1:  R1-9  PS_4.0 modules
Disk 1:  R10:  2S_4.0 modules
Disk 1:  R11-15 2S_1.8 modules

Disk 2:  Identical to Disk 1

Disk 3:  R1-9  PS_4.0 modules
Disk 3:  R10-11:  2S_4.0 modules
Disk 3:  R12-15 2S_1.8 modules

Disk 4:  Identical to Disk 3

Disk 5:  R1-9  PS_4.0 modules
Disk 5:  R10-12:  2S_4.0 modules
Disk 5:  R13-15 2S_1.8 modules