### PR TITLE
Added services channels sections in PP1, so that full optical cabling map can also be used for power cables. + Adds extra info on bundles in TEDD, to ease the Mechanics studies 

### DIFF
--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -33,11 +33,11 @@ public:
   const int slot() const { return slot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
   const int servicesChannel() const { return servicesChannel_; }
-  const std::string servicesChannelSection() const { return servicesChannelSection_; }
+  const ChannelSection& servicesChannelSection() const { return servicesChannelSection_; }
 
 
 private:
-  const std::pair<int, std::string> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  const std::pair<int, ChannelSection> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
   const std::string computeDTCName(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   
@@ -51,7 +51,7 @@ private:
   int slot_;
   bool isPositiveCablingSide_;
   int servicesChannel_;
-  std::string servicesChannelSection_;
+  ChannelSection servicesChannelSection_;
 };
 
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -33,10 +33,11 @@ public:
   const int slot() const { return slot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
   const int servicesChannel() const { return servicesChannel_; }
+  const std::string servicesChannelSection() const { return servicesChannelSection_; }
 
 
 private:
-  const int computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  const std::pair<int, std::string> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
   const std::string computeDTCName(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   
@@ -50,6 +51,7 @@ private:
   int slot_;
   bool isPositiveCablingSide_;
   int servicesChannel_;
+  std::string servicesChannelSection_;
 };
 
 

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -45,11 +45,22 @@ static const std::string cabling_negativePrefix = "neg";
 // CABLING TYPE
 // PS or SS stands for the module type.
 // 10G or 5G stands for the speed in the optical fibers (Gb/s).
-// A or B is an extra distinction between groups of modules, used in TEDD. 
-// PS10GB is used for modules which could be connected to 5G links, but, for data rates reduction purposes, are assigned to 10G.
-// Modules associated to different cabling types should not be mixed with each other.
 // Modules with the same cabling type have to be conected to the same DTC type (PS10G, PS5G, or SS).
+
+// A or B is an extra distinction for PS10G modules, used in TEDD only. 
+// PS10GA is used for modules which should be connected to 10G links (because of their location in the Tracker).
+// PS10GB is used for modules which could actually in theory be connected to 5G links. These modules are connected to 10G links for data rates reduction purposes only.
 enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
+
+
+// SERVICES CHANNEL SECTION
+// There are 3 sections for cables in PP1: A, B, and C.
+// The optical bundles are always placed in section B.
+// Though, the cabling map is also used for power cables. 1 optical bundle = 1 power cable. 
+// As a result, the full optical cabling map can be used for power cables mapping.
+// The only difference is that power cables are assigned to section A or C in PP1.
+// This additional info is dealt with by ChannelSection.
+enum ChannelSection { UNKNOWN, A, C };
 
 
 #endif  // CABLING_CONSTANTS_HH

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -122,7 +122,7 @@ public:
   Property<double, Default> supportPlateThickness;
   Property<double, Default> chipThickness;
 
-  Property<int, AutoDefault> endcapDiskSurface;
+  //Property<int, AutoDefault> diskSurface;
   Property<bool, Default> removeModule;
 
   int16_t cntId() const { return cntId_; }
@@ -160,8 +160,7 @@ public:
       hybridThickness          ("hybridThickness"          , parsedOnly(), 0),
       supportPlateThickness    ("supportPlateThickness"    , parsedOnly(), 0),
       chipThickness            ("chipThickness"            , parsedOnly(), 0),
-    removeModule             ("removeModule"             , parsedOnly(), false),
-    endcapDiskSurface          ("endcapDiskSurface"        , parsedOnly())
+    removeModule             ("removeModule"             , parsedOnly(), false)
 	{ }
 
     virtual bool hasAnyResolutionLocalXParam() const = 0;
@@ -320,6 +319,7 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   virtual TableRef tableRef() const = 0;
   virtual UniRef uniRef() const = 0;
   virtual int16_t moduleRing() const { return -1; }
+  virtual const int diskSurface() const { return -1; }
 
   inline bool isPixelModule() const { return (moduleType().find(insur::type_pixel) != std::string::npos); }
   inline bool isTimingModule() const { return (moduleType().find(insur::type_timing) != std::string::npos); }
@@ -520,6 +520,8 @@ public:
   int16_t moduleRing() const { return ring(); };
   int16_t blade() const { return (int16_t)myid(); } // CUIDADO Think of a better name!
   int16_t side() const { return (int16_t)signum(center().Z()); }
+  Property<int, AutoDefault> endcapDiskSurface;
+  const int diskSurface() const override { return endcapDiskSurface(); }
   //bool hasAnyResolutionLocalXParam() override { return (resolutionLocalXEndcapParam0.state() || resolutionLocalXEndcapParam1.state()); }
   //bool hasAnyResolutionLocalYParam() override { return (resolutionLocalYEndcapParam0.state() || resolutionLocalYEndcapParam1.state()); }
   ReadonlyProperty<double, NoDefault> resolutionLocalXEndcapParam0;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -122,6 +122,7 @@ public:
   Property<double, Default> supportPlateThickness;
   Property<double, Default> chipThickness;
 
+  Property<int, AutoDefault> endcapDiskSurface;
   Property<bool, Default> removeModule;
 
   int16_t cntId() const { return cntId_; }
@@ -159,7 +160,8 @@ public:
       hybridThickness          ("hybridThickness"          , parsedOnly(), 0),
       supportPlateThickness    ("supportPlateThickness"    , parsedOnly(), 0),
       chipThickness            ("chipThickness"            , parsedOnly(), 0),
-      removeModule             ("removeModule"             , parsedOnly(), false)
+    removeModule             ("removeModule"             , parsedOnly(), false),
+    endcapDiskSurface          ("endcapDiskSurface"        , parsedOnly())
 	{ }
 
     virtual bool hasAnyResolutionLocalXParam() const = 0;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -122,7 +122,6 @@ public:
   Property<double, Default> supportPlateThickness;
   Property<double, Default> chipThickness;
 
-  //Property<int, AutoDefault> diskSurface;
   Property<bool, Default> removeModule;
 
   int16_t cntId() const { return cntId_; }
@@ -160,7 +159,7 @@ public:
       hybridThickness          ("hybridThickness"          , parsedOnly(), 0),
       supportPlateThickness    ("supportPlateThickness"    , parsedOnly(), 0),
       chipThickness            ("chipThickness"            , parsedOnly(), 0),
-    removeModule             ("removeModule"             , parsedOnly(), false)
+      removeModule             ("removeModule"             , parsedOnly(), false)
 	{ }
 
     virtual bool hasAnyResolutionLocalXParam() const = 0;

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -118,6 +118,8 @@ public:
   int diskNumber() const { return diskNumber_; }
   int numEmptyRings() const { return count_if(rings_.begin(), rings_.end(), [](const Ring& r) { return r.numModules() == 0; }); }
 
+  const std::map<int, std::set<const Module*> > getSurfaceModules() const;
+
   const std::pair<double, bool> computeIntersectionWithZAxis(double lastZ, double lastRho, double newZ, double newRho) const;
   void computeActualCoverage();
   void computeActualZCoverage();
@@ -137,7 +139,6 @@ public:
   const MaterialObject& materialObject() const;
   ConversionStation* flangeConversionStation() const;
   const std::vector<ConversionStation*>& secondConversionStations() const;
-  std::vector< std::set<const Module*> > getModuleSurfaces() const;
  };
 
 #endif

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -118,7 +118,7 @@ public:
   int diskNumber() const { return diskNumber_; }
   int numEmptyRings() const { return count_if(rings_.begin(), rings_.end(), [](const Ring& r) { return r.numModules() == 0; }); }
 
-  const std::map<int, std::set<const Module*> > getSurfaceModules() const;
+  const std::map<int, std::vector<const Module*> > getSurfaceModules() const;
 
   const std::pair<double, bool> computeIntersectionWithZAxis(double lastZ, double lastRho, double newZ, double newRho) const;
   void computeActualCoverage();

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -216,9 +216,9 @@ namespace insur {
     std::string createModulesDetIdListCsv();
     std::string createSensorsDetIdListCsv();
 
-    std::string createModulesToDTCsCsv(const Tracker& t, bool isPositiveCablingSide);
-    std::string createDTCsToModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
-    std::string createBundlesToEndcapModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
+    std::string createModulesToDTCsCsv(const Tracker& t, const bool isPositiveCablingSide);
+    std::string createDTCsToModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide);
+    std::string createBundlesToEndcapModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide);
 
     TProfile* newProfile(TH1D* sourceHistogram, double xlow, double xup, int desiredNBins = 0);
     TProfile& newProfile(const TGraph& sourceGraph, double xlow, double xup, int nrebin = 1, int nBins = 0);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -217,6 +217,7 @@ namespace insur {
 
     std::string createModulesToDTCsCsv(const Tracker& t, bool isPositiveCablingSide);
     std::string createDTCsToModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
+    std::string createAggregationPatternsCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
 
     TProfile* newProfile(TH1D* sourceHistogram, double xlow, double xup, int desiredNBins = 0);
     TProfile& newProfile(const TGraph& sourceGraph, double xlow, double xup, int nrebin = 1, int nBins = 0);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -218,7 +218,7 @@ namespace insur {
 
     std::string createModulesToDTCsCsv(const Tracker& t, bool isPositiveCablingSide);
     std::string createDTCsToModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
-    std::string createAggregationPatternsCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
+    std::string createBundlesToEndcapModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide);
 
     TProfile* newProfile(TH1D* sourceHistogram, double xlow, double xup, int desiredNBins = 0);
     TProfile& newProfile(const TGraph& sourceGraph, double xlow, double xup, int nrebin = 1, int nBins = 0);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -166,8 +166,8 @@ namespace insur {
     void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
     void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide);
-    RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide);
+    void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection = "");
+    RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection = "");
 
     enum {ViewSectionXY=3, ViewSectionYZ=1, ViewSectionXZ=2};
     void drawEtaTicks(double maxL, double maxR, double tickDistance, double tickLength, double textDistance, Style_t labelFont, Float_t labelSize,

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -166,8 +166,9 @@ namespace insur {
     void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
     void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection = "");
-    RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection = "");
+    RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
 
     enum {ViewSectionXY=3, ViewSectionYZ=1, ViewSectionXZ=2};
     void drawEtaTicks(double maxL, double maxR, double tickDistance, double tickLength, double textDistance, Style_t labelFont, Float_t labelSize,

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -516,7 +516,8 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
 	std::stringstream cableInfo;
 	cableInfo << myCable->myid() << ","
 		  << any2str(myCable->type()) << ",";
-	bundleInfo << myCable->servicesChannel() << " " << myCable->servicesChannelSection() << ",";
+	bundleInfo << myCable->servicesChannel() << " " 
+		   << any2str(myCable->servicesChannelSection()) << ",";
 	
 	const DTC* myDTC = myCable->getDTC();
 	if (myDTC != nullptr) {

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -477,7 +477,7 @@ ModulesToDTCsVisitor::ModulesToDTCsVisitor(bool isPositiveCablingSide) {
 }
 
 void ModulesToDTCsVisitor::preVisit() {
-  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Bundle #/I, Cable #/I, Cable type/C, Cable ServicesChannel/I, DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D" << std::endl;
+  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Bundle #/I, PWR Services Channel/I, Cable #/I, Cable type/C, DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D" << std::endl;
 }
 
 void ModulesToDTCsVisitor::visit(const Barrel& b) {
@@ -515,8 +515,8 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
       if (myCable != nullptr) {
 	std::stringstream cableInfo;
 	cableInfo << myCable->myid() << ","
-		  << any2str(myCable->type()) << ","
-		  << myCable->servicesChannel() << ",";
+		  << any2str(myCable->type()) << ",";
+	bundleInfo << myCable->servicesChannel() << " " << myCable->servicesChannelSection() << ",";
 	
 	const DTC* myDTC = myCable->getDTC();
 	if (myDTC != nullptr) {

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,7 +11,9 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN A SERVICESCHANNEL TO THE CABLE
-  servicesChannel_ = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
+  const std::pair<int, std::string>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
+  servicesChannel_ = servicesChannelInfo.first;
+  servicesChannelSection_ = servicesChannelInfo.second;
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -28,65 +30,78 @@ Cable::~Cable() {
  * They are the channels where the optical cables are routed when they exit the tracker.
  * They are closely related to the phiSector ref.
  */
-const int Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+const std::pair<int, std::string> Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
   int servicesChannel = 0;
+  std::string servicesChannelSection;
+
   if (type == Category::PS10G) {
-    if (phiSectorRef == 0) servicesChannel = 1;
-    else if (phiSectorRef == 1) servicesChannel = 3;
-    else if (phiSectorRef == 2) servicesChannel = 4;
-    else if (phiSectorRef == 3) servicesChannel = 5;
-    else if (phiSectorRef == 4) servicesChannel = 6;
-    else if (phiSectorRef == 5) servicesChannel = 7;
-    else if (phiSectorRef == 6) servicesChannel = 9;
-    else if (phiSectorRef == 7) servicesChannel = 10;
-    else if (phiSectorRef == 8) servicesChannel = 12;   
+    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "C"; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "C"; }   
   }
   else if (type == Category::PS5G) {
     if (slot == 3) {
-      if (phiSectorRef == 0) servicesChannel = 1;
-      else if (phiSectorRef == 1) servicesChannel = 3;
-      else if (phiSectorRef == 2) servicesChannel = 4;
-      else if (phiSectorRef == 3) servicesChannel = 6;
-      else if (phiSectorRef == 4) servicesChannel = 7;
-      else if (phiSectorRef == 5) servicesChannel = 8;
-      else if (phiSectorRef == 6) servicesChannel = 10;
-      else if (phiSectorRef == 7) servicesChannel = 11;
-      else if (phiSectorRef == 8) servicesChannel = 12;
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "C"; }
     }
     else {
-      if (phiSectorRef == 0) servicesChannel = 1;
-      else if (phiSectorRef == 1) servicesChannel = 3;
-      else if (phiSectorRef == 2) servicesChannel = 4;
-      else if (phiSectorRef == 3) servicesChannel = 6;
-      else if (phiSectorRef == 4) servicesChannel = 7;
-      else if (phiSectorRef == 5) servicesChannel = 8;
-      else if (phiSectorRef == 6) servicesChannel = 10;
-      else if (phiSectorRef == 7) servicesChannel = 11;
-      else if (phiSectorRef == 8) servicesChannel = 12;
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "C"; }
     }
   }
   else if (type == Category::SS) {
-    if (slot != 1 && slot != 2) {
-      if (phiSectorRef == 0) servicesChannel = 1;
-      else if (phiSectorRef == 1) servicesChannel = 2;
-      else if (phiSectorRef == 2) servicesChannel = 4;
-      else if (phiSectorRef == 3) servicesChannel = 5;
-      else if (phiSectorRef == 4) servicesChannel = 6;
-      else if (phiSectorRef == 5) servicesChannel = 7;
-      else if (phiSectorRef == 6) servicesChannel = 9;
-      else if (phiSectorRef == 7) servicesChannel = 10;
-      else if (phiSectorRef == 8) servicesChannel = 12;
+    if (slot == 1 || slot == 2) {
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "A"; }
+    }
+    else if (slot == 3) {
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "A"; }
     }
     else {
-      if (phiSectorRef == 0) servicesChannel = 1;
-      else if (phiSectorRef == 1) servicesChannel = 2;
-      else if (phiSectorRef == 2) servicesChannel = 4;
-      else if (phiSectorRef == 3) servicesChannel = 6;
-      else if (phiSectorRef == 4) servicesChannel = 7;
-      else if (phiSectorRef == 5) servicesChannel = 8;
-      else if (phiSectorRef == 6) servicesChannel = 10;
-      else if (phiSectorRef == 7) servicesChannel = 11;
-      else if (phiSectorRef == 8) servicesChannel = 12;
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = "A"; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = "C"; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "A"; }
     }
   }
 
@@ -104,9 +119,10 @@ const int Cable::computeServicesChannel(const int phiSectorRef, const Category& 
     double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
     servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
     servicesChannel *= -1;
+    servicesChannelSection = (servicesChannelSection == "A" ? "C" : "A");
   }
 
-  return servicesChannel;
+  return std::make_pair(servicesChannel, servicesChannelSection);
 }
 
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,7 +11,7 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN A SERVICESCHANNEL TO THE CABLE
-  const std::pair<int, std::string>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
+  const std::pair<int, ChannelSection>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
   servicesChannel_ = servicesChannelInfo.first;
   servicesChannelSection_ = servicesChannelInfo.second;
 
