### PR TITLE
adding 50x50 configs

### DIFF
--- a/geometries/CMS_Phase2/OT_Tilted_362_200_Pixel_4021_5050.cfg
+++ b/geometries/CMS_Phase2/OT_Tilted_362_200_Pixel_4021_5050.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V362_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_1_5050.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_2_1_5050.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_2_1_5050.cfg
@@ -1,0 +1,68 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 7
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 333.15 }
+    Disk 3 { placeZ 443.95 }
+    Disk 4 { placeZ 591.61 }
+    Disk 5 { placeZ 788.37 }
+    Disk 6 { placeZ 1050.58 }
+    Disk 7 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_0_1_5050.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_0_1_5050.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2650
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1850.00 }
+    Disk 2 { placeZ 2085.43 }
+    Disk 3 { placeZ 2350.83 }
+    Disk 4 { placeZ 2650.00 }
+
+    Disk 1 { destination FPIX8 }
+    Disk 2 { destination FPIX9 }
+    Disk 3 { destination FPIX10 }
+    Disk 4 { destination FPIX11 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_1_5050.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_1_5050.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  phiSegments 4
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include BPIX_4_0_0.cfg
+  @include FPIX1_4_0_2_1_5050.cfg
+  @include FPIX2_4_0_0_1_5050.cfg
+
+}


### PR DESCRIPTION
The only changes relative to dev_gabie should be the addition of four config files describing a pixel detector with 50x50 pixels instead of 25x100.  These are based off of OT_Tilted_362_200_Pixel_4021 rather than one of the newer layouts.