### PR TITLE
Inner Tracker: Decreased radii in flat Barrel layout + Added pitch studies.

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel
@@ -17,4 +17,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
@@ -1,4 +1,5 @@
-// 2x1 chips pixel module (25um x 100um)
+// 1x2 chips pixel module (25um x 100um)
+// Chip size 17x19
 moduleType pixel_1x2_25x100  // pixel modules should always have a type starting with keyword 'pixel_'
 
 // Active silicon size
@@ -22,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 4  // green

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50
@@ -1,4 +1,4 @@
-// 2x1 chips pixel module (50um x 50um)
+// 1x2 chips pixel module (50um x 50um)
 // Chip size 17x19
 moduleType pixel_1x2_50x50  // pixel modules should always have a type starting with keyword 'pixel_'
 
@@ -23,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 6  // blue

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_100x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_100x100
@@ -22,4 +22,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -22,4 +22,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_50x200
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_50x200
@@ -22,4 +22,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_50x50
@@ -22,4 +22,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_50x50
@@ -1,4 +1,4 @@
-// 1x1 chips pixel module rotated (50um x 50um)
+// 1x1 chips pixel module (50um x 50um)
 // Chip size 16.4x22
 moduleType pixel_2_1x1_50x50  // pixel modules should always have a type starting with keyword 'pixel_'
 
@@ -23,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 0
+plotColor 5  // brown

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
@@ -1,4 +1,4 @@
-// 2x1 chips pixel module (25um x 100um)
+// 1x2 chips pixel module (25um x 100um)
 // Chip size 16.4x22
 moduleType pixel_2_1x2_25x100  // pixel modules should always have a type starting with keyword 'pixel_'
 
@@ -24,4 +24,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 4  // green

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
@@ -24,4 +24,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 1
+plotColor 6  // clear blue

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
@@ -24,4 +24,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 10 
+plotColor 10  // orange

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
@@ -24,4 +24,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 2
+plotColor 3  // yellow

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_1x1_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_1x1_50x50
@@ -23,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 0
+plotColor 5  // brown

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_2x1_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_2x1_50x50
@@ -1,8 +1,9 @@
-// 1x1 chips pixel module rotated (50um x 50um)
+// 1x2 chips pixel module rotated (50um x 50um)
 // Chip size 16.4x22
 moduleType pixel_2_rotated_2x1_50x50  // pixel modules should always have a type starting with keyword 'pixel_'
 
 // Active silicon size
+// (includes space between chips 0.2mm)
 width 44.2
 length 16.4
 
@@ -23,4 +24,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 0
+plotColor 6  // clear blue

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100
@@ -1,4 +1,5 @@
 // 2x2 chips pixel module (25um x 100um)
+// Chip size 17x19
 moduleType pixel_2x2_25x100  // pixel modules should always have a type starting with keyword 'pixel_'
 
 // Active silicon size
@@ -22,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 10  // orange

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x200
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x200
@@ -22,4 +22,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50
@@ -23,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4
+plotColor 3  // yellow

--- a/geometries/CMS_Phase2/OT613_200_IT404.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT404.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_4.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT405.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT405.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_5.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT406.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT406.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_6.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT407.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT407.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_7.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT502.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT502.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V5/Pixel_V5_0_2.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT503.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT503.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V5/Pixel_V5_0_3.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_0.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_5_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_5_0.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_6_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_6_0.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_7_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_7_0.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_5.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_6.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_7.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_0_7.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_5.cfg
@@ -7,7 +7,7 @@
 
     @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
-    @include stations_FPIX2_4025_Service_Cylinder_near
+    @include stations_FPIX_2_3_Service_Cylinder_near
     
     moduleShape rectangular
     alignEdges true 
@@ -23,37 +23,37 @@
     smallParity -1
     zRotation 1.570796327
     Ring 1 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 40
       ringOuterRadius 108
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 56
       ringOuterRadius 149
     }
     Ring 3 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 36
       ringOuterRadius 188.5
     }
     Ring 4 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 40
       ringOuterRadius 232
     }
     Ring 5 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 48
       ringOuterRadius 253.99
     }
@@ -62,9 +62,9 @@
     Disk 3 { placeZ 2250.83 }
     Disk 4 { placeZ 2550.00 }
 
