### PR TITLE
Single hit efficiency is per-module

### DIFF
--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -80,6 +80,7 @@ public:
   ReadonlyProperty<ZCorrelation, NoDefault> zCorrelation;
   ReadonlyProperty<ReadoutMode, Default> readoutMode;
   ReadonlyProperty<ReadoutType, Default> readoutType;
+  ReadonlyProperty<double, Default> singleHitEfficiency;
 
   ReadonlyProperty<int, Default> triggerWindow;
 
@@ -125,6 +126,7 @@ public:
       numSensors               ("numSensors"               , parsedOnly()),
       sensorLayout             ("sensorLayout"             , parsedOnly() , NOSENSORS),
       readoutType              ("readoutType"              , parsedOnly() , READOUT_STRIP), 
+      singleHitEfficiency      ("singleHitEfficiency"      , parsedOnly() , 1.),
       readoutMode              ("readoutMode"              , parsedOnly() , BINARY),
       zCorrelation             ("zCorrelation"             , parsedOnly()),
       numSparsifiedHeaderBits  ("numSparsifiedHeaderBits"  , parsedOnly()),

--- a/include/Hit.hh
+++ b/include/Hit.hh
@@ -217,7 +217,7 @@ public:
   int nActiveHits(bool usePixels = false, bool useIP = true) const;
   std::vector<double> hadronActiveHitsProbability(bool usePixels = false);
   double hadronActiveHitsProbability(int nHits, bool usePixels = false);
-  void addEfficiency(double efficiency, bool alsoPixel = false);
+  void addEfficiency();
   void keepTriggerOnly();
   void keepTaggedOnly(const string& tag);
   void setTriggerResolution(bool isTrigger);

--- a/include/SimParms.hh
+++ b/include/SimParms.hh
@@ -33,9 +33,6 @@ public:
   ReadonlyProperty<int, NoDefault> ptCost;
   ReadonlyProperty<int, NoDefault> stripCost;
 
-  ReadonlyProperty<double, NoDefault> efficiency;
-  ReadonlyProperty<double, NoDefault> pixelEfficiency;
-
   ReadonlyProperty<double, NoDefault> triggerEtaCut;
   ReadonlyProperty<double, NoDefault> triggerPtCut;
   ReadonlyProperty<int, NoDefault> numTriggerTowersEta, numTriggerTowersPhi;

--- a/include/TrackNew.hh
+++ b/include/TrackNew.hh
@@ -71,7 +71,7 @@ public:
   void addIPConstraint(double dr, double dz);
 
   //! Simulate efficiency by changing some active hits to non-active hits (passive)
