### PR TITLE
Quick code to fix the issues in rings placement in TEDD

### DIFF
--- a/include/Disk.h
+++ b/include/Disk.h
@@ -44,9 +44,10 @@ private:
   PropertyNode<int> ringNode;
   PropertyNodeUnique<std::string> stationsNode;
 
-  inline double getDsDistance(const vector<double>& buildDsDistances, int rindex) const;
-  void buildTopDown(const vector<double>& buildDsDistances);
-  void buildBottomUp(const vector<double>& buildDsDistances);
+  inline double getSmallDelta(const vector<double>& diskSmallDeltas, int ringIndex) const;
+  inline double getDsDistance(const vector<double>& buildDsDistances, int ringIndex) const;
+  void buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector<double>& lastDiskSmallDeltas, const vector<double>& firstDiskDsDistances, const vector<double>& lastDiskDsDistances);
+  //void buildBottomUp(const vector<double>& buildDsDistances);
 
   double averageZ_ = 0;
 public:
@@ -93,8 +94,11 @@ public:
     totalModules.setup([this]() { int cnt = 0; for (const Ring& r : rings_) { cnt += r.numModules(); } return cnt; });
   }
 
+  const std::vector<double> getSmallDeltasFromTree() const;
+  const std::vector<double> getDsDistancesFromTree() const;
+
   void check() override;
-  void build(const vector<double>& buildDsDistances);
+  void build(const vector<double>& firstDiskSmallDeltas, const vector<double>& lastDiskSmallDeltas, const vector<double>& firstDiskDsDistances, const vector<double>& lastDiskDsDistances);
   void translateZ(double z);
   void mirrorZ();
   void cutAtEta(double eta);

--- a/include/Endcap.h
+++ b/include/Endcap.h
@@ -30,7 +30,7 @@ class Endcap : public PropertyObject, public Buildable, public Identifiable<std:
   PropertyNode<int>               diskNode;
   PropertyNodeUnique<std::string> supportNode;
 
-  vector<double> findMaxDsDistances();
+  //vector<double> findMaxDsDistances();
 
  public:
   Endcap() :
@@ -58,6 +58,7 @@ class Endcap : public PropertyObject, public Buildable, public Identifiable<std:
 	return min;
       });
   }
