### PR TITLE
Avi geometry : Corrected Z of first disk in TEDD_2

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V711_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V711_200.cfg
@@ -15,7 +15,7 @@ Endcap TEDD_2 {
   phiOverlap -2
   numRings 15
   outerRadius 1100.00 // Nick 2017-02-24
-  minZ 1854.67    // Disk 1
+  minZ 1853.400    // Disk 1
   Disk 2 { placeZ 1937.67 }
   maxZ 2650.000   // Disk 3
   bigParity 1


### PR DESCRIPTION
Avi geometry : Corrected the Z of disk 1 in TEDD_2.
It is now equal to the Z of disk 1 in TEDD_2, in layouts OT611 and OT612.

WARNING : How was the Z of disk 2 in TEDD_2  calculated in the Avi geometry ?
If it was defined relative to disk 1, maybe it needs to be shifted as well ?