-    Disk 1 { destination FPIX2_1 }
-    Disk 2 { destination FPIX2_2 }
-    Disk 3 { destination FPIX2_3 }
-    Disk 4 { destination FPIX2_4 }
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
   }
 

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_6.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_7.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_0_7.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_4.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_0.cfg
+  @include FPIX1_4_0_2.cfg
+  @include FPIX2_4_0_2_5.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_5.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_5_0.cfg
+  @include FPIX1_4_0_5.cfg
+  @include FPIX2_4_0_5.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_6.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_6_0.cfg
+  @include FPIX1_4_0_6.cfg
+  @include FPIX2_4_0_6.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_7.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_7.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_7_0.cfg
+  @include FPIX1_4_0_7.cfg
+  @include FPIX2_4_0_7.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_0.cfg
@@ -13,7 +13,7 @@
     smallDelta 0 
     zOverlap -0.2 // 200 um gap along the stave
     innerRadius 29
-    outerRadius 140  // is it intended ? outerRadius is 160 for straight BPIX
+    outerRadius 140
     compressed false   
     smallParity 1
     bigParity -1   

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_3.cfg
@@ -155,10 +155,10 @@
     ////////////////////////////  
      
     Layer 3 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_2500
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L3
-      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
       destination BPIX3
       layerRotation 0.131
       radiusMode fixed
@@ -174,6 +174,7 @@
       Ring 5-8 {
           @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_2x1_50x50
           @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_1x2_2500 
+          @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
           ringInnerRadius 105
           ringOuterRadius 109
           tiltAngle 62.0
@@ -183,6 +184,7 @@
       Ring 9-12 {
           @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_2x1_50x50
           @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_1x2_2500 
+          @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
           ringInnerRadius 105
           ringOuterRadius 109
           tiltAngle 72.0
@@ -225,10 +227,10 @@
     //////////////////////////// 
     
     Layer 4 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_2500
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L4
-      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
+      @includestd CMS_Phase2/Pixel/Resolutions/Barrel_25x100
       destination BPIX4
       layerRotation 0.098
       
@@ -241,7 +243,8 @@
       
       Ring 5-8 {
           @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_2x1_50x50
-          @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_1x2_2500 
+          @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_1x2_2500
+          @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
           ringInnerRadius 145
           ringOuterRadius 149
           tiltAngle 54.0
@@ -251,6 +254,7 @@
       Ring 9-13 {
           @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_rotated_2x1_50x50
           @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_1x2_2500 
+          @includestd CMS_Phase2/Pixel/Resolutions/Barrel_50x50
           ringInnerRadius 145
           ringOuterRadius 149
           tiltAngle 65.0

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX1_5_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX1_5_0_1.cfg
@@ -45,7 +45,7 @@
     }
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
       numModules 32 
       ringOuterRadius 159.99

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX1_5_0_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX1_5_0_2.cfg
@@ -8,7 +8,7 @@
 
     @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
-    @include stations_FPIX1_500_Service_Cylinder_near
+    @include stations_FPIX1_501_Service_Cylinder_near
     
     moduleShape rectangular
     alignEdges true 
@@ -23,38 +23,39 @@
     smallParity -1
     zRotation 1.570796327
     Ring 1 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 20
       ringOuterRadius 73.2 
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 32
       ringOuterRadius 93
     }
     Ring 3 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 24
       ringOuterRadius 127
     }
     Ring 4 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 32 
       ringOuterRadius 159.99
     }
-    Disk 1 { placeZ 420.00 }
-    Disk 2 { placeZ 534.00 }
-    Disk 3 { placeZ 680.00 }
-    Disk 4 { placeZ 865.00 }
-    Disk 5 { placeZ 1100.00 }
+    
+    Disk 1 { placeZ 445.00 }
+    Disk 2 { placeZ 559.65 }
+    Disk 3 { placeZ 703.83 }
+    Disk 4 { placeZ 885.16 }
+    Disk 5 { placeZ 1113.20 }
     Disk 6 { placeZ 1400.00 }
 
     Disk 1 { destination FPIX1_1 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX1_5_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX1_5_0_3.cfg
@@ -8,7 +8,7 @@
 
     @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
-    @include stations_FPIX1_500_Service_Cylinder_near
+    @include stations_FPIX1_501_Service_Cylinder_near
     
     moduleShape rectangular
     alignEdges true 
@@ -23,16 +23,16 @@
     smallParity -1
     zRotation 1.570796327
     Ring 1 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 20
       ringOuterRadius 73.2 
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 32
       ringOuterRadius 93
     }
@@ -50,11 +50,12 @@
       numModules 32 
       ringOuterRadius 159.99
     }
