### PR TITLE
Added Avi geometry with new Macro Pixel length

### DIFF
--- a/geometries/CMS_Phase2/OT712_200_IT4025.cfg
+++ b/geometries/CMS_Phase2/OT712_200_IT4025.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V712_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_5.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V712_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V712_200.cfg
@@ -1,0 +1,28 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V712_200.cfg
+  @include TB2S_V460_200.cfg
+  @include TEDD1_V712_200.cfg
+  @include TEDD2_V712_200.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V712_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V712_200.cfg
@@ -1,0 +1,237 @@
+// Tilted barrel version 3.6.6
+// By Stefano 2017-02-07
+// Including update of flat stave thickness from CML's step file
+// and Kamil's 12-th ring in Layer 1
+
+Barrel TBPS {
+  barrelRotation 1.5707963268
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
+  @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS
+
+  numLayers 3
+  startZMode modulecenter
+
+  //////////////////////////
+  /// FLAT PART GEOMETRY ///
+  //////////////////////////
+  bigDelta 11.9 // as in 3.6.5 
+  Layer 1 { smallDelta 3.5625 } // Incorporating CML new plank thickness (3.54mm)
+  Layer 2,3 { smallDelta 3.47 } // Incorporating CML new plank thickness (4.35mm)
+  radiusMode fixed
+  innerRadius 233 // as in 3.6.5 
+  Layer 2 { placeRadiusHint 341.2 } // to make the pair with layer 1 (paired-style)
+  outerRadius 514 // as in 3.6.5
+  // NB : for the z placement of modules within the flat part, the most stringent of zError and zOverlap is used
+
+
+  ////////////////////////////
+  /// TILTED PART GEOMETRY ///
+  ////////////////////////////
+  Layer 1 {
+    isTilted true
+    isTiltedAuto true
+    numModulesFlat 4
+    numModulesTilted 12
+
+    numRods 18
+
+    Ring 5-7 {
+      ringInnerRadius 252.0
+      ringOuterRadius 265.0
+      tiltAngle 47.0
+      theta_g 53.0
+    }
+    Ring 8-11 {
+      ringInnerRadius 249.0
+      ringOuterRadius 259.0
+      tiltAngle 60.0
+      theta_g 40.0
+    }
+    Ring 12-16 {
+      ringInnerRadius 248.0
+      ringOuterRadius 254.0
+      tiltAngle 74.0
+      theta_g 26.0
+    }
+	
+    Ring 5 { ringInnerZ 172.095 }
+    Ring 6 { ringInnerZ 217.117555375977 }
+    Ring 7 { ringInnerZ 267.987493974773 }
+    Ring 8 { ringInnerZ 315.183730978894 }
+    Ring 9 { ringInnerZ 374.20347865732 }
+    Ring 10 { ringInnerZ 443.696419634989 }
+    Ring 11 { ringInnerZ 526.772375745374 }
+    Ring 12 { ringInnerZ 611.086871295854 }
+    Ring 13 { ringInnerZ 720.246008926701 }
+    Ring 14 { ringInnerZ 850.617005751578 }
+    Ring 15 { ringInnerZ 1004.2048784789 }
+    Ring 16 { ringInnerZ 1182.332 }
+    
+  }
+
+  //////////////////
+  /// FULL LAYER ///
+  //////////////////
+  Layer 1 {
+    Ring 1-6 { triggerWindow 5 }
+    Ring 7   { triggerWindow 4 }
+    Ring 8-9 { triggerWindow 5 }
+    Ring 10-11 { triggerWindow 4 }
+    Ring 12-13 { triggerWindow 3 }
+    Ring 14-15 { triggerWindow 2 }
+    Ring 1-3 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_flat_200_26
+      dsDistance 2.6
+    }
+    Ring 4 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_lastFlat_200_26
+      dsDistance 2.6
+    }
+    Ring 5-7 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_tilted_200_26
+      dsDistance 2.6
+    }
+    Ring 8-16 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L1_tilted_200_40
+      dsDistance 4.0
+    }
+  }
+
+
+  ////////////////////////////
+  /// TILTED PART GEOMETRY ///
+  ////////////////////////////
+  Layer 2 {
+    isTilted true
+    isTiltedAuto true
+    numModulesFlat 6
+    numModulesTilted 12
+
+    numRods 26
+
+    Ring 7-9 {
+      ringInnerRadius 354
+      ringOuterRadius 367
+      tiltAngle 42.0
+      theta_g 58.0
+    }
+    Ring 10-13 {
+      ringInnerRadius 352
+      ringOuterRadius 361
+      tiltAngle 57.0
+      theta_g 43.0
+    }
+
+    Ring 14-18 {
+      ringInnerRadius 351
+      ringOuterRadius 358
+      tiltAngle 69.0
+      theta_g 31.0
+    }
+    
+    Ring 7 { ringInnerZ 269.761 }
+    Ring 8 { ringInnerZ 320.670 }
+    Ring 9 { ringInnerZ 376.368 }
+    Ring 10 { ringInnerZ 428.580 }
+    Ring 11 { ringInnerZ 491.921 }
+    Ring 12 { ringInnerZ 562.657 }
+    Ring 13 { ringInnerZ 641.442 }
+    Ring 14 { ringInnerZ 721.143 }
+    Ring 15 { ringInnerZ 816.971 }
+    Ring 16 { ringInnerZ 924.978 }
+    Ring 17 { ringInnerZ 1047.990 }
+    Ring 18 { ringInnerZ 1184.636 } 
+    
+  }
+
+  //////////////////
+  /// FULL LAYER ///
+  //////////////////
+  Layer 2 {
+    Ring 1-11 { triggerWindow 5 }
+    Ring 12-13 { triggerWindow 4 }
+    Ring 14-18 { triggerWindow 7 }
+    Ring 1-5 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_flat_200_16
+      dsDistance 1.6
+    }
+    Ring 6 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_lastFlat_200_16
+      dsDistance 1.6
+    }
+    Ring 7-13 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_tilted_200_26
+      dsDistance 2.6
+    }
+    Ring 14-18 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L2_tilted_200_40
+      dsDistance 4.0
+    }
+  }
+
+
+  ////////////////////////////
+  /// TILTED PART GEOMETRY ///
+  ////////////////////////////
+  Layer 3 {
+    isTilted true
+    isTiltedAuto true
+    numModulesFlat 8
+    numModulesTilted 12
+
+    numRods 36
+
+    Ring 9-14 {
+      ringInnerRadius 524.5
+      ringOuterRadius 536.5
+      tiltAngle 44.0
+      theta_g 56.0
+    }
+    Ring 15-20 {
+      ringInnerRadius 522.5
+      ringOuterRadius 530.5
+      tiltAngle 60.0
+      theta_g 40.0
+    }
+	
+    Ring 9 { ringInnerZ 363.047 }
+    Ring 10 { ringInnerZ 416.15185191988 }
+    Ring 11 { ringInnerZ 472.683945879186 }
+    Ring 12 { ringInnerZ 533.009172527907 }
+    Ring 13 { ringInnerZ 597.235907085741 }
+    Ring 14 { ringInnerZ 665.108622658538 }
+    Ring 15 { ringInnerZ 727.825064017101 }
+    Ring 16 { ringInnerZ 804.833114622754 }
+    Ring 17 { ringInnerZ 888.178629910538 }
+    Ring 18 { ringInnerZ 978.285168078537 }
+    Ring 19 { ringInnerZ 1075.16863741588 }
+    Ring 20 { ringInnerZ 1179.356 }
+    
+  }
+
+  //////////////////
+  /// FULL LAYER ///
+  //////////////////
+  Layer 3 {
+    Ring 1-8 { triggerWindow 7 }
+    Ring 9-10 { triggerWindow 8 }
+    Ring 11-13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 6 }
+    Ring 15 { triggerWindow 6 }
+    Ring 16-20 { triggerWindow 5 }
+    Ring 21 { triggerWindow 4 }
+    Ring 1-7 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L3_flat_200_16
+      dsDistance 1.6
+    }
+    Ring 8 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L3_lastFlat_200_16
+      dsDistance 1.6
+    }
+    Ring 9-20 {
+      @includestd CMS_Phase2/OuterTracker/Materials/Tilted/TBPS_L3_tilted_200_26
+      dsDistance 2.6
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V712_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V712_200.cfg
@@ -1,0 +1,111 @@
+Endcap TEDD_1 {
+  smallParity 1
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1_TEDD_1.cfg
+
+  // Layout construction parameters
+  // zError 139.5
+  zError 0
+
+  zOverlap 0
+  rOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.15 // NICK 2017-03-17 corresponding to moving ring 10 to its nominal z position
+  smallDelta 7.42 // PS NICK 2017
+  phiSegments 4
+  numDisks 2
+  phiOverlap -2 // which saves 4 modules in ring 6 
+  numRings 15
+  outerRadius 1100.00 // Nick 2017-02-24
+  minZ 1311.800
+  maxZ 1395.800
+  bigParity 1
+  
+  Ring 15 { ringOuterRadius 1100.000 }
+  Ring 14 { ringOuterRadius 1032.765 }
+  Ring 13 { ringOuterRadius 923.694 }
+  Ring 12 { ringOuterRadius 850.306 }
+  Ring 11 { ringOuterRadius 742.595 }
+  Ring 10 { ringOuterRadius 659.981 }
+  Ring 9 { ringOuterRadius 604.591 }
+  Ring 8 { ringOuterRadius 577.117 }
+  Ring 7 { ringOuterRadius 526.011 }
+  Ring 6 { ringOuterRadius 495.661 }
+  Ring 5 { ringOuterRadius 445.051 }
+  Ring 4 { ringOuterRadius 411.739 }
+  Ring 3 { ringOuterRadius 361.639 }
+  Ring 2 { ringOuterRadius 325.275 }
+  Ring 1 { ringOuterRadius 275.701 }
+
+  alignEdges false
+  moduleShape rectangular
+  Ring 1-10 {
+    smallDelta 7.42
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
+    @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+  }
+  Ring 11 { // maybe 1.8 is better here
+    smallDelta 7.45
+    dsDistance 1.8
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  }
+  Ring 12-15 {
+    smallDelta 7.45       
+    dsDistance 1.8
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  }
+
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+  
+  Disk 1 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 3 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 6 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 8 }
+    Ring 10 { triggerWindow 10 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 9 }
+    Ring 14 { triggerWindow 11 }
+    Ring 15 { triggerWindow 12 }
+  }
+  
+  Disk 2 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 7 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 9 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 8 }
+    Ring 14 { triggerWindow 10 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)      
+  Disk 1-2 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V712_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V712_200.cfg
@@ -1,0 +1,145 @@
+Endcap TEDD_2 {
+
+  smallParity 1
+  // Layout construction parameters
+  zError 0
+  zOverlap 0
+  rOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.15 // NICK 2017-03-17 corresponding to moving ring 10 to its nominal z position
+  smallDelta 7.42 // PS NICK 2017
+  phiSegments 4
+  numDisks 3
+  phiOverlap -2
+  numRings 15
+  outerRadius 1100.00 // Nick 2017-02-24
+  minZ 1853.400   // Disk 1
+  Disk 2 { placeZ 1937.67 }
+  maxZ 2650.000   // Disk 3
+  bigParity 1
+  
+  Ring 15 { ringOuterRadius 1100.000 }
+  Ring 14 { ringOuterRadius 1021.566 }
+  Ring 13 { ringOuterRadius 914.543 }
+  Ring 12 { ringOuterRadius 831.550 }
+  Ring 11 { ringOuterRadius 726.567 }
+  Ring 10 { ringOuterRadius 639.434 }
+  Ring 9 { ringOuterRadius 587.563 }
+  Ring 8 { ringOuterRadius 552.730 }
+  Ring 7 { ringOuterRadius 502.168 }
+  Ring 6 { ringOuterRadius 465.136 }
+  Ring 5 { ringOuterRadius 414.885 }
+  Ring 4 { ringOuterRadius 375.604 }
+  Ring 3 { ringOuterRadius 361.639 }
+  Ring 2 { ringOuterRadius 325.275 }
+  Ring 1 { ringOuterRadius 275.701 }
+
+  Ring 3 { removeModule true }
+  Ring 2 { removeModule true }
+  Ring 1 { removeModule true }
+
+  alignEdges false
+  moduleShape rectangular
+  Ring 1-10 {
+    smallDelta 7.42
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
+    @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+  }
+  Ring 11 {
+    smallDelta 8.55
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+  }
+  Disk 1-2 {
+    Ring 12-15 {
+      smallDelta 7.45
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+  }
+  Disk 3 {
+    Ring 12 {
+      smallDelta 8.55
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 13-15 {
+      smallDelta 7.45
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+  }
+
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+
+  Disk 1 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 8 }
+    Ring 11 { triggerWindow 10 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 9 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  Disk 2 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 7 }
+    Ring 11 { triggerWindow 9 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 8 }
+    Ring 15 { triggerWindow 9 }
+  }
+
+  Disk 3 {
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 3 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 5 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 6 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 8 }
+    Ring 13 { triggerWindow 6 }
+    Ring 14 { triggerWindow 7 }
+    Ring 15 { triggerWindow 8 }
+  }
+ 
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)
+  Disk 1-3 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}


### PR DESCRIPTION
611 (TDR layout with 'old' macro-pixel length)
612 (TDR layout with new macro-pixel length)
711 (Avi geometry with 'old' macro-pixel length)
712 (Avi geometry with new macro-pixel length)

Created  Avi geometry with new Macro Pixel length. It is called OT712.

TEDD : 
Kept same radii as 612, but with the Z that appear in 711.

TBPS : 
Layers 1 and 3 : Identical to 612.
Layer 2 : Used the same optimization process as performed for 611 -> 612.



NB : 
'Old' macro pixel-length : 32 x 1446 μm
'New' macro pixel-length : 32 x 1467 (= 46944 μm)