@@ -30,78 +30,78 @@ Cable::~Cable() {
  * They are the channels where the optical cables are routed when they exit the tracker.
  * They are closely related to the phiSector ref.
  */
-const std::pair<int, std::string> Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+const std::pair<int, ChannelSection> Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
   int servicesChannel = 0;
-  std::string servicesChannelSection;
+  ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
 
   if (type == Category::PS10G) {
-    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "C"; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "C"; }   
+    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }   
   }
   else if (type == Category::PS5G) {
     if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "C"; }
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
     }
     else {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "C"; }
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
     }
   }
   else if (type == Category::SS) {
     if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "A"; }
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
     }
     else if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "A"; }
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
     }
     else {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = "A"; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = "C"; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = "A"; }
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
     }
   }
 
@@ -119,7 +119,7 @@ const std::pair<int, std::string> Cable::computeServicesChannel(const int phiSec
     double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
     servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
     servicesChannel *= -1;
-    servicesChannelSection = (servicesChannelSection == "A" ? "C" : "A");
+    servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
   }
 
   return std::make_pair(servicesChannel, servicesChannelSection);

--- a/src/Cabling/cabling_constants.cc
+++ b/src/Cabling/cabling_constants.cc
@@ -2,3 +2,5 @@
 
 
 define_enum_strings(Category) = { "Undefined", "PS10G", "PS10GA", "PS10GB", "PS5G", "2S" };