-    Disk 1 { placeZ 420.00 }
-    Disk 2 { placeZ 534.00 }
-    Disk 3 { placeZ 680.00 }
-    Disk 4 { placeZ 865.00 }
-    Disk 5 { placeZ 1100.00 }
+    
+    Disk 1 { placeZ 445.00 }
+    Disk 2 { placeZ 559.65 }
+    Disk 3 { placeZ 703.83 }
+    Disk 4 { placeZ 885.16 }
+    Disk 5 { placeZ 1113.20 }
     Disk 6 { placeZ 1400.00 }
 
     Disk 1 { destination FPIX1_1 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX2_4_0_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX2_4_0_5.cfg
@@ -23,37 +23,37 @@
     smallParity -1
     zRotation 1.570796327
     Ring 1 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 40
       ringOuterRadius 108
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 56
       ringOuterRadius 149
     }
     Ring 3 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 36
       ringOuterRadius 188.5
     }
     Ring 4 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 40
       ringOuterRadius 232
     }
     Ring 5 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 48
       ringOuterRadius 253.99
     }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX2_5_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/FPIX2_5_0_3.cfg
@@ -23,16 +23,16 @@
     smallParity -1
     zRotation 1.570796327
     Ring 1 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 40
       ringOuterRadius 108
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_25x100
+      @includestd CMS_Phase2/Pixel/Resolutions/Endcap_50x50
       numModules 56
       ringOuterRadius 149
     }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_2.cfg
@@ -1,0 +1,34 @@
+
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include BPIX_5_0_1.cfg
+  @include FPIX1_5_0_2.cfg
+  @include FPIX2_4_0_5.cfg
+
+  @include ../Supports/IT_Support_Tube_V2_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V2_0.cfg
+  
+}
+
+
+
+
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_3.cfg
@@ -1,0 +1,34 @@
+
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include BPIX_5_0_3.cfg
+  @include FPIX1_5_0_3.cfg
+  @include FPIX2_5_0_3.cfg
+
+  @include ../Supports/IT_Support_Tube_V2_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V2_0.cfg
+  
+}
+
+
+
+
+

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -98,7 +98,8 @@ OT365_200_IT4025.cfg                 OT Version 3.6.5
                                                                 radii 29.000, 70.146, 117.753, 157.388
                                      and FPIX_2 shifted by 10 cm inwards
                                             disk z: 1750.0, 1985.43, 2250.83, 2550.0
-                                     * Added the pixel support tube and service cylinders
+                                     25x100 everywhere.
+                                     Added the pixel support tube and service cylinders.
 
 OT365_200_IT4026.cfg                 OT Version 3.6.5
                                      Inner tracker version 4.0.2.6 <- based one 4.0.2.5 but with 7 FPIX disks
@@ -189,7 +190,7 @@ OT711_200_IT4025.cfg                      Like 6.1.1 TDR geometry but with paire
                                           
 OT612_200_IT4025.cfg	Like 6.1.1 but with slightly larger PS modules
 
-OT613_200_IT4025.cfg	Like 6.1.2 but fixing bigDelta according to Nick 2017-03-27
+OT613_200_IT4025.cfg	   Like 6.1.2 but fixing bigDelta according to Nick 2017-03-27
                          Zd=29.7mm or bigDelta=14.85
                          New geometry 6.1.3 with slight adjustment in TEDD1 and TEDD2: bigDeelta moved from 14.15mm to 14.85mm
                          this would cause a movement of 1.243mm and 1.351mm in innermost rings of TEDD1 and TEDD2 respectively
@@ -197,12 +198,36 @@ OT613_200_IT4025.cfg	Like 6.1.2 but fixing bigDelta according to Nick 2017-03-27
                         Any ring movement was instead *avoided* by constraining the ring radii to those of 6.1.2, so that the geometry in the
                         xy plane is exactly the same
                         
