### PR TITLE
Reshuffling of bundles -> cables map

### DIFF
--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -48,7 +48,7 @@ static const std::string cabling_negativePrefix = "neg";
 // A or B is an extra distinction between groups of modules, used in TEDD.
 // Modules associated to different cabling types should not be mixed with each other.
 // Modules with the same cabling type have to be conected to the same DTC type (PS10G, PS5G, or SS).
-enum Category { UNDEFINED, PS10G, PS5G, PS5GA, PS5GB, SS };
+enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 
 
 #endif  // CABLING_CONSTANTS_HH

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -45,7 +45,8 @@ static const std::string cabling_negativePrefix = "neg";
 // CABLING TYPE
 // PS or SS stands for the module type.
 // 10G or 5G stands for the speed in the optical fibers (Gb/s).
-// A or B is an extra distinction between groups of modules, used in TEDD.
+// A or B is an extra distinction between groups of modules, used in TEDD. 
+// PS10GB is used for modules which could be connected to 5G links, but, for data rates reduction purposes, are assigned to 10G.
 // Modules associated to different cabling types should not be mixed with each other.
 // Modules with the same cabling type have to be conected to the same DTC type (PS10G, PS5G, or SS).
 enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -78,7 +78,7 @@ Module* Bundle::maxPhiModule() const {
 const int Bundle::computePlotColor(const int id, const bool isPositiveCablingSide) const {
   int plotColor = 0;
   int plotId = (isPositiveCablingSide ? id : (id - 20000));
-  int plotType = 2 + plotId % 2;  // Barrel : Identifies Flat vs Tilted. Endcap : Identifies PS10G vs PG5GA vs PS5GB vs 2S type.
+  int plotType = 2 + plotId % 2;  // Barrel : Identifies Flat vs Tilted. Endcap : Identifies PS10GA vs PG10GB vs PS5G vs 2S type.
   int dizaine = plotId / 10;
   int plotPhi = dizaine % 3;  // Barrel : Identifies phiSegmentRef. Endcap : Identifies phiRegionRef.
   plotColor = plotType * 3 + plotPhi;

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -42,7 +42,7 @@ const int Cable::computeServicesChannel(const int phiSectorRef, const Category& 
     else if (phiSectorRef == 8) servicesChannel = 12;   
   }
   else if (type == Category::PS5G) {
-    if (slot != 3) {
+    if (slot == 3) {
       if (phiSectorRef == 0) servicesChannel = 1;
       else if (phiSectorRef == 1) servicesChannel = 3;
       else if (phiSectorRef == 2) servicesChannel = 4;
@@ -57,11 +57,11 @@ const int Cable::computeServicesChannel(const int phiSectorRef, const Category& 
       if (phiSectorRef == 0) servicesChannel = 1;
       else if (phiSectorRef == 1) servicesChannel = 3;
       else if (phiSectorRef == 2) servicesChannel = 4;
-      else if (phiSectorRef == 3) servicesChannel = 5;
-      else if (phiSectorRef == 4) servicesChannel = 6;
-      else if (phiSectorRef == 5) servicesChannel = 7;
-      else if (phiSectorRef == 6) servicesChannel = 9;
-      else if (phiSectorRef == 7) servicesChannel = 10;
+      else if (phiSectorRef == 3) servicesChannel = 6;
+      else if (phiSectorRef == 4) servicesChannel = 7;
+      else if (phiSectorRef == 5) servicesChannel = 8;
+      else if (phiSectorRef == 6) servicesChannel = 10;
+      else if (phiSectorRef == 7) servicesChannel = 11;
       else if (phiSectorRef == 8) servicesChannel = 12;
     }
   }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -77,7 +77,7 @@ const int Cable::computeServicesChannel(const int phiSectorRef, const Category& 
       else if (phiSectorRef == 7) servicesChannel = 10;
       else if (phiSectorRef == 8) servicesChannel = 12;
     }
-    if (slot == 1 || slot == 2) {
+    else {
       if (phiSectorRef == 0) servicesChannel = 1;
       else if (phiSectorRef == 1) servicesChannel = 2;
       else if (phiSectorRef == 2) servicesChannel = 4;

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -60,7 +60,7 @@ void CablingMap::connectBundlesToCables(std::map<int, Bundle*>& bundles, std::ma
  */
 const Category CablingMap::computeCableType(const Category& bundleType) const {
  Category cableType = bundleType;
- if (bundleType == Category::PS5GA || bundleType == Category::PS5GB) cableType = Category::PS5G;
+ if (bundleType == Category::PS10GA || bundleType == Category::PS10GB) cableType = Category::PS10G;
  return cableType;
 }
 
@@ -85,6 +85,7 @@ const std::map<int, std::pair<int, int> > CablingMap::computeCablesPhiSectorRefA
 
     // COLLECT RELEVANT INFO
     const PhiPosition& bundlePhiPosition = myBundle->phiPosition();
+    const int phiSegmentRef = bundlePhiPosition.phiSegmentRef(); 
     const double phiSectorWidth = bundlePhiPosition.phiSectorWidth();
     const int phiSectorRef = bundlePhiPosition.phiSectorRef();  
    
@@ -98,25 +99,42 @@ const std::map<int, std::pair<int, int> > CablingMap::computeCablesPhiSectorRefA
     const std::string subDetectorName = myBundle->subDetectorName();
     const int layerDiskNumber = myBundle->layerDiskNumber();
 
+    const bool isPositiveCablingSide = myBundle->isPositiveCablingSide();
+
     // by default
     int cablePhiSectorRef = phiSectorRef;
     int slot = 0;
 
     // PS10G
     if (cableType == Category::PS10G) {
-      if (subDetectorName == cabling_tbps || (subDetectorName == cabling_tedd1 && layerDiskNumber == 1) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 2)) {
+      bool isTiltedWithFlat;
+      if (subDetectorName == cabling_tbps && myBundle->isTiltedPart()) {
+	if (isPositiveCablingSide) isTiltedWithFlat = ((phiSegmentRef % 2) == 0);
+	else isTiltedWithFlat = ((phiSegmentRef % 2) == 1);
+      }
+
+      // BARREL FLAT PART + ENDCAPS DISKS 2, 4
+      if ((subDetectorName == cabling_tbps && !myBundle->isTiltedPart()) || (subDetectorName == cabling_tbps && myBundle->isTiltedPart() && isTiltedWithFlat) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 2) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 4)) {
 	slot = 1;
+      }
+      // BARREL TILTED PART +  ENDCAPS DISKS 1, 3, 5
+      if ((subDetectorName == cabling_tbps && myBundle->isTiltedPart() && !isTiltedWithFlat) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 1) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 3) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 5)) {
+	slot = 2;
       }
     }
 
     // PS5G
     else if (cableType == Category::PS5G) {
-      if ( (subDetectorName == cabling_tbps && layerDiskNumber == 2) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 3 && bundleType == Category::PS5GA) ) {
-	slot = 2;
+      if (subDetectorName == cabling_tbps && layerDiskNumber == 2) {
+	slot = 3;
+      }
+
+      else if ((subDetectorName == cabling_tedd1 && layerDiskNumber == 1) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 3) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 5)) {
+	slot = 4;
       }
 
       // STAGGERING
-      else if ( (subDetectorName == cabling_tbps && layerDiskNumber == 3) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 3 && bundleType == Category::PS5GB) ) {
+      else if ( (subDetectorName == cabling_tbps && layerDiskNumber == 3) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 2) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 4) ) {
 	// TBPS
 	if (subDetectorName == cabling_tbps) {
 	  // TILTED PART
@@ -129,7 +147,7 @@ const std::map<int, std::pair<int, int> > CablingMap::computeCablesPhiSectorRefA
 	      Layer3TiltedPhiSectorsCounter[nextPhiSectorRef] += 1;
 	      cablePhiSectorRef = nextPhiSectorRef;
 	    }
-	    slot = 3;
+	    slot = 6;
 	  }
 	  // FLAT PART : assign TBPS bundles with TEDD bundles
 	  else {
@@ -141,19 +159,14 @@ const std::map<int, std::pair<int, int> > CablingMap::computeCablesPhiSectorRefA
 	      Layer3FlatPhiSectorsCounter[nextPhiSectorRef] += 1;
 	      cablePhiSectorRef = nextPhiSectorRef;
 	    }
