### PR TITLE
Fixing an old bug

### DIFF
--- a/include/AnalyzerVisitor.h
+++ b/include/AnalyzerVisitor.h
@@ -60,7 +60,8 @@ public:
   TriggerEfficiencyMapVisitor(TH2D& map, double pt) : myMap_(map), myPt_(pt) { counter_ = (TH2D*)map.Clone(); }
 
   void visit(const DetectorModule& aModule) {
-    // CUIDADO needs to return immediately if module is not pt enabled!!!!
+    // returns immediately if module is not pt enabled
+    if (aModule.sensorLayout() != PT) return;
     double myValue = PtErrorAdapter(aModule).getTriggerProbability(myPt_);
     if (myValue>=0) AnalyzerHelpers::drawModuleOnMap(aModule, myValue, myMap_, *counter_);
   }


### PR DESCRIPTION
trigger tuning analysis would crash if non-pt modules are in the Outer Tracker