### PR TITLE
Cabling in TEDD, from modules to bundles: add info on possible modules aggregation patterns combinations.

### DIFF
--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -219,6 +219,7 @@ namespace insur {
     std::string createModulesToDTCsCsv(const Tracker& t, const bool isPositiveCablingSide);
     std::string createDTCsToModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide);
     std::string createBundlesToEndcapModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide);
+    std::string countBundlesToEndcapModulesCombinations(const CablingMap* myCablingMap, const bool isPositiveCablingSide);
 
     TProfile* newProfile(TH1D* sourceHistogram, double xlow, double xup, int desiredNBins = 0);
     TProfile& newProfile(const TGraph& sourceGraph, double xlow, double xup, int nrebin = 1, int nBins = 0);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6956,7 +6956,6 @@ namespace insur {
     }
     if (myDTCs.size() == 0) bundlesToEndcapModulesCsv << std::endl;
 
-
     return bundlesToEndcapModulesCsv.str();
   }
 
@@ -6999,17 +6998,22 @@ namespace insur {
 		pattern[surfaceIndex] += 1; 
 	      }
 
-	      // Checks pattern makes sense, and put it in a-b-c-d format.
-	      std::multiset<int> combination;
+	      // Checks pattern makes sense, and create the corresponding combination.
+	      // A combination is the number of modules per disk surface, irrespective of the surface |Z| ordering.
+	      // One wants 1-2-3-4 and 3-4-1-2 to end up in the same combination: 1-2-3-4.
+	      // Duplicates are allowed: combination 1-2-3-3 can happen!
+	      std::multiset<int> combination;  
 	      for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
 		auto found = pattern.find(surfaceIndex);
 		if (found != pattern.end()) {
 		  const int numModulesPerDiskSurface = found->second;
+		  // Create combination
 		  combination.insert(numModulesPerDiskSurface);
 		}
 		else logERROR("In TEDD, bundle " + any2str(bundle.myid()) 
 			      + "does not connect to any module belonging to disk surface" + any2str(surfaceIndex));
 	      }
+	      // Count the occurences of each combination.
 	      combinationsDistribution[combination] += 1;
 	    }
 	  }	 
@@ -7017,6 +7021,7 @@ namespace insur {
       }
     }
 
+    // Print the different encountered combinations, and their occurences.
     for (const auto& comb : combinationsDistribution) {
       summaryText << "Combination";
       std::multiset<int> combination = comb.first;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6965,7 +6965,8 @@ namespace insur {
      A pattern is, for a given bundle, the number of connected modules per disk surface.
      Here, patterns are irrespective of the disk surface ordering.
      For example, 1-2-3-4 or 3-4-1-2 are both considered to be combination 1-2-3-4.
-     All this is because Mechanics will need, in TEDD, custom aggregation patch cords, to group the fibers from each disk surface into one bundle.
+     All this is because Electronics/Mechanics will need, in TEDD, custom aggregation patch cords, 
+     to group the fibers from each disk surface into one bundle.
      One need to know how many customs aggregation patch cords are needed!
   */
   std::string Vizard::countBundlesToEndcapModulesCombinations(const CablingMap* myCablingMap, const bool isPositiveCablingSide) {


### PR DESCRIPTION
This is for used for the Mechanics/Electronics designs.
For more details, please have a look at: https://indico.cern.ch/event/651638/contributions/2660769/attachments/1494529/2324838/CMSTrackerWeek18July2017_Cabling.pdf 

We consider one given bundle here in TEDD.
The fibers from all modules are gathered, at the edge of each disk surface, with a ferrule.
The corresponding 4 cables from the 4 disk surfaces are, in turn, gathered into the bundle.
This is done thanks to a custom aggregation system, since the cables from the disk surfaces are linked to more or less modules.

One need to know the number of different custom aggregation systems needed.
This is irrespective of the ordering of the disk surfaces.

This info is added on top of the relevant csv file, on the cabling tab on the website.