-	    slot = 4;
+	    slot = 5;
 	  }
 	}
 	// TEDD_2
-	else slot = 4;
-      }
-
-      else if ( (subDetectorName == cabling_tedd1 && layerDiskNumber == 1) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 4) ) {
-	slot = 5;
-      }
-
-      else if ( (subDetectorName == cabling_tedd1 && layerDiskNumber == 2) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 5) ) {
-	slot = 6;
+	else {
+	  if (subDetectorName == cabling_tedd1 && layerDiskNumber == 2) slot = 5;
+	  else if (subDetectorName == cabling_tedd2 && layerDiskNumber == 4) slot = 6;
+	}
       }
     }
 
@@ -210,7 +223,10 @@ const std::map<int, std::pair<int, int> > CablingMap::computeCablesPhiSectorRefA
       }
     }
   
-    if (slot == 0) logERROR("Connection from ribbon to cable : ribbon category is unknown. Slot was not defined properly.");
+    if (slot == 0) {
+      std::cout << "bundleType = "  << bundleType << " cableType = " << cableType <<  " subDetectorName  =" << subDetectorName << " layerDiskNumber = " << layerDiskNumber << " isPositiveCablingSide = " << isPositiveCablingSide << std::endl;
+      logERROR("Connection from ribbon to cable : ribbon category is unknown. Slot was not defined properly.");
+    }
 
 
     // COLLECT phiSectorRef and slots which have been computed.

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -107,18 +107,12 @@ const std::map<int, std::pair<int, int> > CablingMap::computeCablesPhiSectorRefA
 
     // PS10G
     if (cableType == Category::PS10G) {
-      bool isTiltedWithFlat;
-      if (subDetectorName == cabling_tbps && myBundle->isTiltedPart()) {
-	if (isPositiveCablingSide) isTiltedWithFlat = ((phiSegmentRef % 2) == 0);
-	else isTiltedWithFlat = ((phiSegmentRef % 2) == 1);
-      }
-
-      // BARREL FLAT PART + ENDCAPS DISKS 2, 4
-      if ((subDetectorName == cabling_tbps && !myBundle->isTiltedPart()) || (subDetectorName == cabling_tbps && myBundle->isTiltedPart() && isTiltedWithFlat) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 2) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 4)) {
+      // BARREL FLAT PART + ENDCAPS DISKS 1, 3, 5
+      if ((subDetectorName == cabling_tbps && !myBundle->isTiltedPart()) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 1) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 3) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 5)) {
 	slot = 1;
       }
