### PR TITLE
Detailed plots of the different endcaps

### DIFF
--- a/include/Disk.h
+++ b/include/Disk.h
@@ -125,6 +125,7 @@ public:
   const MaterialObject& materialObject() const;
   ConversionStation* flangeConversionStation() const;
   const std::vector<ConversionStation*>& secondConversionStations() const;
-};
+  std::vector< std::set<const Module*> > getModuleSurfaces() const;
+ };
 
 #endif

--- a/include/Endcap.h
+++ b/include/Endcap.h
@@ -75,8 +75,6 @@ class Endcap : public PropertyObject, public Buildable, public Identifiable<std:
   const Container& disks() const         { return disks_; }
   SupportStructures& supportStructures() { return supportStructures_; }
 
-  set<Module*> modules();
-
   Property<        int   , NoDefault>  numDisks;
   Property<        double, NoDefault>  barrelMaxZ;
   Property<        double, NoDefault>  innerZ;

--- a/include/Endcap.h
+++ b/include/Endcap.h
@@ -18,7 +18,6 @@ namespace material {
 }
 
 class Endcap : public PropertyObject, public Buildable, public Identifiable<std::string>, public Visitable {
-
  private:
   typedef boost::ptr_vector<Disk>                       Container;
   typedef boost::ptr_vector<material::SupportStructure> SupportStructures;
@@ -75,6 +74,8 @@ class Endcap : public PropertyObject, public Buildable, public Identifiable<std:
 
   const Container& disks() const         { return disks_; }
   SupportStructures& supportStructures() { return supportStructures_; }
+
+  set<Module*> modules();
 
   Property<        int   , NoDefault>  numDisks;
   Property<        double, NoDefault>  barrelMaxZ;

--- a/include/Tracker.h
+++ b/include/Tracker.h
@@ -23,7 +23,7 @@
 using std::set;
 using material::SupportStructure;
 
-class Tracker : public PropertyObject, public Buildable, public Identifiable<string>, Clonable<Tracker>, Visitable {
+class Tracker : public PropertyObject, public Buildable, public Identifiable<string>, Clonable<Tracker>, public Visitable {
   class ModuleSetVisitor : public GeometryVisitor {
   public:
     typedef set<Module*> Modules;

--- a/include/Vizard.h
+++ b/include/Vizard.h
@@ -231,7 +231,7 @@ namespace insur {
     double averageHistogramValues(TH1D& histo, double cutoffStart, double cutoffEnd);
 
     void createSummaryCanvas(double maxZ, double maxRho, Analyzer& analyzer, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYCanvasEC);
-    void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, TCanvas *&XYCanvasEC);
+    void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
 
     enum {ViewSectionXY=3, ViewSectionYZ=1, ViewSectionXZ=2};
     void drawEtaTicks(double maxL, double maxR, double tickDistance, double tickLength, double textDistance, Style_t labelFont, Float_t labelSize,

--- a/src/Endcap.cpp
+++ b/src/Endcap.cpp
@@ -103,3 +103,15 @@ void Endcap::build() {
   cleanup();
   builtok(true);
 }
+
+set<Module*> Endcap::modules() {
+  class ModuleVisitor : public GeometryVisitor {
+  public:
+    set<Module*> result;
+    void visit(Module& m) { result.insert(&m); }
+  };
+  ModuleVisitor v;
+  this->accept(v);
+  return v.result;
+}
+

--- a/src/Endcap.cpp
+++ b/src/Endcap.cpp
@@ -104,14 +104,4 @@ void Endcap::build() {
   builtok(true);
 }
 
-set<Module*> Endcap::modules() {
-  class ModuleVisitor : public GeometryVisitor {
-  public:
-    set<Module*> result;
-    void visit(Module& m) { result.insert(&m); }
-  };
-  ModuleVisitor v;
-  this->accept(v);
-  return v.result;
-}
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2694,17 +2694,14 @@ namespace insur {
     TCanvas* result = nullptr;
     std::string aClass;
     PlotDrawer<YZ, Type> yzDrawer;
-    //double maxR = 1100;
-    //double maxL = 2800;
-    //double scaleFactor = maxR / 600;
 
     for (unsigned int i=0; i< trackers_.size(); ++i) {
       Tracker& tracker = *(trackers_[i]);
-      yzDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
+      yzDrawer.addModules(tracker);
     }
 
-    int rzCanvasX = vis_max_canvas_sizeX; //int(maxL/scaleFactor);
-    int rzCanvasY = vis_min_canvas_sizeY; //int(maxR/scaleFactor);
+    int rzCanvasX = vis_max_canvas_sizeX;
+    int rzCanvasY = vis_min_canvas_sizeY;
     result = new TCanvas("FullRZCanvas", "RZView Canvas (full layout)", rzCanvasX, rzCanvasY );
     result->cd();
     yzDrawer.drawFrame<SummaryFrameStyle>(*result);
@@ -2720,7 +2717,7 @@ namespace insur {
 
     for (unsigned int i=0; i< trackers_.size(); ++i) {
       Tracker& tracker = *(trackers_[i]);
-      xyDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL);
+      xyDrawer.addModulesType(tracker, BARREL);
     }
 
     int xyCanvasX = vis_min_canvas_sizeX;
@@ -6038,7 +6035,7 @@ namespace insur {
     RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", rzCanvasX, rzCanvasY );
     RZCanvas->cd();
     PlotDrawer<YZ, Type> yzDrawer;
-    yzDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL | ENDCAP);
+    yzDrawer.addModules(tracker);
     yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
     yzDrawer.drawModules<ContourStyle>(*RZCanvas);
 
@@ -6046,28 +6043,52 @@ namespace insur {
     RZCanvasBarrel = new TCanvas("RZCanvasBarrel", "RZView CanvasBarrel", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     RZCanvasBarrel->cd();
     PlotDrawer<YZ, Type> yzDrawerBarrel(viewPortMax, viewPortMax);
-    yzDrawerBarrel.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL);
+    yzDrawerBarrel.addModulesType(tracker, BARREL);
     yzDrawerBarrel.drawFrame<SummaryFrameStyle>(*RZCanvasBarrel);
     yzDrawerBarrel.drawModules<ContourStyle>(*RZCanvasBarrel);
 
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
     XYCanvas->cd();
     PlotDrawer<XY, Type> xyBarrelDrawer;
-    xyBarrelDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL);
+    xyBarrelDrawer.addModulesType(tracker, BARREL);
     xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
 
     for (auto& anEndcap : tracker.endcaps() ) {
       TCanvas* XYCanvasEC = new TCanvas(Form("XYCanvasEC_%s", anEndcap.myid().c_str()),
-					Form("XY projection of Endcap (%s)", anEndcap.myid().c_str()),
+					Form("XY projection of Endcap %s", anEndcap.myid().c_str()),
 					vis_min_canvas_sizeX, vis_min_canvas_sizeY );
       XYCanvasEC->cd();
       PlotDrawer<XY, Type> xyEndcapDrawer;
-      set<Module*> modules = anEndcap.modules();
-      xyEndcapDrawer.addModulesType(modules.begin(), modules.end(), ENDCAP);
+      xyEndcapDrawer.addModules(anEndcap);
       xyEndcapDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasEC);
       xyEndcapDrawer.drawModules<ContourStyle>(*XYCanvasEC);
       XYCanvasesEC.push_back(XYCanvasEC);
+    }
+
+    // And now one per disk surface
+    for (auto& anEndcap : tracker.endcaps() ) {
+      if (anEndcap.disks().size()>0) {
+	auto lastDiskIt = anEndcap.disks().end();
+	lastDiskIt--;
+	const Disk& lastDisk = *(lastDiskIt);
+
+	std::vector<std::set<const Module*>> modZ = lastDisk.getModuleSurfaces();
+	int iSurface=0;
+	for (std::set<const Module*>& moduleSet : modZ) {
+	  iSurface++; //for (int iSurface=1; iSurface<=4; ++iSurface) {
+	  TCanvas* XYCanvasEC = new TCanvas(Form("XYCanvasEC_%s_%d", anEndcap.myid().c_str(), iSurface),
+					    Form("XY projection of Endcap %s -- surface %d", anEndcap.myid().c_str(), iSurface),
+					    vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	  XYCanvasEC->cd();
+	  PlotDrawer<XY, Type> xyEndcapDrawer;
+
+	  xyEndcapDrawer.addModules(moduleSet.begin(), moduleSet.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
+	  xyEndcapDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasEC);
+	  xyEndcapDrawer.drawModules<ContourStyle>(*XYCanvasEC);
+	  XYCanvasesEC.push_back(XYCanvasEC);
+	}
+      }
     }
   }
 


### PR DESCRIPTION
This gives a warning I do not  understand during compilation of Vizard.o:
What I do not understand is why is anEndcap const...

Building target Vizard.o...
colorgcc -std=c++11  -g -fpermissive -lstdc++ -fmax-errors=2 -Iinclude/ `root-config --cflags` -c -o lib/Vizard.o src/Vizard.cc
src/Vizard.cc: In member function ‘void insur::Vizard::createSummaryCanvasNicer(Tracker&, TCanvas*&, TCanvas*&, TCanvas*&, std::vector<TCanvas*>&)’:
src/Vizard.cc:6066:47: warning: passing ‘const Endcap’ as ‘this’ argument discards qualifiers [-fpermissive]
       set<Module*> modules = anEndcap.modules();
                                               ^
In file included from include/Tracker.h:17:0,
                 from include/Vizard.h:44,
                 from src/Vizard.cc:6:
include/Endcap.h:78:16: note:   in call to ‘std::set<DetectorModule*> Endcap::modules()’
   set<Module*> modules();
