### PR TITLE
Solved 2 errors in TEDD phiOverlap calculation code

### DIFF
--- a/include/Disk.h
+++ b/include/Disk.h
@@ -71,7 +71,7 @@ public:
     bigDelta(    "bigDelta"   , parsedAndChecked()),
     zError(      "zError"     , parsedAndChecked()),
     zHalfLength( "zHalfLength", parsedAndChecked()),
-    rOverlap(    "rOverlap"   , parsedOnly(), 1.),
+    rOverlap(    "rOverlap"   , parsedOnly(), 0.),
     bigParity(   "bigParity"  , parsedOnly(), 1),
     buildZ(      "buildZ"     , parsedOnly()),
     placeZ(      "placeZ"     , parsedOnly()),

--- a/include/Ring.h
+++ b/include/Ring.h
@@ -139,7 +139,7 @@ class Ring : public PropertyObject, public Buildable, public Identifiable<int>, 
   double compute_d(double x, double y, double l);
   double computeTentativePhiAperture(double moduleWaferDiameter, double minRadius);
   std::pair<double, int> computeOptimalRingParametersWedge(double moduleWaferDiameter, double minRadius);
-  std::pair<double, int> computeOptimalRingParametersRectangle(double moduleWidth, double maxRadius);
+  std::pair<double, int> computeOptimalRingParametersRectangle(double moduleWidth, double highRadius);
 
   void buildModules(EndcapModule* templ, int numMods, double smallDelta);
   void buildBottomUp();

--- a/src/Ring.cpp
+++ b/src/Ring.cpp
@@ -67,10 +67,10 @@ std::pair<double, int> Ring::computeOptimalRingParametersWedge(double moduleWafe
   return std::make_pair(optimalAlpha, optimalNumMods);
 }
 
-std::pair<double, int> Ring::computeOptimalRingParametersRectangle(double moduleWidth, double maxRadius) {
-  double delta = phiOverlap()/maxRadius;
-  double optimalAlpha = 2*asin(moduleWidth/2. / maxRadius) - delta;
-  double tentativeNumMods = 2*M_PI/optimalAlpha;
+std::pair<double, int> Ring::computeOptimalRingParametersRectangle(double moduleWidth, double highRadius) {
+  double effectiveWidth = moduleWidth - phiOverlap();
+  double optimalAlpha = 2 * atan( effectiveWidth / (2. * highRadius));
+  double tentativeNumMods = 2 * M_PI/ optimalAlpha;
   int modsPerSlice = ceil(tentativeNumMods/phiSegments());
   if ((modsPerSlice % 2) == 0 && requireOddModsPerSlice()) modsPerSlice++;
   int optimalNumMods = modsPerSlice * phiSegments();


### PR DESCRIPTION
**Solved 2 errors in TEDD phiOverlap calculation code :** 

1) The modules angle coverage should be calculated with atan instead of asin.
Indeed, it is not rMax which is actually used as argument, but rHigh.
This has a non negligible effect : 
**For example, for OT567, in TEDD_2, for each disk : 4 modules more.**

2) phiOverlap/Radius was used directly as an angle, instead of atan(phiOverlap/Radius).
This doesnt seem to have important effect, at least for OT567.
(since phiOverlap/Radius very close to 0.).

Off-topic NB : Also set rOverlap to 0. by default in the code.