+
+define_enum_strings(ChannelSection) = { "Unknown", "A", "C" };

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -227,21 +227,21 @@ void Disk::build(const ScanEndcapInfo& extremaDisksInfo) {
 }
 
 
-const std::map<int, std::set<const Module*> > Disk::getSurfaceModules() const {
+const std::map<int, std::vector<const Module*> > Disk::getSurfaceModules() const {
 
   class SurfaceSplitterVisitor : public ConstGeometryVisitor {
   public:
-    const std::map<int, std::set<const Module*> > surfaceModules() const { return surfaceModules_; }
+    const std::map<int, std::vector<const Module*> > surfaceModules() const { return surfaceModules_; }
     void visit(const EndcapModule& m) {
-      surfaceModules_[m.diskSurface()].insert(&m);    
+      surfaceModules_[m.diskSurface()].push_back(&m);    
     }
   private:
-    std::map<int, std::set<const Module*> > surfaceModules_;
+    std::map<int, std::vector<const Module*> > surfaceModules_;
   };
 
   SurfaceSplitterVisitor v;
   accept(v);
-  const std::map<int, std::set<const Module*> >& surfaceModules = v.surfaceModules();
+  const std::map<int, std::vector<const Module*> >& surfaceModules = v.surfaceModules();
   return surfaceModules;
 }
 

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -331,7 +331,7 @@ const std::vector<ConversionStation*>& Disk::secondConversionStations() const {
 }
 
 std::vector<std::set<const Module*>> Disk::getModuleSurfaces() const {
-  class SurfaceSplitterVisitor : public ConstGeometryVisitor {
+  class SurfaceSplitterVisitor : public GeometryVisitor {
   private:
     int sideIndex;
     double ringAvgZ;
@@ -339,15 +339,16 @@ std::vector<std::set<const Module*>> Disk::getModuleSurfaces() const {
   public:
     double diskAverageZ;
     std::set<const Module*> mod[4];
-    void visit(const Ring& r) {
+    void visit(Ring& r) {
       sideIndex = 0;
       ringAvgZ = r.averageZ();
       if (ringAvgZ>diskAverageZ) sideIndex+=2;
     }
-    void visit(const Module& m) {
+    void visit(Module& m) {
       int deltaSide=0;
       if (m.center().Z()>ringAvgZ) deltaSide+=1;
       mod[sideIndex+deltaSide].insert(&m);
+      m.endcapDiskSurface(sideIndex+deltaSide);
     }
   };
   SurfaceSplitterVisitor v;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1386,35 +1386,15 @@ namespace insur {
       isPositiveCablingSide = true;
       channelsContent->addItem(positiveSideName);
       // GENERAL
-      // Fill services channels maps
-      std::map<int, std::vector<int> > cablesPerChannelPlus;
-      std::map<int, int> psBundlesPerChannelPlus;
-      std::map<int, int> ssBundlesPerChannelPlus;
-      analyzeServicesChannels(myCablingMap, cablesPerChannelPlus, psBundlesPerChannelPlus, ssBundlesPerChannelPlus, isPositiveCablingSide);
-      // Create table
-      RootWTable* channelsTablePlus = createServicesChannelTable(cablesPerChannelPlus, psBundlesPerChannelPlus, ssBundlesPerChannelPlus, isPositiveCablingSide);
+      RootWTable* channelsTablePlus = servicesChannels(myCablingMap, isPositiveCablingSide);
       channelsContent->addItem(channelsTablePlus);
-
       // SECTION A
-      std::string servicesChannelSection = "A";
-      // Fill services channels maps
-      std::map<int, std::vector<int> > cablesPerChannelPlusA;
-      std::map<int, int> psBundlesPerChannelPlusA;
-      std::map<int, int> ssBundlesPerChannelPlusA;
-      analyzeServicesChannels(myCablingMap, cablesPerChannelPlusA, psBundlesPerChannelPlusA, ssBundlesPerChannelPlusA, isPositiveCablingSide, servicesChannelSection);
-      // Create table
-      RootWTable* channelsTablePlusA = createServicesChannelTable(cablesPerChannelPlusA, psBundlesPerChannelPlusA, ssBundlesPerChannelPlusA, isPositiveCablingSide, servicesChannelSection);
+      ChannelSection requestedSection = ChannelSection::A;
+      RootWTable* channelsTablePlusA = servicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTablePlusA);
-
       // SECTION C
-      servicesChannelSection = "C";
-      // Fill services channels maps
-      std::map<int, std::vector<int> > cablesPerChannelPlusC;
-      std::map<int, int> psBundlesPerChannelPlusC;
-      std::map<int, int> ssBundlesPerChannelPlusC;
-      analyzeServicesChannels(myCablingMap, cablesPerChannelPlusC, psBundlesPerChannelPlusC, ssBundlesPerChannelPlusC, isPositiveCablingSide, servicesChannelSection);
-      // Create table
-      RootWTable* channelsTablePlusC = createServicesChannelTable(cablesPerChannelPlusC, psBundlesPerChannelPlusC, ssBundlesPerChannelPlusC, isPositiveCablingSide, servicesChannelSection);
+      requestedSection = ChannelSection::C;
+      RootWTable* channelsTablePlusC = servicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTablePlusC);
 
       // NEGATIVE CABLING SIDE
@@ -1422,36 +1402,16 @@ namespace insur {
       channelsContent->addItem(spacer);
       channelsContent->addItem(negativeSideName);
       // GENERAL
-      servicesChannelSection = "";
-      // Fill services channels maps
-      std::map<int, std::vector<int> > cablesPerChannelMinus;
-      std::map<int, int> psBundlesPerChannelMinus;
-      std::map<int, int> ssBundlesPerChannelMinus;
-      analyzeServicesChannels(myCablingMap, cablesPerChannelMinus, psBundlesPerChannelMinus, ssBundlesPerChannelMinus, isPositiveCablingSide);
-      // Create table
-      RootWTable* channelsTableMinus = createServicesChannelTable(cablesPerChannelMinus, psBundlesPerChannelMinus, ssBundlesPerChannelMinus, isPositiveCablingSide);
+      requestedSection = ChannelSection::UNKNOWN;
+      RootWTable* channelsTableMinus = servicesChannels(myCablingMap, isPositiveCablingSide);
       channelsContent->addItem(channelsTableMinus);
-
       // SECTION A
-      servicesChannelSection = "A";
-      // Fill services channels maps
-      std::map<int, std::vector<int> > cablesPerChannelMinusA;
-      std::map<int, int> psBundlesPerChannelMinusA;
-      std::map<int, int> ssBundlesPerChannelMinusA;
-      analyzeServicesChannels(myCablingMap, cablesPerChannelMinusA, psBundlesPerChannelMinusA, ssBundlesPerChannelMinusA, isPositiveCablingSide, servicesChannelSection);
-      // Create table
-      RootWTable* channelsTableMinusA = createServicesChannelTable(cablesPerChannelMinusA, psBundlesPerChannelMinusA, ssBundlesPerChannelMinusA, isPositiveCablingSide, servicesChannelSection);
+      requestedSection = ChannelSection::A;
+      RootWTable* channelsTableMinusA = servicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTableMinusA);
-
       // SECTION C
-      servicesChannelSection = "C";
-      // Fill services channels maps
-      std::map<int, std::vector<int> > cablesPerChannelMinusC;
-      std::map<int, int> psBundlesPerChannelMinusC;
-      std::map<int, int> ssBundlesPerChannelMinusC;
-      analyzeServicesChannels(myCablingMap, cablesPerChannelMinusC, psBundlesPerChannelMinusC, ssBundlesPerChannelMinusC, isPositiveCablingSide, servicesChannelSection);
-      // Create table
-      RootWTable* channelsTableMinusC = createServicesChannelTable(cablesPerChannelMinusC, psBundlesPerChannelMinusC, ssBundlesPerChannelMinusC, isPositiveCablingSide, servicesChannelSection);
+      requestedSection = ChannelSection::C;
+      RootWTable* channelsTableMinusC = servicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTableMinusC);
 
 
@@ -1476,23 +1436,44 @@ namespace insur {
   }
 
 
+  /* Interface to gather information on services channels, and create a table storing it.
+   */
+  RootWTable* Vizard::servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection) {
+    std::map<int, std::vector<int> > cablesPerChannel;
+    std::map<int, int> psBundlesPerChannel;
+    std::map<int, int> ssBundlesPerChannel;
 
-  void Vizard::analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection) {
+    // Fill services channels maps.
+    analyzeServicesChannels(myCablingMap, cablesPerChannel, psBundlesPerChannel, ssBundlesPerChannel, isPositiveCablingSide, requestedSection);
+
+    // Create table.
+    RootWTable* channelsTable = createServicesChannelTable(cablesPerChannel, psBundlesPerChannel, ssBundlesPerChannel, isPositiveCablingSide, requestedSection);
+
+    return channelsTable;
+  }
+
+
+  /* Get the requested Services Channels info from the cabling map.
+   */
+  void Vizard::analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection) {
 
     const std::map<int, Cable*>& cables = (isPositiveCablingSide ? myCablingMap->getCables() : myCablingMap->getNegCables());
 
     for (const auto& myCable : cables) {
-      std::string section = myCable.second->servicesChannelSection();
+      const ChannelSection& mySection = myCable.second->servicesChannelSection();
 
-      if (requestedSection == "" || (requestedSection != "" && section == requestedSection)) {
+      // If necessary, can select the Services Channels corresponding to the requested section.
+      if ( requestedSection == ChannelSection::UNKNOWN 
+	   || (requestedSection != ChannelSection::UNKNOWN && mySection == requestedSection)
+	   ) {
 
-	int channel = myCable.second->servicesChannel();
+	const int channel = myCable.second->servicesChannel();
 
-	int cableId = myCable.first;
+	const int cableId = myCable.first;
 	cablesPerChannel[channel].push_back(cableId);
 
-	Category cableType = myCable.second->type();      
-	int numBundles = myCable.second->numBundles();
+	const Category cableType = myCable.second->type();      
+	const int numBundles = myCable.second->numBundles();
 
 	if (cableType == Category::PS10G || cableType == Category::PS5G) psBundlesPerChannel[channel] += numBundles;
 	else if (cableType == Category::SS) ssBundlesPerChannel[channel] += numBundles;
@@ -1502,8 +1483,9 @@ namespace insur {
   }
 
 
-
-  RootWTable* Vizard::createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection) {
+  /* Create the table with Services Channel information.
+   */
+  RootWTable* Vizard::createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection) {
 
     RootWTable* channelsTable = new RootWTable();
 
@@ -1520,7 +1502,7 @@ namespace insur {
 
     // Fill table
     for (int i = 1; i <= 12; i++) {
-      int channel = (isPositiveCablingSide ? i : -i);
+      const int channel = (isPositiveCablingSide ? i : -i);
       int numCablesPerChannel = (cablesPerChannel.count(channel) != 0 ? cablesPerChannel.at(channel).size() : 0);
       int numPsBundlesPerChannel = (psBundlesPerChannel.count(channel) != 0 ? psBundlesPerChannel.at(channel) : 0);
       int numSsBundlesPerChannel = (ssBundlesPerChannel.count(channel) != 0 ? ssBundlesPerChannel.at(channel) : 0);
@@ -1529,7 +1511,7 @@ namespace insur {
       // Channel name
       std::stringstream channelName;
       channelName << "OT" << channel;
-      if (requestedSection != "") channelName << " " << requestedSection;
+      if (requestedSection != ChannelSection::UNKNOWN) channelName << " " << any2str(requestedSection);
       channelsTable->setContent(i, 0, channelName.str());
 
       channelsTable->setContent(i, 1, numCablesPerChannel);
@@ -1550,7 +1532,6 @@ namespace insur {
 
     return channelsTable;
   }
-
 
 
 
@@ -6845,13 +6826,14 @@ namespace insur {
 	  cableInfo << cable.myid() << ","
 		    << any2str(cable.type()) << ",";
 	  int servicesChannel = cable.servicesChannel();
-	  std::string servicesChannelSection = cable.servicesChannelSection();
+	  ChannelSection servicesChannelSection = cable.servicesChannelSection();
 
 	  const PtrVector<Bundle>& myBundles = cable.bundles();
 	  for (const auto& bundle : myBundles) {
 	    std::stringstream bundleInfo;
 	    bundleInfo << bundle.myid() << ","
-		       << servicesChannel << " " << servicesChannelSection << ",";
+		       << servicesChannel << " " 
+		       << any2str(servicesChannelSection) << ",";
 
 	    const PtrVector<Module>& myModules = bundle.modules();
 	    for (const auto& module : myModules) {

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6459,11 +6459,11 @@ namespace insur {
       if (anEndcap.disks().size()>0) {
 	const Disk& lastDisk = anEndcap.disks().back();
      
-	const std::map<int, std::set<const Module*> >& allSurfaceModules = lastDisk.getSurfaceModules();
+	const std::map<int, std::vector<const Module*> >& allSurfaceModules = lastDisk.getSurfaceModules();
 	for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
 	  auto found = allSurfaceModules.find(surfaceIndex);
 	  if (found != allSurfaceModules.end()) {
-	    const std::set<const Module*>& surfaceModules = found->second;
+	    const std::vector<const Module*>& surfaceModules = found->second;
 	    TCanvas* XYCanvasEC = new TCanvas(Form("XYCanvasEC_%s_%d", anEndcap.myid().c_str(), surfaceIndex),
 					      Form("XY projection of Endcap %s -- surface %d", anEndcap.myid().c_str(), surfaceIndex),
 					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6541,11 +6541,11 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       if (anEndcap.disks().size() > 0) {
 	const Disk& lastDisk = anEndcap.disks().back();	
-	const std::map<int, std::set<const Module*> >& allSurfaceModules = lastDisk.getSurfaceModules();
+	const std::map<int, std::vector<const Module*> >& allSurfaceModules = lastDisk.getSurfaceModules();
 	for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
 	  auto found = allSurfaceModules.find(surfaceIndex);
 	  if (found != allSurfaceModules.end()) {
-	    const std::set<const Module*>& surfaceModules = found->second;
+	    const std::vector<const Module*>& surfaceModules = found->second;
 	    TCanvas* XYSurfaceDisk = new TCanvas(Form("XYSurfaceEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						 Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), surfaceIndex),
 						 vis_min_canvas_sizeX, vis_min_canvas_sizeY );

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6800,7 +6800,7 @@ namespace insur {
 
   /* Create csv file, navigating from Module hierarchy level to DTC hierarchy level.
    */
-  std::string Vizard::createModulesToDTCsCsv(const Tracker& tracker, bool isPositiveCablingSide) {
+  std::string Vizard::createModulesToDTCsCsv(const Tracker& tracker, const bool isPositiveCablingSide) {
     ModulesToDTCsVisitor v(isPositiveCablingSide);
     v.preVisit();
     tracker.accept(v);
@@ -6810,7 +6810,7 @@ namespace insur {
 
   /* Create csv file, navigating from DTC hierarchy level to Module hierarchy level.
    */
-  std::string Vizard::createDTCsToModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide) {
+  std::string Vizard::createDTCsToModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide) {
 
     std::stringstream modulesToDTCsCsv;
     modulesToDTCsCsv << "DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, Cable #/I, Cable type/C, Bundle #/I, PWR Services Channel/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
@@ -6831,8 +6831,8 @@ namespace insur {
 	  std::stringstream cableInfo;
 	  cableInfo << cable.myid() << ","
 		    << any2str(cable.type()) << ",";
-	  int servicesChannel = cable.servicesChannel();
-	  ChannelSection servicesChannelSection = cable.servicesChannelSection();
+	  const int servicesChannel = cable.servicesChannel();
+	  const ChannelSection servicesChannelSection = cable.servicesChannelSection();
 
 	  const PtrVector<Bundle>& myBundles = cable.bundles();
 	  for (const auto& bundle : myBundles) {
@@ -6874,7 +6874,7 @@ namespace insur {
      - 3 modules from disk surface 3.
      - 2 modules from disk surface 4 (the disk surface with biggest |Z|).
    */
-  std::string Vizard::createBundlesToEndcapModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide) {
+  std::string Vizard::createBundlesToEndcapModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide) {
 
     std::stringstream bundlesToEndcapModulesCsv;
     bundlesToEndcapModulesCsv << "Bundle #/I, # Modules per Disk Surface (Sorted by increasing |Z|), Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
@@ -6911,7 +6911,7 @@ namespace insur {
 		modulesInBundleInfo.push_back(moduleInfo.str());
 
 		// Get which disk surface the module belongs to.
-		int surfaceIndex = module.diskSurface();
+		const int surfaceIndex = module.diskSurface();
 		// Count the number of modules per disk surface.
 		pattern[surfaceIndex] += 1; 
 	      }
@@ -6931,7 +6931,7 @@ namespace insur {
 	      
 	      // Print info in csv file: bundle info + pattern info + associated modules info.
 	      bundlesToEndcapModulesCsv << bundleInfo.str() << patternInfo.str();
-	      int numModulesInBundle = modulesInBundleInfo.size();
+	      const int numModulesInBundle = modulesInBundleInfo.size();
 	      for (int i = 0; i < numModulesInBundle; i++) {
 		// Set empty the first 2 columns, since they are the same for all modules belonging to a given bundle.
 		if (i != 0) bundlesToEndcapModulesCsv << ", " << ", ";

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1373,6 +1373,7 @@ namespace insur {
       // POSITIVE CABLING SIDE
       isPositiveCablingSide = true;
       channelsContent->addItem(positiveSideName);
+      // GENERAL
       // Fill services channels maps
       std::map<int, std::vector<int> > cablesPerChannelPlus;
       std::map<int, int> psBundlesPerChannelPlus;
@@ -1381,10 +1382,35 @@ namespace insur {
       // Create table
       RootWTable* channelsTablePlus = createServicesChannelTable(cablesPerChannelPlus, psBundlesPerChannelPlus, ssBundlesPerChannelPlus, isPositiveCablingSide);
       channelsContent->addItem(channelsTablePlus);
+
+      // SECTION A
+      std::string servicesChannelSection = "A";
+      // Fill services channels maps
+      std::map<int, std::vector<int> > cablesPerChannelPlusA;
+      std::map<int, int> psBundlesPerChannelPlusA;
+      std::map<int, int> ssBundlesPerChannelPlusA;
+      analyzeServicesChannels(myCablingMap, cablesPerChannelPlusA, psBundlesPerChannelPlusA, ssBundlesPerChannelPlusA, isPositiveCablingSide, servicesChannelSection);
+      // Create table
+      RootWTable* channelsTablePlusA = createServicesChannelTable(cablesPerChannelPlusA, psBundlesPerChannelPlusA, ssBundlesPerChannelPlusA, isPositiveCablingSide, servicesChannelSection);
+      channelsContent->addItem(channelsTablePlusA);
+
+      // SECTION C
+      servicesChannelSection = "C";
+      // Fill services channels maps
+      std::map<int, std::vector<int> > cablesPerChannelPlusC;
+      std::map<int, int> psBundlesPerChannelPlusC;
+      std::map<int, int> ssBundlesPerChannelPlusC;
+      analyzeServicesChannels(myCablingMap, cablesPerChannelPlusC, psBundlesPerChannelPlusC, ssBundlesPerChannelPlusC, isPositiveCablingSide, servicesChannelSection);
+      // Create table
+      RootWTable* channelsTablePlusC = createServicesChannelTable(cablesPerChannelPlusC, psBundlesPerChannelPlusC, ssBundlesPerChannelPlusC, isPositiveCablingSide, servicesChannelSection);
+      channelsContent->addItem(channelsTablePlusC);
+
       // NEGATIVE CABLING SIDE
       isPositiveCablingSide = false;
       channelsContent->addItem(spacer);
       channelsContent->addItem(negativeSideName);
+      // GENERAL
+      servicesChannelSection = "";
       // Fill services channels maps
       std::map<int, std::vector<int> > cablesPerChannelMinus;
       std::map<int, int> psBundlesPerChannelMinus;
@@ -1393,6 +1419,28 @@ namespace insur {
       // Create table
       RootWTable* channelsTableMinus = createServicesChannelTable(cablesPerChannelMinus, psBundlesPerChannelMinus, ssBundlesPerChannelMinus, isPositiveCablingSide);
       channelsContent->addItem(channelsTableMinus);
+
+      // SECTION A
+      servicesChannelSection = "A";
+      // Fill services channels maps
+      std::map<int, std::vector<int> > cablesPerChannelMinusA;
+      std::map<int, int> psBundlesPerChannelMinusA;
+      std::map<int, int> ssBundlesPerChannelMinusA;
+      analyzeServicesChannels(myCablingMap, cablesPerChannelMinusA, psBundlesPerChannelMinusA, ssBundlesPerChannelMinusA, isPositiveCablingSide, servicesChannelSection);
+      // Create table
+      RootWTable* channelsTableMinusA = createServicesChannelTable(cablesPerChannelMinusA, psBundlesPerChannelMinusA, ssBundlesPerChannelMinusA, isPositiveCablingSide, servicesChannelSection);
+      channelsContent->addItem(channelsTableMinusA);
+
+      // SECTION C
+      servicesChannelSection = "C";
+      // Fill services channels maps
+      std::map<int, std::vector<int> > cablesPerChannelMinusC;
+      std::map<int, int> psBundlesPerChannelMinusC;
+      std::map<int, int> ssBundlesPerChannelMinusC;
+      analyzeServicesChannels(myCablingMap, cablesPerChannelMinusC, psBundlesPerChannelMinusC, ssBundlesPerChannelMinusC, isPositiveCablingSide, servicesChannelSection);
+      // Create table
+      RootWTable* channelsTableMinusC = createServicesChannelTable(cablesPerChannelMinusC, psBundlesPerChannelMinusC, ssBundlesPerChannelMinusC, isPositiveCablingSide, servicesChannelSection);
+      channelsContent->addItem(channelsTableMinusC);
 
 
       // Distinct DTCs 2D map
@@ -1417,28 +1465,33 @@ namespace insur {
 
 
 
-  void Vizard::analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide) {
+  void Vizard::analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection) {
 
     const std::map<int, Cable*>& cables = (isPositiveCablingSide ? myCablingMap->getCables() : myCablingMap->getNegCables());
 
     for (const auto& myCable : cables) {
-      int channel = myCable.second->servicesChannel();
+      std::string section = myCable.second->servicesChannelSection();
 
-      int cableId = myCable.first;
-      cablesPerChannel[channel].push_back(cableId);
+      if (requestedSection == "" || (requestedSection != "" && section == requestedSection)) {
 
-      Category cableType = myCable.second->type();      
-      int numBundles = myCable.second->numBundles();
+	int channel = myCable.second->servicesChannel();
 
-      if (cableType == Category::PS10G || cableType == Category::PS5G) psBundlesPerChannel[channel] += numBundles;
-      else if (cableType == Category::SS) ssBundlesPerChannel[channel] += numBundles;
-      else { std::cout << "analyzeServicesChannels : Undetected cable type" << std::endl; }
+	int cableId = myCable.first;
+	cablesPerChannel[channel].push_back(cableId);
+
+	Category cableType = myCable.second->type();      
+	int numBundles = myCable.second->numBundles();
+
+	if (cableType == Category::PS10G || cableType == Category::PS5G) psBundlesPerChannel[channel] += numBundles;
+	else if (cableType == Category::SS) ssBundlesPerChannel[channel] += numBundles;
+	else { std::cout << "analyzeServicesChannels : Undetected cable type" << std::endl; }
+      }
     }
   }
 
 
 
-  RootWTable* Vizard::createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide) {
+  RootWTable* Vizard::createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, bool isPositiveCablingSide, std::string requestedSection) {
 
     RootWTable* channelsTable = new RootWTable();
 
@@ -1464,6 +1517,7 @@ namespace insur {
       // Channel name
       std::stringstream channelName;
       channelName << "OT" << channel;
+      if (requestedSection != "") channelName << " " << requestedSection;
       channelsTable->setContent(i, 0, channelName.str());
 
       channelsTable->setContent(i, 1, numCablesPerChannel);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1313,6 +1313,12 @@ namespace insur {
       myTextFile->addText(createDTCsToModulesCsv(myCablingMap, isPositiveCablingSide));
       filesContent->addItem(myTextFile);
       // Bundles to Modules: Aggregation Patterns in TEDD
+      /*This is used for bundle assembly.
+	For example, for a given buddle, the pattern 3-4-3-2 means that the bundle is connected to:
+	- 3 modules from disk surface 1 (the disk surface with lowest |Z|).
+	- 4 modules from disk surface 2.
+	- 3 modules from disk surface 3.
+	- 2 modules from disk surface 4 (the disk surface with biggest |Z|).*/
       myTextFile = new RootWTextFile(Form("AggregationPatternsPos%s.csv", name.c_str()), "Bundles to Modules: Aggregation Patterns in TEDD");
       myTextFile->addText(createBundlesToEndcapModulesCsv(myCablingMap, isPositiveCablingSide));
       filesContent->addItem(myTextFile);
@@ -1335,8 +1341,6 @@ namespace insur {
       myTextFile = new RootWTextFile(Form("DTCsToModulesNeg%s.csv", name.c_str()), "DTCs to modules");
       myTextFile->addText(createDTCsToModulesCsv(myCablingMap, isPositiveCablingSide));
       filesContent->addItem(myTextFile);
-
-      
 
 
       // Cabling efficiency

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6814,7 +6814,7 @@ namespace insur {
   std::string Vizard::createDTCsToModulesCsv(const CablingMap* myCablingMap, bool isPositiveCablingSide) {
 
     std::stringstream modulesToDTCsCsv;
-    modulesToDTCsCsv << "DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, Cable #/I, Cable type/C, Cable ServicesChannel/I, Bundle #/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
+    modulesToDTCsCsv << "DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, Cable #/I, Cable type/C, Bundle #/I, PWR Services Channel/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
 
     const std::map<const std::string, const DTC*>& myDTCs = (isPositiveCablingSide ? myCablingMap->getDTCs() : myCablingMap->getNegDTCs());
     for (const auto& dtc : myDTCs) {
@@ -6831,13 +6831,15 @@ namespace insur {
 	for (const auto& cable : myCables) {
 	  std::stringstream cableInfo;
 	  cableInfo << cable.myid() << ","
-		    << any2str(cable.type()) << ","
-		    << cable.servicesChannel() << ",";
+		    << any2str(cable.type()) << ",";
+	  int servicesChannel = cable.servicesChannel();
+	  std::string servicesChannelSection = cable.servicesChannelSection();
 
 	  const PtrVector<Bundle>& myBundles = cable.bundles();
 	  for (const auto& bundle : myBundles) {
 	    std::stringstream bundleInfo;
-	    bundleInfo << bundle.myid() << ",";
+	    bundleInfo << bundle.myid() << ","
+		       << servicesChannel << " " << servicesChannelSection << ",";
 
 	    const PtrVector<Module>& myModules = bundle.modules();
 	    for (const auto& module : myModules) {


### PR DESCRIPTION
- Added services channels sections in PP1, so that full optical cabling map can also be used for power cables.
The mapping for 1 power cable follows the same scheme as for 1 optical bundle.
Though, optical and power cables have a different assignment in PP1, which is dealt with here.

There are 3 sections for cables in PP1: A, B, and C.
The optical bundles are always placed in section B.
The power cables are assigned to section A or C.

- The positions of channels with cooling have been optimized.   
1 channel out of 2 leaves space for cooling pipes routing.

- Added extra info on bundles in TEDD, to ease the Mechanics studies.
One provides, for a given bundle, the number of connected modules per disk surface.
The disk surfaces are sorted per increasing |Z|.
 For example, for a given bundle, the pattern 3-4-3-2 means that the bundle is connected to:   
 3 modules from disk surface 1 (the disk surface with lowest |Z|).      
 4 modules from disk surface 2.     
 3 modules from disk surface 3.     
 2 modules from disk surface 4 (the disk surface with biggest |Z|).