+ 
   void build();
   void cutAtEta(double eta);
   void accept(GeometryVisitor& v) {

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -38,15 +38,15 @@ void Disk::check() {
 }
 
 double Disk::getSmallDelta(const vector<double>& diskSmallDeltas, int ringIndex) const {
-  std::cout << " ringIndex = " << ringIndex << std::endl;
-  std::cout << "diskSmallDeltas.size() = " << diskSmallDeltas.size() << std::endl;
+  //std::cout << " ringIndex = " << ringIndex << std::endl;
+  //std::cout << "diskSmallDeltas.size() = " << diskSmallDeltas.size() << std::endl;
   if (ringIndex > diskSmallDeltas.size()) throw PathfulException("Tries to access information from ring which is not in disk.");
   return diskSmallDeltas.at(ringIndex - 1);
 }
 
 double Disk::getDsDistance(const vector<double>& diskDsDistances, int ringIndex) const {
-  std::cout << " ringIndex = " << ringIndex << std::endl;
-  std::cout << "diskDsDistances.size() = " << diskDsDistances.size() << std::endl;
+  //std::cout << " ringIndex = " << ringIndex << std::endl;
+  //std::cout << "diskDsDistances.size() = " << diskDsDistances.size() << std::endl;
   if (ringIndex > diskDsDistances.size()) throw PathfulException("Tries to access information from ring which is not in disk.");
   return diskDsDistances.at(ringIndex - 1);
 }
@@ -123,7 +123,7 @@ void Disk::cutAtEta(double eta) {
 
 void Disk::buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector<double>& lastDiskSmallDeltas, const vector<double>& firstDiskDsDistances, const vector<double>& lastDiskDsDistances) {
   double lastRho;
-  double lastSmallDelta;
+  //double lastSmallDelta;
   for (int i = numRings(), parity = -bigParity(); i > 0; i--, parity *= -1) {
     Ring* ring = GeometryFactory::make<Ring>();
     ring->buildDirection(Ring::TOPDOWN);
@@ -188,6 +188,7 @@ void Disk::buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector
       double nextRhoWZError   = lastRho / (lastZ - errorShiftZ) * (newZ - errorShiftZ);
 
       double nextRho = MAX(nextRhoWOverlap, nextRhoWZError);
+      std::cout << "FINALLLLLLLL nextRho " << nextRho << std::endl;
       ring->buildStartRadius(nextRho);
     }
 
@@ -201,7 +202,7 @@ void Disk::buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector
 
     // Keep for next calculation
     lastRho        = ring->minR();
-    lastSmallDelta = ring->smallDelta();
+    //lastSmallDelta = ring->smallDelta();
   }
 }
 

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -139,39 +139,10 @@ void Disk::buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector
       if (parity > 0) {
 	lastZ = buildZ() - zHalfLength() - bigDelta() - getSmallDelta(firstDiskSmallDeltas, i+1) - getDsDistance(firstDiskDsDistances, i+1) / 2.;
 	newZ  = buildZ() - zHalfLength() + bigDelta() + getSmallDelta(firstDiskSmallDeltas, i) + getDsDistance(firstDiskDsDistances, i) / 2.;
-
-	std::cout << "OOOOOOO firstDiskSmallDeltas.size() = " << firstDiskSmallDeltas.size() << std::endl;
-
-	std::cout << "!!!!!! DISK i = " << myid() << std::endl;
-	std::cout << "!!!!!! RING i = " << i << std::endl;
-	std::cout << "parity = " << parity << std::endl;
-	std::cout << "lastZ = " << lastZ << std::endl;
-	std::cout << "last smallDelta = " << getSmallDelta(firstDiskSmallDeltas, i+1) << std::endl;
-	std::cout << "last dsDistance = " << getDsDistance(firstDiskDsDistances, i+1) << std::endl;
-	std::cout << "newZ = " << newZ << std::endl;
-	std::cout << "new small delta = " << getSmallDelta(firstDiskSmallDeltas, i) << std::endl;
-	std::cout << "new dsDistance = " << getDsDistance(firstDiskDsDistances, i) << std::endl;
-
-
       }
       else {
 	lastZ = buildZ() + zHalfLength() + bigDelta() - getSmallDelta(lastDiskSmallDeltas, i+1) - getDsDistance(lastDiskDsDistances, i+1) / 2.;
         newZ  = buildZ() + zHalfLength() - bigDelta() + getSmallDelta(lastDiskSmallDeltas, i) + getDsDistance(lastDiskDsDistances, i) / 2.;
-
-	std::cout << "OOOOOOO lastDiskSmallDeltas.size() = " << lastDiskSmallDeltas.size() << std::endl;
-
-	std::cout << "!!!!!! DISK i = " << myid() << std::endl;
-	std::cout << "!!!!!! RING i = " << i << std::endl;
-	std::cout << "parity = " << parity << std::endl;
-	std::cout << "lastZ = " << lastZ << std::endl;
-	std::cout << "last smallDelta = " << getSmallDelta(lastDiskSmallDeltas, i+1) << std::endl;
-	std::cout << "last dsDistance = " << getDsDistance(lastDiskDsDistances, i+1) << std::endl;
-	std::cout << "newZ = " << newZ << std::endl;
-	std::cout << "new small delta = " << getSmallDelta(lastDiskSmallDeltas, i) << std::endl;
-	std::cout << "new dsDistance = " << getDsDistance(lastDiskDsDistances, i) << std::endl;
-
-
-
       }
 
 
@@ -188,7 +159,6 @@ void Disk::buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector
       double nextRhoWZError   = lastRho / (lastZ - errorShiftZ) * (newZ - errorShiftZ);
 
       double nextRho = MAX(nextRhoWOverlap, nextRhoWZError);
-      std::cout << "FINALLLLLLLL nextRho " << nextRho << std::endl;
       ring->buildStartRadius(nextRho);
     }
 

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -2,6 +2,34 @@
 #include "messageLogger.h"
 #include "ConversionStation.h"
 