-      // BARREL TILTED PART +  ENDCAPS DISKS 1, 3, 5
-      if ((subDetectorName == cabling_tbps && myBundle->isTiltedPart() && !isTiltedWithFlat) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 1) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 3) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 5)) {
+      // BARREL TILTED PART + ENDCAPS DISKS 2, 4
+      if ((subDetectorName == cabling_tbps && myBundle->isTiltedPart()) || (subDetectorName == cabling_tedd1 && layerDiskNumber == 2) || (subDetectorName == cabling_tedd2 && layerDiskNumber == 4)) {
 	slot = 2;
       }
     }

--- a/src/Cabling/ModulesToBundlesConnector.cc
+++ b/src/Cabling/ModulesToBundlesConnector.cc
@@ -152,17 +152,17 @@ const Category ModulesToBundlesConnector::computeBundleType(const bool isBarrel,
   else {
     // TEDD_1
     if (subDetectorName == cabling_tedd1) {
-      if (ringNumber <= 4) bundleType = Category::PS10G;
-      else if (ringNumber >= 5 && ringNumber <= 7) bundleType = Category::PS5GA;
-      else if (ringNumber >= 8 && ringNumber <= 10) bundleType = Category::PS5GB;
+      if (ringNumber <= 4) bundleType = Category::PS10GA;
+      else if (ringNumber >= 5 && ringNumber <= 7) bundleType = Category::PS10GB;
+      else if (ringNumber >= 8 && ringNumber <= 10) bundleType = Category::PS5G;
       else if (ringNumber >= 11) bundleType = Category::SS;
     }
 
     // TEDD_2
     else if (subDetectorName == cabling_tedd2) {
       if (ringNumber <= 3) bundleType = Category::UNDEFINED;
-      else if (ringNumber >= 4 && ringNumber <= 6) bundleType = Category::PS5GA;
-      else if (ringNumber >= 7 && ringNumber <= 10) bundleType = Category::PS5GB;
+      else if (ringNumber >= 4 && ringNumber <= 6) bundleType = Category::PS10GB;
+      else if (ringNumber >= 7 && ringNumber <= 10) bundleType = Category::PS5G;
       else if (ringNumber >= 11) bundleType = Category::SS;
     }
   }
@@ -223,9 +223,9 @@ const int ModulesToBundlesConnector::computeBundleTypeIndex(const bool isBarrel,
   }
   // ENDCAPS
   else {
-    if (bundleType == Category::PS10G) bundleTypeIndex = 0;
-    else if (bundleType == Category::PS5GA) bundleTypeIndex = 1;
-    else if (bundleType == Category::PS5GB) bundleTypeIndex = 2;
+    if (bundleType == Category::PS10GA) bundleTypeIndex = 0;
+    else if (bundleType == Category::PS10GB) bundleTypeIndex = 1;
+    else if (bundleType == Category::PS5G) bundleTypeIndex = 2;
     else if (bundleType == Category::SS) bundleTypeIndex = 3;
   }
   return bundleTypeIndex;

--- a/src/Cabling/PhiPosition.cc
+++ b/src/Cabling/PhiPosition.cc
@@ -41,11 +41,11 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
     phiRegionWidth_ = 0;	  
     phiRegionStart_ = 0.;
     // PS10G, PS5GA
-    if (bundleType == Category::PS10G || bundleType == Category::PS5GA ) {
+    if (bundleType == Category::PS10GA || bundleType == Category::PS10GB ) {
       phiRegionWidth_ = cabling_nonantWidth;
     }
     // PS5GB
-    else if (bundleType == Category::PS5GB ) {
+    else if (bundleType == Category::PS5G ) {
       phiRegionWidth_ = cabling_semiNonantWidth;
     }
     // 2S

--- a/src/Cabling/PhiPosition.cc
+++ b/src/Cabling/PhiPosition.cc
@@ -40,11 +40,11 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
     // This is because for several cases, there can be too many modules per bundle, hence the phi width is defined smaller.
     phiRegionWidth_ = 0;	  
     phiRegionStart_ = 0.;
-    // PS10G, PS5GA
+    // PS10GA, PS10GB
     if (bundleType == Category::PS10GA || bundleType == Category::PS10GB ) {
       phiRegionWidth_ = cabling_nonantWidth;
     }
-    // PS5GB
+    // PS5G
     else if (bundleType == Category::PS5G ) {
       phiRegionWidth_ = cabling_semiNonantWidth;
     }

--- a/src/Cabling/cabling_constants.cc
+++ b/src/Cabling/cabling_constants.cc
@@ -1,4 +1,4 @@
 #include "Cabling/cabling_constants.hh"
 
 
-define_enum_strings(Category) = { "Undefined", "PS10G", "PS5G", "PS5GA", "PS5GB", "2S" };
+define_enum_strings(Category) = { "Undefined", "PS10G", "PS10GA", "PS10GB", "PS5G", "2S" };


### PR DESCRIPTION
This is to reduce the data rate to DTCs reading the lower radii layers.
See https://indico.cern.ch/event/651635/contributions/2663563/attachments/1493796/2323189/hugo.pdf .

Following reshuffling was done in bundles -> cables map for PS modules.
In a given Phi-Sector:
- 10 G for Slot 1: TBPS Layer 1 flat rod + TEDD disks 1, 3 , 5 (PS10G + ex-PS5GA).
- 10 G for Slot 2: TBPS Layer 1 tilted rods + TEDD disks 2, 4 (PS10G + ex-PS5GA).
- 5 G for Slot 3: TBPS Layer 2, all rods.
- 5 G for Slot 4: TEDD disks 1, 3, 5 (ex-PS5GB).
- 5 G for Slot 5: TBPS Layer 3 flat rods + TEDD disk 2 (ex-PS5GB).
- 5 G for Slot 6: TBPS Layer 3 tilted rods + TEDD disk 4 (ex-PS5GB).

Cabling map before PR:
![fullmap_not_resfuffled](https://user-images.githubusercontent.com/11192654/28315375-68ea9090-6bbe-11e7-9804-86541fc8beda.png)

Cabling map after PR:
![fullmap_resfuffled](https://user-images.githubusercontent.com/11192654/28315385-72f9c8f8-6bbe-11e7-8919-a91412fcf374.png)

Results are at http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT4025/cablingOuter.html 
(I will also replace the map on TDR layout reference webpage).
