### PR TITLE
Xml export : automatization of latest updates

### DIFF
--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -199,7 +199,7 @@ namespace insur {
     static const std::string xml_PX_fileident = "pixel";
     static const std::string xml_pixbar = "PixelBarrel";
     static const std::string xml_OT_bar = "Phase2OTBarrel";
-    static const std::string xml_PX_bar = "Phase1PixelBarrel";
+    static const std::string xml_PX_bar = "Phase2PixelBarrel";
     static const std::string xml_pixfwd = "PixelForward"; 
     static const std::string xml_OT_fwd = "Phase2OTForward";
     static const std::string xml_PX_fwd = "Phase2PixelEndcap";
@@ -254,7 +254,7 @@ namespace insur {
     static const std::string xml_par_tail = "Par";
     static const std::string xml_reco = "TrackerRecMaterial";
     static const std::string xml_OT_reco_layer_name = "Phase2OTBarrelLayer";
-    static const std::string xml_PX_reco_layer_name = "Phase1PixelBarrelLayer";
+    static const std::string xml_PX_reco_layer_name = "Phase2PixelBarrelLayer";
     static const std::string xml_OT_reco_disc_name = "Phase2OTForwardDisk";
     static const std::string xml_PX_reco_disc_name = "Phase2PixelForwardDisk";
     static const std::string xml_forward = "Fw";
@@ -273,10 +273,10 @@ namespace insur {
 
 
     static const std::string xml_OT_topo_barrel_name = "Phase2OTBarrelSubDet";
-    static const std::string xml_PX_topo_barrel_name = "Phase1PixelBarrel";
+    static const std::string xml_PX_topo_barrel_name = "Phase2PixelBarrel";
 
     static const std::string xml_OT_topo_barrel_value = "Phase2OTBarrel";
-    static const std::string xml_PX_topo_barrel_value = "PixelPhase1Barrel";
+    static const std::string xml_PX_topo_barrel_value = "PixelPhase2Barrel";
 
     static const std::string xml_OT_topo_layer_name = "OuterTrackerPixelBarrelLayer";
     static const std::string xml_PX_topo_layer_name = "PixelBarrelLayer";
@@ -285,7 +285,7 @@ namespace insur {
     static const std::string xml_PX_topo_layer_value = xml_PX_topo_layer_name;
    
     static const std::string xml_OT_topo_straight_rod_name = "OuterTrackerPixelBarrelLadder";
-    static const std::string xml_PX_topo_straight_rod_name = "Phase1PixelBarrelRod";
+    static const std::string xml_PX_topo_straight_rod_name = "Phase2PixelBarrelRod";
    
     static const std::string xml_OT_topo_straight_rod_value = "PixelBarrelLadder";
     static const std::string xml_PX_topo_straight_rod_value = "PixelBarrelLadder";

--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -259,9 +259,11 @@ namespace insur {
     static const std::string xml_PX_reco_disc_name = "Phase2PixelForwardDisk";
     static const std::string xml_forward = "Fw";
     static const std::string xml_backward = "Bw";
-    static const std::string xml_places_unflipped_mod_in_rod = "RODTOMODULE";
-    static const std::string xml_places_flipped_mod_in_rod = "RODTOFLIPPEDMODULE";
-    static const std::string xml_flip_mod_rot = "FLIP"; 
+    static const std::string xml_OT_places_unflipped_mod_in_rod = "OUTERTRACKERRODTOMODULE";
+    static const std::string xml_OT_places_flipped_mod_in_rod = "OUTERTRACKERRODTOFLIPPEDMODULE";
+    static const std::string xml_PX_places_unflipped_mod_in_rod = "INNERTRACKERRODTOMODULE";
+    static const std::string xml_PX_places_flipped_mod_in_rod = "INNERTRACKERRODTOFLIPPEDMODULE";
+    static const std::string xml_Y180 = "Y180"; 
     static const std::string xml_endcap_rot = "EndcapRot";
     /**
      * CMSSW constants

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -69,31 +69,58 @@ namespace insur {
     pos.trans.dy = 0.0;
     pos.trans.dz = 0.0;
     pos.rotref = "";
-
-    // Initialise rotation list with Harry's tilt mod
-    // This rotation places an unflipped module within a rod
+  
     Rotation rot;
-    rot.name = xml_places_unflipped_mod_in_rod;
-    rot.thetax = 90.0;
-    rot.phix = 90.0;
-    rot.thetay = 0.0;
-    rot.phiy = 0.0;
-    rot.thetaz = 90.0;
-    rot.phiz = 0.0;
-    r.insert(std::pair<const std::string,Rotation>(rot.name,rot));
+    // PLACING MODULE WITHIN A ROD
+    // Outer Tracker : local X axis, at e.g. Phi = 0°, is parallel to CMS_Y.
+    if (!isPixelTracker) {
+      // This rotation places an unflipped module within a rod
+      rot.name = xml_OT_places_unflipped_mod_in_rod;
+      rot.thetax = 90.0;
+      rot.phix = 90.0;
+      rot.thetay = 0.0;
+      rot.phiy = 0.0;
+      rot.thetaz = 90.0;
+      rot.phiz = 0.0;
+      r.insert(std::pair<const std::string,Rotation>(rot.name,rot));
 
-    // This rotation places a flipped module within a rod
-    rot.name = xml_places_flipped_mod_in_rod;
-    rot.thetax = 90.0;
-    rot.phix = 270.0;
-    rot.thetay = 0.0;
-    rot.phiy = 0.0;
-    rot.thetaz = 90.0;
-    rot.phiz = 180.0;
-    r.insert(std::pair<const std::string,Rotation>(rot.name,rot));
+      // This rotation places a flipped module within a rod.
+      // Flip is 180° rotation around local X axis.
+      rot.name = xml_OT_places_flipped_mod_in_rod;
+      rot.thetax = 90.0;
+      rot.phix = 270.0;
+      rot.thetay = 0.0;
+      rot.phiy = 0.0;
+      rot.thetaz = 90.0;
+      rot.phiz = 180.0;
+      r.insert(std::pair<const std::string,Rotation>(rot.name,rot));
+    }
+    // Inner Tracker : local X axis, at e.g. Phi = 0°, is antiparallel to CMS_Y.
+    else {
+      // This rotation places an unflipped module within a rod
+      rot.name = xml_PX_places_unflipped_mod_in_rod;
+      rot.thetax = 90.0;
+      rot.phix = 270.0;
+      rot.thetay = 180.0;
+      rot.phiy = 0.0;
+      rot.thetaz = 90.0;
+      rot.phiz = 0.0;
+      r.insert(std::pair<const std::string,Rotation>(rot.name,rot));
 
-    // Flip module (Fix Y axis)
-    rot.name = xml_flip_mod_rot;
+      // This rotation places a flipped module within a rod.
+      // Flip is 180° rotation around local X axis.
+      rot.name = xml_PX_places_flipped_mod_in_rod;
+      rot.thetax = 90.0;
+      rot.phix = 90.0;
+      rot.thetay = 180.0;
+      rot.phiy = 0.0;
+      rot.thetaz = 90.0;
+      rot.phiz = 180.0;
+      r.insert(std::pair<const std::string,Rotation>(rot.name,rot));
+    }
+
+    // Y180 : Rotation of 180° around CMS_Y axis.
+    rot.name = xml_Y180;
     rot.thetax = 90.0;
     rot.phix = 180.0;
     rot.thetay = 90.0;
@@ -639,6 +666,9 @@ namespace insur {
 	rodNextPhiName << xml_rod << xml_unflipped << layer; // e.g.RodUnflipped1
       }
 
+      std::string places_unflipped_mod_in_rod = (!isPixelTracker ? xml_OT_places_unflipped_mod_in_rod : xml_PX_places_unflipped_mod_in_rod);
+      std::string places_flipped_mod_in_rod = (!isPixelTracker ? xml_OT_places_flipped_mod_in_rod : xml_PX_places_flipped_mod_in_rod);
+
       double rodStartPhiAngle, rodNextPhiStartPhiAngle;
 
       // information on tilted rings, indexed by ring number
@@ -718,16 +748,16 @@ namespace insur {
 
 	      pos.trans.dx = iiter->getModule().center().Rho() - RadiusIn;
 	      pos.trans.dz = iiter->getModule().center().Z();
-	      if (!iiter->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_unflipped_mod_in_rod; }
-	      else { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_flipped_mod_in_rod; }
+	      if (!iiter->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
+	      else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
 	      p.push_back(pos);
 	      
 	      // This is a copy of the BModule (FW/BW barrel half)
 	      if (partner != oiter->end()) {
 		pos.trans.dx = partner->getModule().center().Rho() - RadiusIn;
 		pos.trans.dz = partner->getModule().center().Z();
-		if (!partner->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_unflipped_mod_in_rod; }
-		else { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_flipped_mod_in_rod; }
+		if (!partner->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
+		else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
 		pos.copy = 2; 
 		p.push_back(pos);
 		pos.copy = 1;
@@ -745,16 +775,16 @@ namespace insur {
 
 	      pos.trans.dx = iiter->getModule().center().Rho() - RadiusOut;
 	      pos.trans.dz = iiter->getModule().center().Z();
-	      if (!iiter->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_unflipped_mod_in_rod; }
-	      else { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_flipped_mod_in_rod; }
+	      if (!iiter->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
+	      else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
 	      p.push_back(pos);
 	      
 	      // This is a copy of the BModule (FW/BW barrel half)
 	      if (partner != oiter->end()) {
 		pos.trans.dx = partner->getModule().center().Rho() - RadiusOut;
 		pos.trans.dz = partner->getModule().center().Z();
-		if (!partner->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_unflipped_mod_in_rod; }
-		else { pos.rotref = trackerXmlTags.nspace + ":" + xml_places_flipped_mod_in_rod; }
+		if (!partner->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
+		else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
 		pos.copy = 2; 
 		p.push_back(pos);
 		pos.copy = 1;
@@ -1960,7 +1990,7 @@ namespace insur {
 	    p.push_back(pos);
 	    pos.copy = 2;
 	    pos.trans.dz = -pos.trans.dz;
-	    pos.rotref = trackerXmlTags.nspace + ":" + xml_flip_mod_rot;
+	    pos.rotref = trackerXmlTags.nspace + ":" + xml_Y180;
 	    p.push_back(pos);
 	  }
 
@@ -1992,7 +2022,7 @@ namespace insur {
 	      p.push_back(pos);
 	      pos.copy = 2;
 	      pos.trans.dz = -pos.trans.dz;
-	      pos.rotref = trackerXmlTags.nspace + ":" + xml_flip_mod_rot;
+	      pos.rotref = trackerXmlTags.nspace + ":" + xml_Y180;
 	      p.push_back(pos);
 	      
 
@@ -2145,7 +2175,7 @@ namespace insur {
 	    p.push_back(pos);
 	    pos.copy = 2;
 	    pos.trans.dz = -pos.trans.dz;
-	    pos.rotref = trackerXmlTags.nspace + ":" + xml_flip_mod_rot;
+	    pos.rotref = trackerXmlTags.nspace + ":" + xml_Y180;
 	    p.push_back(pos);
 	  }
 

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -614,7 +614,7 @@ namespace insur {
       // Special case where a composite with same name already exists
       if (mapCompoToPrintedCompo_.find(nspaceName) != mapCompoToPrintedCompo_.end()) {
 	//throw PathfulException("Found several composite materials with same name " + nspaceName);
-	std::cout << "VERY IMPORTANT : VOLUME " << nspaceName << " IS DUPLICATED !!!!!!!!!!" << std::endl;
+	std::cerr << "VERY IMPORTANT : VOLUME " << nspaceName << " IS DUPLICATED !!!!!!!!!!" << std::endl;
       }
       // Add the composite which has just been printed, to the list of printed composites.
       printedComposites_.push_back(comp);
@@ -656,6 +656,10 @@ namespace insur {
     void XMLWriter::box(std::string name, double dx, double dy, double dz, std::ostringstream& stream) {
         stream << xml_box_open << name << xml_box_first_inter << dx << xml_box_second_inter << dy;
         stream << xml_box_third_inter << dz << xml_box_close;
+	if (dx < 0. || dy < 0. || dz < 0.) {
+	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined box."
+		    << " dx = " << dx << " dy = " << dy << " dz = " << dz << std::endl;
+	}
     }
     
     /**
@@ -676,6 +680,10 @@ namespace insur {
         //stream << xml_trapezoid_second_inter << dyy << xml_trapezoid_third_inter << dx;
         //stream << xml_trapezoid_fourth_inter << dx << xml_trapezoid_fifth_inter << dz;
         stream << xml_trapezoid_close;
+	if (dx < 0. || dxx < 0. || dy < 0. || dyy < 0. || dz < 0.) {
+	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined trapezoid."
+		    << " dx = " << dx << "dxx = " << dxx << " dy = " << dy << " dyy = " << dyy << " dz = " << dz << std::endl;
+	}
     }
     
     /**
@@ -690,6 +698,10 @@ namespace insur {
     void XMLWriter::tubs(std::string name, double rmin, double rmax, double dz, std::ostringstream& stream) {
         stream << xml_tubs_open << name << xml_tubs_first_inter << rmin << xml_tubs_second_inter << rmax;
         stream << xml_tubs_third_inter << dz << xml_tubs_close;
+	if (rmin > rmax || dz < 0.) {
+	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined tub."
+		    << " rmin = " << rmin << "rmax = " << rmax << " dz = " << dz << std::endl;
+	}
     }
 
     /**
@@ -707,6 +719,10 @@ namespace insur {
         stream << xml_cone_open << name << xml_cone_first_inter << rmax1 << xml_cone_second_inter << rmax2;
         stream << xml_cone_third_inter << rmin1 << xml_cone_fourth_inter << rmin2;
         stream << xml_cone_fifth_inter << dz << xml_cone_close;
+	if (rmin1 > rmax1 || rmin2 > rmax2 || dz < 0.) {
+	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined tub."
+		    << " rmin1 = " << rmin1 << "rmax1 = " << rmax1 << " rmin2 = " << rmin2 << "rmax2 = " << rmax2 << " dz = " << dz << std::endl;
+	}
     }
     
     /**

--- a/src/tk2CMSSW.cc
+++ b/src/tk2CMSSW.cc
@@ -279,7 +279,9 @@ namespace insur {
       char hn[256];
       hn[255] = 0;
       gethostname(hn, 255); // if hostname is too long it gets truncated and the string might or might not contain a terminating null byte, therefore we force the last char to be null by construction
-      return std::string(pwd->pw_gecos) + " (" + pwd->pw_name + " on " + hn + ")";
+      auto userInfo = split<std::string>(pwd->pw_gecos, ",");
+      std::string name = (userInfo.size() > 0 ? userInfo[0] : "");
+      return name + " (" + pwd->pw_name + " on " + hn + ")";
     }
     
 }

--- a/xml/pixbar.xml
+++ b/xml/pixbar.xml
@@ -161,19 +161,19 @@
       <ZSection z="125.0*cm" rMin="118.0*cm" rMax="120.0*cm"/>
       <ZSection z="291.0*cm" rMin="118.0*cm" rMax="120.0*cm"/>
     </Polycone>
-    <Polycone name="Phase1PixelBarrel" startPhi="0*deg" deltaPhi="360*deg">
+    <Polycone name="Phase2PixelBarrel" startPhi="0*deg" deltaPhi="360*deg">
       <ZSection z="-[Zv1]"         rMin="[Rin1]"          rMax="[Rout1]" />
       <ZSection z="[Zv1]"          rMin="[Rin1]"          rMax="[Rout1]" />
     </Polycone>
     <SubtractionSolid name="Phase2OTBarrel">
       <rSolid name="Barrel"/>
-      <rSolid name="Phase1PixelBarrel"/>
+      <rSolid name="Phase2PixelBarrel"/>
       <Translation x="0*cm" y="0*cm" z="0*cm"/>
     </SubtractionSolid> 
   </SolidSection>
   <LogicalPartSection label="pixbar.xml">
-    <LogicalPart name="Phase1PixelBarrel" category="unspecified">
-      <rSolid name="Phase1PixelBarrel"/>
+    <LogicalPart name="Phase2PixelBarrel" category="unspecified">
+      <rSolid name="Phase2PixelBarrel"/>
       <rMaterial name="materials:Air"/>
     </LogicalPart>
     <LogicalPart name="Phase2OTBarrel" category="unspecified">

--- a/xml/pixelProdCuts.xml
+++ b/xml/pixelProdCuts.xml
@@ -3,7 +3,7 @@
   <!-- WARNING : ARE THE VALUES FOR ProdCutsForElectrons, ProdCutsForPositrons AND ProdCutsForGamma CORRECT IN THIS FILE ? -->
   <SpecParSection label="trackerProdCuts.xml" eval="true">
     <SpecPar name="tracker-dead-pixel">
-      <PartSelector path="//pixbar:Phase1PixelBarrel"/>
+      <PartSelector path="//pixbar:Phase2PixelBarrel"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap"/>
       <Parameter name="CMSCutsRegion" value="TrackerPixelDeadRegion" eval="false"/>
       <Parameter name="ProdCutsForElectrons" value="1*mm"/>

--- a/xml/pixelsens.xml
+++ b/xml/pixelsens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
 <SpecParSection label="spec-pars2.xml">
-  <SpecPar name="ROUHitsTrackerPhase1PixelBarrel">
+  <SpecPar name="ROUHitsTrackerPhase2PixelBarrel">
     <!--mid point marker-->
     <Parameter name="SensitiveDetector" value="TkAccumulatingSensitiveDetector" />
     <Parameter name="ReadOutName" value="TrackerHitsPixelBarrel" />


### PR DESCRIPTION
This quick PR includes the automation of latest updates, which were used to produce the TDR XMLs.
It includes : 
- Renamed PixelBarrel to Phase2, to match new CMMSW code by Alessia in CMSSW.
- In Inner Tracker, use Phase 1 modules local frame of reference orientation, as requested by Alessia.
NB : This issue might be risen again for the Tilted Inner Tracker, as there, the Phase 2 modules local frame of reference orientation will make more sense.
- When the shape of a volume if defined, check that volume > 0.