### PR TITLE
New 6.1.3 geometry with correct DD separation

### DIFF
--- a/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
@@ -10,9 +10,7 @@ zCorrelation samesegment
 
 numSensors 2
 
-powerStripChip 0
-powerModuleChip 6300 
-powerModuleOptical 0
+powerPerModule 6300 
 
 sensorThickness 0.2
 

--- a/geometries/CMS_Phase2/OT613_200_IT4025.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT4025.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_5.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V613_200.cfg
@@ -1,0 +1,28 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+  
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V612_200.cfg
+  @include TB2S_V360_200.cfg
+  @include TEDD1_V613_200.cfg
+  @include TEDD2_V613_200.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V612_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V612_200.cfg
@@ -3,9 +3,7 @@ Endcap TEDD_1 {
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1_TEDD_1.cfg
 
   // Layout construction parameters
-  // zError 139.5
   zError 0
-  // Ring 1-7 { ringGap -1.75 } // $$$$$$$$$$$$$$$$$4
   zOverlap 0
   rOverlap 0
   etaCut 10

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -1,0 +1,109 @@
+Endcap TEDD_1 {
+  smallParity 1
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD_V3_5_1_TEDD_1.cfg
+
+  // Layout construction parameters
+  zError 0
+  zOverlap 0
+  rOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
+  smallDelta 7.42 // PS NICK 2017
+  phiSegments 4
+  numDisks 2
+  phiOverlap -2 // which saves 4 modules in ring 6 
+  numRings 15
+  outerRadius 1100.00 // Nick 2017-02-24
+  minZ 1311.80 // Stefano&Duccio 2017-03-17 reducing clearance from 20 mm to 5 mm
+  maxZ 1550.00
+  bigParity 1
+
+  Ring 15 { ringOuterRadius 1100 }
+  Ring 14 { ringOuterRadius 1032.765 }
+  Ring 13 { ringOuterRadius 923.694 }
+  Ring 12 { ringOuterRadius 850.306 }
+  Ring 11 { ringOuterRadius 742.595 }
+  Ring 10 { ringOuterRadius 659.981 }
+  Ring 9 { ringOuterRadius 604.591 }
+  Ring 8 { ringOuterRadius 577.117 }
+  Ring 7 { ringOuterRadius 526.011 }
+  Ring 6 { ringOuterRadius 495.661 }
+  Ring 5 { ringOuterRadius 445.051 }
+  Ring 4 { ringOuterRadius 411.739 }
+  Ring 3 { ringOuterRadius 361.639 }
+  Ring 2 { ringOuterRadius 325.275 }
+  Ring 1 { ringOuterRadius 275.701 }
+
+  alignEdges false
+  moduleShape rectangular
+  Ring 1-10 {
+    smallDelta 7.42
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
+    @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+  }
+  Ring 11 { // maybe 1.8 is better here
+    smallDelta 7.45
+    dsDistance 1.8
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  }
+  Ring 12-15 {
+    smallDelta 7.45       
+    dsDistance 1.8
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+  }
+
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+  
+  Disk 1 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 3 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 6 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 8 }
+    Ring 10 { triggerWindow 10 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 9 }
+    Ring 14 { triggerWindow 11 }
+    Ring 15 { triggerWindow 12 }
+  }
+  
+  Disk 2 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 7 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 9 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 8 }
+    Ring 14 { triggerWindow 10 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)      
+  Disk 1-2 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V612_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V612_200.cfg
@@ -20,7 +20,6 @@ Endcap TEDD_2 {
   maxZ 2650.000
   bigParity 1
 
-  // Ring 1-9 { ringGap -1.4 } // ##############
   Ring 1-8   { ringGap 1.816 } //
   Ring 9     { ringGap 2.816 } // To avoid clash of ring 9 to 11
   Ring 10    { ringGap 3.158 } // To avoid clash of ring 9 to 11

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -1,0 +1,141 @@
+Endcap TEDD_2 {
+
+  smallParity 1
+  // Layout construction parameters
+  zError 0
+  zOverlap 0
+  rOverlap 0
+  etaCut 10
+  smallParity 1
+  trackingTags trigger,tracker
+  bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
+  smallDelta 7.42 // PS NICK 2017
+  phiSegments 4
+  numDisks 3
+  phiOverlap -2
+  numRings 15
+  outerRadius 1100.00 // Nick 2017-02-24
+  minZ 1853.400
+  Disk 2 { placeZ 2216.190 }
+  maxZ 2650.000
+  bigParity 1
+
+  Ring 15 { ringOuterRadius 1100 }
+  Ring 14 { ringOuterRadius 1021.566 }
+  Ring 13 { ringOuterRadius 914.543 }
+  Ring 12 { ringOuterRadius 831.55 }
+  Ring 11 { ringOuterRadius 726.567 }
+  Ring 10 { ringOuterRadius 639.434 }
+  Ring 9 { ringOuterRadius 587.563 }
+  Ring 8 { ringOuterRadius 552.73 }
+  Ring 7 { ringOuterRadius 502.168 }
+  Ring 6 { ringOuterRadius 465.136 }
+  Ring 5 { ringOuterRadius 414.885 }
+  Ring 4 { ringOuterRadius 375.604 }
+  Ring 3 { removeModule true }
+  Ring 2 { removeModule true }
+  Ring 1 { removeModule true }
+
+  alignEdges false
+  moduleShape rectangular
+  Ring 1-10 {
+    smallDelta 7.42
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
+    @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40
+  }
+  Ring 11 {
+    smallDelta 8.55
+    dsDistance 4.0
+    @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+    @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+  }
+  Disk 1-2 {
+    Ring 12-15 {
+      smallDelta 7.45
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+  }
+  Disk 3 {
+    Ring 12 {
+      smallDelta 8.55
+      dsDistance 4.0
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_40
+    }
+    Ring 13-15 {
+      smallDelta 7.45
+      dsDistance 1.8
+      @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
+      @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18
+    }
+  }
+
+  @includestd CMS_Phase2/OuterTracker/Materials/disk
+  @includestd CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+
+  Disk 1 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 8 }
+    Ring 11 { triggerWindow 10 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 9 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  Disk 2 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 7 }
+    Ring 11 { triggerWindow 9 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 8 }
+    Ring 15 { triggerWindow 9 }
+  }
+
+  Disk 3 {
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 3 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 5 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 6 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 8 }
+    Ring 13 { triggerWindow 6 }
+    Ring 14 { triggerWindow 7 }
+    Ring 15 { triggerWindow 8 }
+  }
+ 
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)
+  Disk 1-3 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -177,4 +177,14 @@ OT711_200_IT4025.cfg                      Like 6.1.1 TDR geometry but with paire
 
 
                                           