+const std::vector<double> Disk::getSmallDeltasFromTree() const {
+  std::vector<double> smallDeltas;
+
+  for (int i = 1; i <= numRings(); i++) {
+    Ring* ringTemplate = GeometryFactory::make<Ring>();
+    ringTemplate->store(propertyTree());
+    if (ringNode.count(i) > 0) ringTemplate->store(ringNode.at(i));
+    smallDeltas.push_back(ringTemplate->smallDelta());
+  }
+  return smallDeltas;
+}
+
+const std::vector<double> Disk::getDsDistancesFromTree() const {
+  std::vector<double> dsDistances;
+
+  for (int i = 1; i <= numRings(); i++) {
+    Ring* ringTemplate = GeometryFactory::make<Ring>();
+    ringTemplate->store(propertyTree());
+    if (ringNode.count(i) > 0) ringTemplate->store(ringNode.at(i));
+
+    RectangularModule* modTemplate = GeometryFactory::make<RectangularModule>();
+    modTemplate->store(propertyTree());
+    if (ringNode.count(i) > 0) modTemplate->store(ringNode.at(i));
+    dsDistances.push_back(modTemplate->dsDistance());
+  }
+  return dsDistances;
+}
+
 void Disk::check() {
   PropertyObject::check();
   
@@ -9,8 +37,18 @@ void Disk::check() {
   else if (!numRings.state() && !innerRadius.state()) throw PathfulException("At least one between numRings and innerRadius must be specified"); 
 }
 
-double Disk::getDsDistance(const vector<double>& buildDsDistances, int rindex) const {
-  return rindex-1 >= buildDsDistances.size() ? buildDsDistances.back() : buildDsDistances.at(rindex-1);
+double Disk::getSmallDelta(const vector<double>& diskSmallDeltas, int ringIndex) const {
+  std::cout << " ringIndex = " << ringIndex << std::endl;
+  std::cout << "diskSmallDeltas.size() = " << diskSmallDeltas.size() << std::endl;
+  if (ringIndex > diskSmallDeltas.size()) throw PathfulException("Tries to access information from ring which is not in disk.");
+  return diskSmallDeltas.at(ringIndex - 1);
+}
+
+double Disk::getDsDistance(const vector<double>& diskDsDistances, int ringIndex) const {
+  std::cout << " ringIndex = " << ringIndex << std::endl;
+  std::cout << "diskDsDistances.size() = " << diskDsDistances.size() << std::endl;
+  if (ringIndex > diskDsDistances.size()) throw PathfulException("Tries to access information from ring which is not in disk.");
+  return diskDsDistances.at(ringIndex - 1);
 }
 
 void Disk::cutAtEta(double eta) { 
@@ -24,7 +62,7 @@ void Disk::cutAtEta(double eta) {
   maxR.clear();
 }
 
-void Disk::buildBottomUp(const vector<double>& buildDsDistances) {
+/*void Disk::buildBottomUp(const vector<double>& buildDsDistances) {
 //  auto childmap = propertyTree().getChildMap<int>("Ring");
   double lastRho = 0;
   double lastSmallDelta;
@@ -34,7 +72,7 @@ void Disk::buildBottomUp(const vector<double>& buildDsDistances) {
     ring->buildDirection(Ring::BOTTOMUP);
     ring->buildCropRadius(outerRadius());
     ring->store(propertyTree());
-    if (ringNode.count(i) > 0) ring->store(ringNode.at(i)); /*childmap.count(i) > 0 ? childmap[i] : propertyTree()*/
+    if (ringNode.count(i) > 0) ring->store(ringNode.at(i)); //childmap.count(i) > 0 ? childmap[i] : propertyTree()
     if (i == 1) {
       ring->buildStartRadius(innerRadius());
     } else {
@@ -43,6 +81,8 @@ void Disk::buildBottomUp(const vector<double>& buildDsDistances) {
       double newZ  = buildZ() + (parity > 0 ? + bigDelta() : - bigDelta()) - ring->smallDelta() - getDsDistance(buildDsDistances, i)/2;  
       double lastZ = buildZ() + (parity > 0 ? - bigDelta() : + bigDelta()) + lastSmallDelta     + getDsDistance(buildDsDistances, i)/2;
       //double originZ = parity > 0 ? -zError() : +zError();
+
+
 
       // Calculate shift in Z position of extreme cases (either innemost or outermost disc)
       // Remember that disc put always in to the centre of endcap
@@ -79,9 +119,9 @@ void Disk::buildBottomUp(const vector<double>& buildDsDistances) {
     lastSmallDelta = ring->smallDelta();
   }
   numRings(rings_.size());
-}
+}*/
 
-void Disk::buildTopDown(const vector<double>& buildDsDistances) {
+void Disk::buildTopDown(const vector<double>& firstDiskSmallDeltas, const vector<double>& lastDiskSmallDeltas, const vector<double>& firstDiskDsDistances, const vector<double>& lastDiskDsDistances) {
   double lastRho;
   double lastSmallDelta;
   for (int i = numRings(), parity = -bigParity(); i > 0; i--, parity *= -1) {
@@ -89,29 +129,68 @@ void Disk::buildTopDown(const vector<double>& buildDsDistances) {
     ring->buildDirection(Ring::TOPDOWN);
     ring->store(propertyTree());
     if (ringNode.count(i) > 0) ring->store(ringNode.at(i));
+
     if (i == numRings()) {
       ring->buildStartRadius(outerRadius());
     } else {
 
-      // Calcaluate new and last position in Z
-      double newZ  = buildZ() + (parity > 0 ? + bigDelta() : - bigDelta()) + ring->smallDelta() + getDsDistance(buildDsDistances, i)/2; // CUIDADO was + smallDelta + dsDistances[nRing-1]/2;
-      double lastZ = buildZ() + (parity > 0 ? - bigDelta() : + bigDelta()) - lastSmallDelta     - getDsDistance(buildDsDistances, i+1)/2; // CUIDADO was - smallDelta - dsDistances[nRing-1]/2; // try with prevRing here
+      double lastZ, newZ;
+      // Calcalate new and last position in Z
+      if (parity > 0) {
+	lastZ = buildZ() - zHalfLength() - bigDelta() - getSmallDelta(firstDiskSmallDeltas, i+1) - getDsDistance(firstDiskDsDistances, i+1) / 2.;
+	newZ  = buildZ() - zHalfLength() + bigDelta() + getSmallDelta(firstDiskSmallDeltas, i) + getDsDistance(firstDiskDsDistances, i) / 2.;
+
+	std::cout << "OOOOOOO firstDiskSmallDeltas.size() = " << firstDiskSmallDeltas.size() << std::endl;
+
+	std::cout << "!!!!!! DISK i = " << myid() << std::endl;
+	std::cout << "!!!!!! RING i = " << i << std::endl;
+	std::cout << "parity = " << parity << std::endl;
+	std::cout << "lastZ = " << lastZ << std::endl;
+	std::cout << "last smallDelta = " << getSmallDelta(firstDiskSmallDeltas, i+1) << std::endl;
+	std::cout << "last dsDistance = " << getDsDistance(firstDiskDsDistances, i+1) << std::endl;
+	std::cout << "newZ = " << newZ << std::endl;
+	std::cout << "new small delta = " << getSmallDelta(firstDiskSmallDeltas, i) << std::endl;
+	std::cout << "new dsDistance = " << getDsDistance(firstDiskDsDistances, i) << std::endl;
+
+
+      }
+      else {
+	lastZ = buildZ() + zHalfLength() + bigDelta() - getSmallDelta(lastDiskSmallDeltas, i+1) - getDsDistance(lastDiskDsDistances, i+1) / 2.;
+        newZ  = buildZ() + zHalfLength() - bigDelta() + getSmallDelta(lastDiskSmallDeltas, i) + getDsDistance(lastDiskDsDistances, i) / 2.;
+
+	std::cout << "OOOOOOO lastDiskSmallDeltas.size() = " << lastDiskSmallDeltas.size() << std::endl;
+
+	std::cout << "!!!!!! DISK i = " << myid() << std::endl;
+	std::cout << "!!!!!! RING i = " << i << std::endl;
+	std::cout << "parity = " << parity << std::endl;
+	std::cout << "lastZ = " << lastZ << std::endl;
+	std::cout << "last smallDelta = " << getSmallDelta(lastDiskSmallDeltas, i+1) << std::endl;
+	std::cout << "last dsDistance = " << getDsDistance(lastDiskDsDistances, i+1) << std::endl;
+	std::cout << "newZ = " << newZ << std::endl;
+	std::cout << "new small delta = " << getSmallDelta(lastDiskSmallDeltas, i) << std::endl;
+	std::cout << "new dsDistance = " << getDsDistance(lastDiskDsDistances, i) << std::endl;
+
+
+
+      }
+
 
       // Calculate shift in Z position of extreme cases (either innemost or outermost disc)
       // Remember that disc put always in to the centre of endcap
-      double shiftZ = parity > 0 ? +zHalfLength() : -zHalfLength();
+      //double shiftZ = parity > 0 ? +zHalfLength() : -zHalfLength();
 
       // Calculate shift in Z due to beam spot
       double errorShiftZ   = parity > 0 ? +zError() : -zError();
 
       // Calculate next rho taking into account overlap in extreme cases of innermost or outermost disc
-      double nextRhoWOverlap  = (lastRho + rOverlap())/(lastZ - shiftZ)*(newZ - shiftZ);
+      double nextRhoWOverlap  = (lastRho + rOverlap()) / lastZ * newZ;
       // Calculate next rho taking into account overlap zError in extreme cases of innermost or outermost disc
-      double nextRhoWZError   = (lastRho)/(lastZ - shiftZ - errorShiftZ)*(newZ - shiftZ - errorShiftZ);
+      double nextRhoWZError   = lastRho / (lastZ - errorShiftZ) * (newZ - errorShiftZ);
 
       double nextRho = MAX(nextRhoWOverlap, nextRhoWZError);
       ring->buildStartRadius(nextRho);
     }
+
     ring->myid(i);
     ring->build();
     ring->translateZ(parity > 0 ? bigDelta() : -bigDelta());
@@ -126,15 +205,15 @@ void Disk::buildTopDown(const vector<double>& buildDsDistances) {
   }
 }
 
-void Disk::build(const vector<double>& buildDsDistances) {
+void Disk::build(const vector<double>& firstDiskSmallDeltas, const vector<double>& lastDiskSmallDeltas, const vector<double>& firstDiskDsDistances, const vector<double>& lastDiskDsDistances) {
   ConversionStation* conversionStation;
   materialObject_.store(propertyTree());
   materialObject_.build();
 
   try {
     logINFO(Form("Building %s", fullid(*this).c_str()));
-    if (numRings.state()) buildTopDown(buildDsDistances);
-    else buildBottomUp(buildDsDistances);
+    if (numRings.state()) buildTopDown(firstDiskSmallDeltas, lastDiskSmallDeltas, firstDiskDsDistances, lastDiskDsDistances);
+    //else buildBottomUp(buildDsDistances);
     translateZ(placeZ());
   } catch (PathfulException& pe) { pe.pushPath(fullid(*this)); throw; }
 

--- a/src/Endcap.cpp
+++ b/src/Endcap.cpp
@@ -10,7 +10,7 @@ void Endcap::cutAtEta(double eta) {
   numDisks(disks_.size());
 }
 
-vector<double> Endcap::findMaxDsDistances() { // drill down into the property trees to find the maximum dsDistance
+/*vector<double> Endcap::findMaxDsDistances() { // drill down into the property trees to find the maximum dsDistance
   vector<double> maxDsDistances; 
   double endcapDsDistance = propertyTree().get("dsDistance", 0.);
 
@@ -43,7 +43,9 @@ vector<double> Endcap::findMaxDsDistances() { // drill down into the property tr
   }
   maxDsDistances.push_back(endcapDsDistance); // adds a default element to be used in case disks need more rings than the vector specifies dsDistances for
   return maxDsDistances;
-}
+  }*/
+
+//std::vector<double>, 
 
 void Endcap::build() {
   try {
@@ -53,7 +55,10 @@ void Endcap::build() {
     if (!innerZ.state()) innerZ(barrelMaxZ() + barrelGap());
     else if(barrelGap.state()) logWARNING("'innerZ' was set, ignoring 'barrelGap'");
 
-    vector<double> maxDsDistances = findMaxDsDistances();
+    /*vector<double> maxDsDistances = findMaxDsDistances();
+    for (int i = 0; i < maxDsDistances.size(); i++) {
+      std::cout << maxDsDistances.at(i) << std::endl;
+      }*/
     vector<Disk*> tdisks;
 
     double alpha = pow(outerZ()/innerZ(), 1/double(numDisks()-1)); // geometric progression factor
@@ -73,11 +78,29 @@ void Endcap::build() {
       diskp->store(propertyTree());
       if (diskNode.count(i) > 0) diskp->store(diskNode.at(i));
 
+      std::vector<double> firstDiskSmallDeltas, firstDiskDsDistances, lastDiskSmallDeltas, lastDiskDsDistances;
+     
+      Disk* disk1 = GeometryFactory::make<Disk>();
+      disk1->myid(1);
+      disk1->store(propertyTree());
+      if (diskNode.count(1) > 0) disk1->store(diskNode.at(1));
+      firstDiskSmallDeltas = diskp->getSmallDeltasFromTree();
+      firstDiskDsDistances = diskp->getDsDistancesFromTree();
+      
+      Disk* diskL = GeometryFactory::make<Disk>();
+      diskL->myid(numDisks());
+      diskL->store(propertyTree());
+      if (diskNode.count(numDisks()) > 0) diskL->store(diskNode.at(numDisks()));
+      lastDiskSmallDeltas = diskp->getSmallDeltasFromTree();
+      lastDiskDsDistances = diskp->getDsDistancesFromTree();
+      
+      std::cout << "FOUND ITTTTTTTTT " << lastDiskSmallDeltas.size() << std::endl;
+
       // To test the extreme cases -> one needs to test either first or last layer (based on parity)
       diskp->zHalfLength((outerZ()-innerZ())/2.);
 
       // Build
-      diskp->build(maxDsDistances);
+      diskp->build(firstDiskSmallDeltas, lastDiskSmallDeltas, firstDiskDsDistances, lastDiskDsDistances);
 
       // Mirror discs
       Disk* diskn = GeometryFactory::clone(*diskp);

--- a/src/Endcap.cpp
+++ b/src/Endcap.cpp
@@ -84,17 +84,17 @@ void Endcap::build() {
       disk1->myid(1);
       disk1->store(propertyTree());
       if (diskNode.count(1) > 0) disk1->store(diskNode.at(1));
-      firstDiskSmallDeltas = diskp->getSmallDeltasFromTree();
-      firstDiskDsDistances = diskp->getDsDistancesFromTree();
+      firstDiskSmallDeltas = disk1->getSmallDeltasFromTree();
+      firstDiskDsDistances = disk1->getDsDistancesFromTree();
       
       Disk* diskL = GeometryFactory::make<Disk>();
       diskL->myid(numDisks());
       diskL->store(propertyTree());
       if (diskNode.count(numDisks()) > 0) diskL->store(diskNode.at(numDisks()));
-      lastDiskSmallDeltas = diskp->getSmallDeltasFromTree();
-      lastDiskDsDistances = diskp->getDsDistancesFromTree();
+      lastDiskSmallDeltas = diskL->getSmallDeltasFromTree();
+      lastDiskDsDistances = diskL->getDsDistancesFromTree();
       
-      std::cout << "FOUND ITTTTTTTTT " << lastDiskSmallDeltas.size() << std::endl;
+      //std::cout << "FOUND ITTTTTTTTT " << lastDiskSmallDeltas.size() << std::endl;
 
       // To test the extreme cases -> one needs to test either first or last layer (based on parity)
       diskp->zHalfLength((outerZ()-innerZ())/2.);


### PR DESCRIPTION
Modified the rings placement in TEDD, which had issues.

For a given TEDD : 

1) Vector of dsDistances (for a disk) not taken into account properly.
 For a given disk, instead of the correct vec of dsDstances, the vec of maxDsDisances was used. 

2) Vector of smallDeltas (for a disk) not taken into account properly.
For example, for OT567 , in TEDD_2 :
- Disks 1 and 2 rings radii were calculated, with the constraints that Disk 1 Ring 12 smallDelta = 7.45 (fine) and Disk 3 Ring 12 smallDelta = 7.45 (not fine).
- Disks 3 rings radii were calculated, with the constraints that Disk 1 Ring 12 smallDelta = 8.55 (not fine) and Disk 3 Ring 12 smallDelta = 8.55 (fine).
**Consequences : Disk within TEDD_2 were differnet (different radi and even different number of modules).**

NB : Very quick code, style to be improve, but results fully tested.