-  void addEfficiency(double efficiency);
+  void addEfficiency();
 
   //! Set track polar angle - theta, azimuthal angle - phi, particle transverse momentum - pt (signed: + -> particle in-out, - -> particle out-in)
   const Polar3DVector& setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -135,7 +135,6 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
 				       MaterialBudget* pm) {
 
   auto& simParms = SimParms::getInstance();
-  double efficiency = simParms.efficiency();
 
   materialTracksUsed = etaSteps;
 
@@ -209,7 +208,7 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
         //track.sort();
         //track.setTriggerResolution(true); // TODO: remove this (?)
 
-        if (efficiency!=1) track.addEfficiency(efficiency);
+        track.addEfficiency();
         // For each momentum/transverse momentum compute the tracks error
         for (const auto& pIter : momenta ) {
           int    parameter = pIter/Units::MeV; // Store p or pT in MeV as int (key to the map)
@@ -331,7 +330,6 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
                                           int etaSteps) {
 
     auto& simParms = SimParms::getInstance();
-    double efficiency = simParms.efficiency();
 
     materialTracksUsed = etaSteps;
 
@@ -371,7 +369,7 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
 
         // std::cerr << " material after = " << track.getCorrectedMaterial().radiation << std::endl;
 
-        if (efficiency!=1) track.addEfficiency(efficiency, false);
+        track.addEfficiency();
         if (track.nActiveHits(true)>0) { // At least 3 points are needed to measure the arrow
           tv.push_back(track);
         }    
@@ -879,8 +877,6 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
                                      MaterialBudget* pm) {
 
   Tracker& tracker = mb.getTracker();
-  double efficiency = SimParms::getInstance().efficiency();
-  double pixelEfficiency = SimParms::getInstance().pixelEfficiency();
   materialTracksUsed = etaSteps;
   int nTracks;
   double etaStep, eta, theta, phi;
@@ -1080,8 +1076,8 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
     track.addHit(hit);
     if (!track.noHits()) {
       track.sort();
-      if (efficiency!=1) track.addEfficiency(efficiency, false);
-      if (pixelEfficiency!=1) track.addEfficiency(efficiency, true);
+      track.addEfficiency();
+      track.addEfficiency();
 
       // @@ Hadrons
       int nActive = track.nActiveHits();

--- a/src/Hit.cc
+++ b/src/Hit.cc
@@ -930,8 +930,10 @@ void Track::addEfficiency() {
   for (std::vector<Hit*>::iterator it = hitV_.begin(); it!=hitV_.end(); ++it) {
     if ((*it)->getObjectKind() == Hit::Active) {
       double efficiency = (*it)->getHitModule()->singleHitEfficiency();
-      if ((double(random())/RAND_MAX) > efficiency) { // This hit is LOST
-	(*it)->setObjectKind(Hit::Inactive);
+      if (efficiency!=1) {
+        if ((double(random())/RAND_MAX) > efficiency) { // This hit is LOST
+          (*it)->setObjectKind(Hit::Inactive);
+        }
       }
     }
   }

--- a/src/Hit.cc
+++ b/src/Hit.cc
@@ -926,18 +926,12 @@ void Track::print() {
  * @param efficiency the modules active fraction
  * @param alsoPixel true if the efficiency removal applies to the pixel hits also
  */
-void Track::addEfficiency(double efficiency, bool pixel /* = false */ ) {
+void Track::addEfficiency() {
   for (std::vector<Hit*>::iterator it = hitV_.begin(); it!=hitV_.end(); ++it) {
     if ((*it)->getObjectKind() == Hit::Active) {
-      if ((pixel)&&(*it)->isPixel()) {
-	if ((double(random())/RAND_MAX) > efficiency) { // This hit is LOST
-	  (*it)->setObjectKind(Hit::Inactive);
-	}
-      }
-      if ((!pixel)&&(!(*it)->isPixel())) {
-	if ((double(random())/RAND_MAX) > efficiency) { // This hit is LOST
-	  (*it)->setObjectKind(Hit::Inactive);
-	}
+      double efficiency = (*it)->getHitModule()->singleHitEfficiency();
+      if ((double(random())/RAND_MAX) > efficiency) { // This hit is LOST
+	(*it)->setObjectKind(Hit::Inactive);
       }
     }
   }

--- a/src/SimParms.cc
+++ b/src/SimParms.cc
@@ -21,8 +21,6 @@ SimParms::SimParms() :
     useIPConstraint("useIPConstraint", parsedAndChecked()),
     ptCost("ptCost", parsedAndChecked()),
     stripCost("stripCost", parsedAndChecked()),
-    efficiency("efficiency", parsedAndChecked()),
-    pixelEfficiency("pixelEfficiency", parsedAndChecked()),
     triggerEtaCut("triggerEtaCut", parsedAndChecked()),
     triggerPtCut("triggerPtCut", parsedAndChecked()),
     numTriggerTowersEta("numTriggerTowersEta", parsedAndChecked()),

--- a/src/TrackNew.cc
+++ b/src/TrackNew.cc
@@ -487,10 +487,9 @@ void TrackNew::addIPConstraint(double dr, double dz) {
 //
 // Simulate efficiency by changing some active hits to non-active hits (passive)
 //
-void TrackNew::addEfficiency(double efficiency) {
-
+void TrackNew::addEfficiency() {
   for (auto& iHit : m_hits) {
-
+    double efficiency = iHit->getHitModule()->singleHitEfficiency();
     if (iHit->isActive()) {
       if ((double(random())/RAND_MAX)>efficiency) iHit->setAsPassive(); // This hit is LOST
     }

--- a/src/TrackNew.cc
+++ b/src/TrackNew.cc
@@ -489,9 +489,11 @@ void TrackNew::addIPConstraint(double dr, double dz) {
 //
 void TrackNew::addEfficiency() {
   for (auto& iHit : m_hits) {
-    double efficiency = iHit->getHitModule()->singleHitEfficiency();
     if (iHit->isActive()) {
-      if ((double(random())/RAND_MAX)>efficiency) iHit->setAsPassive(); // This hit is LOST
+      double efficiency = iHit->getHitModule()->singleHitEfficiency();
+      if (efficiency!=1) {
+        if ((double(random())/RAND_MAX)>efficiency) iHit->setAsPassive(); // This hit is LOST
+      }
     }
   }
 }


### PR DESCRIPTION
In order to accurately study the effect of single-hit inefficiency, this was made a module-parameter

Surprisingly, this made the code run a little faster: on my laptop running with 3000 tracks on CMS-OT6.1.3-IT4.0.2.5 takes 139.7s instead of 144.5s with 95% single-hit efficiency and 112.5s instead of 117.4s for 50% single-hit efficiency.

Validation: the results are not comparable for 50% efficiency (the random effect is too large) but are compatible for 95% efficiency.

Using this patch a bug was cured: the previous parameter named efficiency was affecting the pixels too and I am not sure what efficiencyPixel was actually doing (I only noticed when trying to compare with the new behaviour). Furthermore these two parameters (which used to be in SimParms) were not designed according to the current paradigm of flexibility in properties.