+OT612_200_IT4025.cfg	Like 6.1.1 but with slightly larger PS modules
+
+OT613_200_IT4025.cfg	Like 6.1.2 but fixing bigDelta according to Nick 2017-03-27
+                         Zd=29.7mm or bigDelta=14.85
+                         New geometry 6.1.3 with slight adjustment in TEDD1 and TEDD2: bigDeelta moved from 14.15mm to 14.85mm
+                         this would cause a movement of 1.243mm and 1.351mm in innermost rings of TEDD1 and TEDD2 respectively
+                         and add 4 modules in one ring of TEDD2.
+                        Any ring movement was instead *avoided* by constraining the ring radii to those of 6.1.2, so that the geometry in the
+                        xy plane is exactly the same
+
 


### PR DESCRIPTION
OT613_200_IT4025.cfg	Like 6.1.2 but fixing bigDelta according to Nick 2017-03-27
                         Zd=29.7mm or bigDelta=14.85
                         New geometry 6.1.3 with slight adjustment in TEDD1 and TEDD2: bigDeelta moved from 14.15mm to 14.85mm
                         this would cause a movement of 1.243mm and 1.351mm in innermost rings of TEDD1 and TEDD2 respectively
                         and add 4 modules in one ring of TEDD2.
                        Any ring movement was instead *avoided* by constraining the ring radii to those of 6.1.2, so that the geometry in the
                        xy plane is exactly the same