+OT613_200_IT4125.cfg	  Like OT613_200_IT4025, but with 50x50 pixels instead of 25x100.
+
+OT613_200_IT404.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.0.4:
+                                      - geometry similar to IT4.0.2.5, but with radii of barrel layers reduced (same as flat part of IT 5.0.1).
+                                      - module type 25x100 everywhere.
+                                      
+OT613_200_IT405.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.0.5:
+                                      - geometry same as IT4.0.4
+                                      - module type 50x50 everywhere.
+                                      
+OT613_200_IT406.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.0.6:
+                                      - geometry same as IT4.0.4
+                                      - 25x100 in 1x2 modules, 50x50 in 2x2 modules.                                  
+
+OT613_200_IT407.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.0.7:
+                                      - geometry same as IT4.0.4
+                                      - 50x50 in 1x2 modules, 25x100 in 2x2 modules.   
+                                      
+                        
 OT613_200_IT500.cfg                  OT Version 6.1.3
                                      Inner Tracker version 5.0.0 : tilted Inner Tracker. Head of series.
                                      First-jet optimization :)
                                      1-chip modules everywhere in the tilted Barrel.
                                      FPIX1 : 2 disks were removed with respect to TDR version.
                                      FPIX2 : same as TDR version.
+                                     50x50 in BPIX, 25x100 in FPIX.
                                      
 OT613_200_IT501.cfg                  OT Version 6.1.3
                                      Inner Tracker version 5.0.1 : tilted Inner Tracker. 
@@ -213,6 +238,17 @@ OT613_200_IT501.cfg                  OT Version 6.1.3
                                          (d) 1x2 modules in the tilted part of layers 3-4 (dimensions 16.4 x 44.2, rotated by 90 degrees) 
                                      FPIX1 : 2 disks were removed with respect to TDR version.
                                      FPIX2 : same as TDR version.
+                                     50x50 in BPIX, 25x100 in FPIX.
+                                     
+OT613_200_IT502.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 5.0.2: 
+                                      - geometry same as IT5.0.1
+                                      - module type 50x50 everywhere.
+                                     
+OT613_200_IT503.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 5.0.3: 
+                                      - geometry same as IT5.0.1
+                                      - 50x50 in 1x1 and 1x2 modules, 25x100 in 2x2 modules.
                                                                                                            
 
-OT613_200_IT4125.cfg	Like above, but with 50x50 pixels instead of 25x100
+


### PR DESCRIPTION
This allows additional geometries + pitch studies.

Following Inner Tracker layouts are added:

UNTILTED LAYOUTS:
- IT 4025 (not added here) :      
TDR geometry
25x100 everywhere.       
http://cms-tklayout.web.cern.ch/cms-tklayout/layouts/reference/OT613_200_IT4025/layoutpixel.html 

- IT 404:   
**geometry similar to IT4.0.2.5, but with radii of barrel layers reduced (same as flat part of IT 5.0.1).   
Layer1: Radius = 29 mm + 12 rods (IT 4025) -> Radius = 29 mm + 12 rods (IT 404)
Layer2: Radius = 70.146 mm + 28 rods (IT 4025) -> Radius = 60 mm + 24 rods (IT 404)
Layer3: Radius = 117.753 mm + 24 rods (IT 4025) -> Radius = 100 mm + 20 rods (IT 404)
Layer4: Radius = 157.388 mm + 32 rods (IT 4025) -> Radius = 140 mm + 28 rods (IT 404)**
25x100 everywhere.  
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT404/layoutpixel.html

- IT 405:    
same geometry as IT404 . 
50x50 everywhere.   
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT405/layoutpixel.html

- IT 406:   
same geometry as IT404.    
25x100 in 1x2 modules, 50x50 in 2x2 modules.   
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT406/layoutpixel.html

- IT 407:   
geometry as in IT404.     
50x50 in 1x2 modules, 25x100 in 2x2 modules.   
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT407/layoutpixel.html 


TILTED LAYOUTS:
- IT 501 (not added here) :   
50x50 in BPIX, 25x100 elsewhere.   
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT501/layoutpixel.html

- IT 502:   
same geometry as IT501.     
50x50 everywhere.   
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT502/layoutpixel.html  

- IT 503:     
same geometry as IT501.    
50x50 in 1x1 and 1x2 modules, 25x100 in 2x2 modules.  
http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT503/layoutpixel.html


**The decrease of barrel layers radii (IT 4025 -> IT 404) provides a great improvement of the coverage.
As a result, flat IT 404 geometry might very likely be the 'actual' one to be built.**

**The tilted Inner Tracker geometry will be considered in the event that the rectangular modules cannot reasonably be built  (IT 404) + the square modules (IT405) does not lead to satisfactory result in a flat geometry.**

**As a result, following geometries of interest will be exported for further studies: IT404, IT405, and IT502.**


NB: In this PR, an Inner Tracker modules colour convention is introduced, as follows:
1x2_25x100 : green
2x2_25x100 : orange
1x1_50x50 : brown
1x2_50x50 : blue
2x2_50x50 : yellow


