### PR TITLE
Fixing a time-wasting bug

### DIFF
--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -656,8 +656,8 @@ namespace insur {
   bool Squid::reportResolutionSite() {
     if (mb) {
       startTaskClock("Creating resolution report");
-      v.errorSummary(a, site, "", false);
 #ifdef NO_TAGGED_TRACKING
+      v.errorSummary(a, site, "", false);
       v.errorSummary(a, site, "trigger", true);
 #else
       v.taggedErrorSummary(a, site);


### PR DESCRIPTION
  the "dead code" errorSummary was called even when taggedErrorSummary should have been
  TODO: remove *all* code under NO_TAGGED_TRACKING