### PR TITLE
Small PR: Added Tracking Volumes Services Details plots + cleaned Tracking Volume code

### DIFF
--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -498,6 +498,7 @@ namespace insur {
     bool isModuleInEtaSector(const Tracker& tracker, const Module* module, int etaSector) const;
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;
 
+    void computeTrackingVolumeMaterialBudget(const Track& track, const int nTracks, const std::map<std::string, Material>& innerTrackerModulesComponentsRI, const std::map<std::string, Material>& outerTrackerModulesComponentsRI);
     void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax);
     const Material computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical);
 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -59,6 +59,21 @@ namespace insur {
    */
   static const std::string msg_module_warning = "Warning: tracker module with undefined subdetector type found.";
 
+
+  /**
+   * Constants specific to the Analyzer
+   */
+  static const std::string outer_tracker_id = "Outer";
+  static const std::string beam_pipe = "Beam Pipe";
+  static const std::string services_under_pixel_tracking_volume = "Services under Pixel Tracking Volume";
+  static const std::string services_in_pixel_tracking_volume = "Services in Pixel Tracking Volume";
+  static const std::string supports_in_pixel_tracking_volume = "Supports in Pixel Tracking Volume";
+  static const std::string services_and_supports_in_interstice = "Services and supports in interstice";
+  static const std::string services_in_outer_tracking_volume = "Services in Outer Tracking Volume";
+  static const std::string supports_in_outer_tracking_volume = "Supports in Outer Tracking Volume";
+
+
+
   /**
    * Two comparison functions for <i>std::pair<int, int></i> entries.
    */
@@ -91,22 +106,30 @@ namespace insur {
   class Analyzer : private AnalyzerTools {
   public:
     Analyzer();
-    virtual ~Analyzer() {}
+    virtual ~Analyzer() {}  
     std::map<std::string, TH1D*>& getHistoActiveComponentsR() { return rComponents; }
     std::map<std::string, TH1D*>& getHistoActiveComponentsI() { return iComponents; }
+    // TRACKING VOLUMES PLOTS
+    // Beam pipe
     std::map<std::string, TH1D*>& getHistoBeamPipeR() { return rComponentsBeamPipe; }
     std::map<std::string, TH1D*>& getHistoBeamPipeI() { return iComponentsBeamPipe; }
+    // Pixel interstice (between Beam pipe and Pixel tracking volumes)
     std::map<std::string, TH1D*>& getHistoPixelIntersticeR() { return rComponentsPixelInterstice; }
     std::map<std::string, TH1D*>& getHistoPixelIntersticeI() { return iComponentsPixelInterstice; }
+    // Pixel tracking volume
     std::map<std::string, TH1D*>& getHistoPixelTrackingVolumeR() { return rComponentsPixelTrackingVolume; }
     std::map<std::string, TH1D*>& getHistoPixelTrackingVolumeI() { return iComponentsPixelTrackingVolume; }
+    // Interstice (betweenPixel and Outer tracking volumes)
     std::map<std::string, TH1D*>& getHistoIntersticeR() { return rComponentsInterstice; }
     std::map<std::string, TH1D*>& getHistoIntersticeI() { return iComponentsInterstice; }
+    // Outer tracking volume
     std::map<std::string, TH1D*>& getHistoOuterTrackingVolumeR() { return rComponentsOuterTrackingVolume; }
     std::map<std::string, TH1D*>& getHistoOuterTrackingVolumeI() { return iComponentsOuterTrackingVolume; }
-    //std::map<std::string, TH1D*>& getHistoTotalTrackingVolumeR() { return rComponentsTotalTrackingVolume; }
-    //std::map<std::string, TH1D*>& getHistoTotalTrackingVolumeI() { return iComponentsTotalTrackingVolume; }
-    //std::vector<std::string>& getComponentsTrackingVolume() { return componentsTotalTrackingVolumeOrder; }
+    // SERVICES DETAILS (in Pixel and Outer tracking volumes only)
+    std::map<std::string, TH1D*>& getHistoServicesDetailsPixelTrackingVolumeR() { return rComponentsServicesDetailsPixelTrackingVolume; }
+    std::map<std::string, TH1D*>& getHistoServicesDetailsPixelTrackingVolumeI() { return iComponentsServicesDetailsPixelTrackingVolume; }
+    std::map<std::string, TH1D*>& getHistoServicesDetailsOuterTrackingVolumeR() { return rComponentsServicesDetailsOuterTrackingVolume; }
+    std::map<std::string, TH1D*>& getHistoServicesDetailsOuterTrackingVolumeI() { return iComponentsServicesDetailsOuterTrackingVolume; }
     TH1D& getHistoModulesBarrelsR() { return ractivebarrel; }
     TH1D& getHistoModulesBarrelsI() { return iactivebarrel; }
     TH1D& getHistoModulesEndcapsR() { return ractiveendcap; }
@@ -317,6 +340,8 @@ namespace insur {
     std::map<std::string, TH1D*> rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume;
     std::map<std::string, TH1D*> rComponentsInterstice, iComponentsInterstice;
     std::map<std::string, TH1D*> rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume;
+    std::map<std::string, TH1D*> rComponentsServicesDetailsPixelTrackingVolume, iComponentsServicesDetailsPixelTrackingVolume;
+    std::map<std::string, TH1D*> rComponentsServicesDetailsOuterTrackingVolume, iComponentsServicesDetailsOuterTrackingVolume;
     TH2D isor, isoi;
     TH2D mapRadiation, mapInteraction;
     TH2I mapRadiationCount, mapInteractionCount;

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -498,6 +498,8 @@ namespace insur {
     bool isModuleInEtaSector(const Tracker& tracker, const Module* module, int etaSector) const;
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;
 
+    void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax);
+
     static int bsCounter;
     
     std::string billOfMaterials_;

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -499,6 +499,7 @@ namespace insur {
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;
 
     void computeTrackingVolumeMaterialBudget(const Track& track, const int nTracks, const std::map<std::string, Material>& innerTrackerModulesComponentsRI, const std::map<std::string, Material>& outerTrackerModulesComponentsRI);
+    void fillRIServicesDetailsHistos(std::map<std::string, TH1D*>& rServicesDetails, std::map<std::string, TH1D*>& iServicesDetails, const Hit* hitOnService, const double eta, const double theta, const int nTracks, const double etaMax);
     void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax);
     const Material computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical);
 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -499,6 +499,7 @@ namespace insur {
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;
 
     void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax);
+    const Material computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical);
 
     static int bsCounter;
     

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -499,9 +499,9 @@ namespace insur {
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;
 
     void computeTrackingVolumeMaterialBudget(const Track& track, const int nTracks, const std::map<std::string, Material>& innerTrackerModulesComponentsRI, const std::map<std::string, Material>& outerTrackerModulesComponentsRI);
-    void fillRIServicesDetailsHistos(std::map<std::string, TH1D*>& rServicesDetails, std::map<std::string, TH1D*>& iServicesDetails, const Hit* hitOnService, const double eta, const double theta, const int nTracks, const double etaMax);
-    void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax);
-    const Material computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical);
+    void fillRIServicesDetailsHistos(std::map<std::string, TH1D*>& rServicesDetails, std::map<std::string, TH1D*>& iServicesDetails, const Hit* hitOnService, const double eta, const double theta, const int nTracks, const double etaMax) const;
+    void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax) const;
+    const Material computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical) const;
 
     static int bsCounter;
     

--- a/include/Hit.hh
+++ b/include/Hit.hh
@@ -86,7 +86,7 @@ public:
   Hit(double myDistance);
   Hit(double myDistance, Module* myModule, HitType activeHitType);
   Module* getHitModule() { return hitModule_; };
-  InactiveElement* getHitInactiveElement() { return hitInactiveElement_; };
+  InactiveElement* getHitInactiveElement() const { return hitInactiveElement_; };
   void computeLocalResolution();
   double getResolutionRphi(double trackR);
   double getResolutionZ(double trackR);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -153,7 +153,8 @@ namespace insur {
   private:
     TProfile* totalEtaProfileSensors_ = 0, *totalEtaProfileSensorsPixel_ = 0;
     TProfile* totalEtaProfileLayers_ = 0, *totalEtaProfileLayersPixel_ = 0;
-    std::map<std::string, TH1D*> rCompsPixelTrackingVolume_, iCompsPixelTrackingVolume_;  
+    std::map<std::string, TH1D*> rCompsPixelTrackingVolume_, iCompsPixelTrackingVolume_;
+    std::map<std::string, TH1D*> rServicesDetailsPixelTrackingVolume_, iServicesDetailsPixelTrackingVolume_;
   bool geometry_created;
     std::string commandLine_;
     int detailedModules(std::vector<Layer*>* layers,

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3692,7 +3692,7 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
    * One needs to correct the MB, ie take into account the angle of the track crossing the volumes.
    * Then Analyzer::fillRIComponentsHistos is directly used.
    */
-  void Analyzer::fillRIServicesDetailsHistos(std::map<std::string, TH1D*>& rServicesDetails, std::map<std::string, TH1D*>& iServicesDetails, const Hit* hitOnService, const double eta, const double theta, const int nTracks, const double etaMax) {
+  void Analyzer::fillRIServicesDetailsHistos(std::map<std::string, TH1D*>& rServicesDetails, std::map<std::string, TH1D*>& iServicesDetails, const Hit* hitOnService, const double eta, const double theta, const int nTracks, const double etaMax) const {
 
     const InactiveElement* inactive = hitOnService->getHitInactiveElement();
     std::map<std::string, Material> servicesComponentsRI = inactive->getComponentsRI();
@@ -3715,7 +3715,7 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
   /* Fill histograms with corrected Material Budget: left pad for Radiation Length, right pad for Interaction Length.
    * The MB is split by component category.
    */
-  void Analyzer::fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax) {
+  void Analyzer::fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax) const {
 
     // RADIATION LENGTH HISTOGRAM
     auto& rComponentsHisto = rComponentsHistos[componentName];
@@ -3745,7 +3745,7 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 
   /* Calculate corrected MB , ie the MB which takes into account the angle of the track crossing the volumes.
    */
-  const Material Analyzer::computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical) {
+  const Material Analyzer::computeCorrectedMat(const Material& uncorrectedMat, const double theta, const bool isInactiveVolumeVertical) const {
     Material correctedMat;
     correctedMat.radiation = uncorrectedMat.radiation / (isInactiveVolumeVertical ? cos(theta) : sin(theta));  
     correctedMat.interaction = uncorrectedMat.interaction / (isInactiveVolumeVertical ? cos(theta) : sin(theta));

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1144,7 +1144,7 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 
     if (eta >= 0.) {
 
-      // FULL VOLUME, SERVICES DETAILS
+      // EXTRA PLOTS: SERVICES DETAILS (FULL VOLUMES)
       for (const auto& hit : track.getHitV()) {
 	if (!hit->isPixel() && hit->getObjectCategory() == Hit::Service) {
 	  
@@ -1170,167 +1170,16 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
       // TRACKING VOLUME MATERIAL BUDGET PLOTS    
       if (mb.getTracker().myid() == outer_tracker_id) {
 
-	// ASSIGN TRACKING VOLUME IDENTIFIERS TO ALL HITS OF THE TRACK:
+	// 1) ASSIGN TRACKING VOLUME IDENTIFIERS TO ALL HITS OF THE TRACK:
 	// Is the hit within Inner Tracker Tracking Volume ? Outer Tracking Volume ? In between ? Outside ?
 	track.assignTrackingVolumesToHits();
 
-
-	// BEAM PIPE MATERIAL BUDGET  
-	// Material belonging to the Beam Pipe, and located before an active hit on the Tracker.
-	for (const auto& hit : track.getHitV()) {
-	  if (hit->isTotalTrackingVolume() && hit->getObjectCategory() == Hit::BeamPipe) {
-	    const Material& correctedMat = hit->getCorrectedMaterial();
-	    fillRIComponentsHistos(rComponentsBeamPipe, iComponentsBeamPipe,
-				   beam_pipe, 
-				   correctedMat, eta, 
-				   nTracks, etaMax);
-	  }
-
-	  // MATERIAL BUDGET UNDER INNER TRACKER TRACKING VOLUME
-	  // Material not belonging to the Beam Pipe, and located before an active hit on the Inner Tracker.
-	  if (hit->isPixelIntersticeVolume() && hit->getObjectCategory() != Hit::BeamPipe) {
-	    const Material& correctedMat = hit->getCorrectedMaterial();
-	    fillRIComponentsHistos(rComponentsPixelInterstice, iComponentsPixelInterstice, 
-				   services_under_pixel_tracking_volume, 
-				   correctedMat, eta, 
-				   nTracks, etaMax);
-	  }
-	}
-    
-
-
-	// MATERIAL BUDGET WITHIN INNER TRACKER TRACKING VOLUME: A + B + C
-	// Material (IT or OT) located between first and last active hit on the Inner Tracker.
-
-	// A: modules
-	for (const auto& it : ignoredPixelSumComponentsRI) {
-	  std::string componentName = it.first;
-	  const Material& correctedMat = it.second;
-	  fillRIComponentsHistos(rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume,
-				 componentName,
-				 correctedMat, eta, 
-				 nTracks, etaMax);
-	}
-
-
-
-
-      for (const auto& hit : track.getHitV()) {
-	// B: services
-	if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
-	  const Material& correctedMat = hit->getCorrectedMaterial();
-	  fillRIComponentsHistos(rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume,
-				 services_in_pixel_tracking_volume, 
-				 correctedMat, eta, 
-				 nTracks, etaMax);
-	}
-
-
-	// C: supports
-	if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Support) {
-	  const Material& correctedMat = hit->getCorrectedMaterial();
-	  fillRIComponentsHistos(rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume,
-				 supports_in_pixel_tracking_volume, 
-				 correctedMat, eta, 
-				 nTracks, etaMax);
-	}
-
-
-
-	// MATERIAL BUDGET BETWEEN INNER TRACKER AND OUTER TRACKER TRACKING VOLUMES
-	// Material (IT or OT) located between last active hit on the Inner Tracker and first active hit on the Outer Tracker.
-	if (hit->isIntersticeVolume()) {
-	  const Material& correctedMat =  hit->getCorrectedMaterial();
-	  fillRIComponentsHistos(rComponentsInterstice, iComponentsInterstice,
-				 services_and_supports_in_interstice,
-				 correctedMat, eta, 
-				 nTracks, etaMax);
-	}
-      }
-
-
-      // MATERIAL BUDGET WITHIN OUTER TRACKER TRACKING VOLUME: D + E + F
-      // Material (IT or OT) located between first and last active hit on the Outer Tracker.
-
-      // D: modules
-      for (const auto& it : sumComponentsRI) {
-	std::string componentName = it.first;
-	const Material& correctedMat = it.second;
-	fillRIComponentsHistos(rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume,
-			       componentName,
-			       correctedMat, eta, 
-			       nTracks, etaMax);
-      }
- 
-
-      for (const auto& hit : track.getHitV()) {
-
-	// E: services
-	if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
-	  const Material& correctedMat = hit->getCorrectedMaterial();
-	  fillRIComponentsHistos(rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume,
-				 services_in_outer_tracking_volume,
-				 correctedMat, eta, 
-				 nTracks, etaMax);
-	}
-
-	// F: supports
-	if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Support) {
-	  const Material& correctedMat = hit->getCorrectedMaterial();
-	  fillRIComponentsHistos(rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume,
-				 supports_in_outer_tracking_volume,
-				 correctedMat, eta, 
-				 nTracks, etaMax);
-	}
-      }
-
-
-
-
-      // EXTRA PLOTS: SERVICES DETAILS
-      for (const auto& hit : track.getHitV()) {
-	// DETAILS OF SERVICES WITHIN INNER TRACKER TRACKING VOLUME
-	if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
-	  
-	  InactiveElement* inactive = hit->getHitInactiveElement();
-	  std::map<std::string, Material> servicesComponentsRI = inactive->getComponentsRI();
-
-	  for (const auto& it : servicesComponentsRI) {
-	   
-	    std::string componentName = it.first;
-	    const Material& uncorrectedMat = it.second;
-	    const Material& correctedMat = computeCorrectedMat(uncorrectedMat, theta, inactive->isVertical()); 
-
-	    fillRIComponentsHistos(rComponentsServicesDetailsPixelTrackingVolume, iComponentsServicesDetailsPixelTrackingVolume,
-				   componentName,
-				   correctedMat, eta, 
-				   nTracks, etaMax);
-	  }
-	}	  
-
-	// DETAILS OF SERVICES WITHIN OUTER TRACKER TRACKING VOLUME
-	if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
-	  
-	  InactiveElement* inactive = hit->getHitInactiveElement();
-	  std::map<std::string, Material> servicesComponentsRI = inactive->getComponentsRI();
-
-	  for (const auto& it : servicesComponentsRI) {
-
-	    std::string componentName = it.first;
-	    const Material& uncorrectedMat = it.second;
-	    const Material& correctedMat = computeCorrectedMat(uncorrectedMat, theta, inactive->isVertical());	    
-
-	    fillRIComponentsHistos(rComponentsServicesDetailsOuterTrackingVolume, iComponentsServicesDetailsOuterTrackingVolume,
-				   componentName,
-				   correctedMat, eta, 
-				   nTracks, etaMax);
-	  }
-	}	  
-      }
-
-
+	// 2) FILL THE TRACKING VOLUME MATERIAL BUDGET HISTOGRAMS
+	computeTrackingVolumeMaterialBudget(track, nTracks, ignoredPixelSumComponentsRI, sumComponentsRI);
       }
     }
+
+
   }
 
 
@@ -1351,6 +1200,172 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 #endif // MATERIAL_SHADOW
 
 }
+
+
+
+
+  void Analyzer::computeTrackingVolumeMaterialBudget(const Track& track, const int nTracks, const std::map<std::string, Material>& innerTrackerModulesComponentsRI, const std::map<std::string, Material>& outerTrackerModulesComponentsRI) {
+    double eta = track.getEta();
+    double theta = track.getTheta();
+    double etaMax = getEtaMaxMaterial();
+
+    // BEAM PIPE MATERIAL BUDGET  
+    // Material belonging to the Beam Pipe, and located before an active hit on the Tracker.
+    for (const auto& hit : track.getHitV()) {
+      if (hit->isTotalTrackingVolume() && hit->getObjectCategory() == Hit::BeamPipe) {
+	const Material& correctedMat = hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsBeamPipe, iComponentsBeamPipe,
+			       beam_pipe, 
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+
+      // MATERIAL BUDGET UNDER INNER TRACKER TRACKING VOLUME
+      // Material not belonging to the Beam Pipe, and located before an active hit on the Inner Tracker.
+      if (hit->isPixelIntersticeVolume() && hit->getObjectCategory() != Hit::BeamPipe) {
+	const Material& correctedMat = hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsPixelInterstice, iComponentsPixelInterstice, 
+			       services_under_pixel_tracking_volume, 
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+    }
+    
+
+
+    // MATERIAL BUDGET WITHIN INNER TRACKER TRACKING VOLUME: A + B + C
+    // Material (IT or OT) located between first and last active hit on the Inner Tracker.
+
+    // A: modules
+    for (const auto& it : innerTrackerModulesComponentsRI) {
+      std::string componentName = it.first;
+      const Material& correctedMat = it.second;
+      fillRIComponentsHistos(rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume,
+			     componentName,
+			     correctedMat, eta, 
+			     nTracks, etaMax);
+    }
+
+
+
+
+    for (const auto& hit : track.getHitV()) {
+      // B: services
+      if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
+	const Material& correctedMat = hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume,
+			       services_in_pixel_tracking_volume, 
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+
+
+      // C: supports
+      if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Support) {
+	const Material& correctedMat = hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsPixelTrackingVolume, iComponentsPixelTrackingVolume,
+			       supports_in_pixel_tracking_volume, 
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+
+
+
+      // MATERIAL BUDGET BETWEEN INNER TRACKER AND OUTER TRACKER TRACKING VOLUMES
+      // Material (IT or OT) located between last active hit on the Inner Tracker and first active hit on the Outer Tracker.
+      if (hit->isIntersticeVolume()) {
+	const Material& correctedMat =  hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsInterstice, iComponentsInterstice,
+			       services_and_supports_in_interstice,
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+    }
+
+
+    // MATERIAL BUDGET WITHIN OUTER TRACKER TRACKING VOLUME: D + E + F
+    // Material (IT or OT) located between first and last active hit on the Outer Tracker.
+
+    // D: modules
+    for (const auto& it : outerTrackerModulesComponentsRI) {
+      std::string componentName = it.first;
+      const Material& correctedMat = it.second;
+      fillRIComponentsHistos(rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume,
+			     componentName,
+			     correctedMat, eta, 
+			     nTracks, etaMax);
+    }
+ 
+
+    for (const auto& hit : track.getHitV()) {
+
+      // E: services
+      if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
+	const Material& correctedMat = hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume,
+			       services_in_outer_tracking_volume,
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+
+      // F: supports
+      if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Support) {
+	const Material& correctedMat = hit->getCorrectedMaterial();
+	fillRIComponentsHistos(rComponentsOuterTrackingVolume, iComponentsOuterTrackingVolume,
+			       supports_in_outer_tracking_volume,
+			       correctedMat, eta, 
+			       nTracks, etaMax);
+      }
+    }
+
+
+
+
+    // EXTRA PLOTS: SERVICES DETAILS (TRACKING VOLUMES)
+    for (const auto& hit : track.getHitV()) {
+      // DETAILS OF SERVICES WITHIN INNER TRACKER TRACKING VOLUME
+      if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
+	  
+	InactiveElement* inactive = hit->getHitInactiveElement();
+	std::map<std::string, Material> servicesComponentsRI = inactive->getComponentsRI();
+
+	for (const auto& it : servicesComponentsRI) {
+	   
+	  std::string componentName = it.first;
+	  const Material& uncorrectedMat = it.second;
+	  const Material& correctedMat = computeCorrectedMat(uncorrectedMat, theta, inactive->isVertical()); 
+
+	  fillRIComponentsHistos(rComponentsServicesDetailsPixelTrackingVolume, iComponentsServicesDetailsPixelTrackingVolume,
+				 componentName,
+				 correctedMat, eta, 
+				 nTracks, etaMax);
+	}
+      }	  
+
+      // DETAILS OF SERVICES WITHIN OUTER TRACKER TRACKING VOLUME
+      if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
+	  
+	InactiveElement* inactive = hit->getHitInactiveElement();
+	std::map<std::string, Material> servicesComponentsRI = inactive->getComponentsRI();
+
+	for (const auto& it : servicesComponentsRI) {
+
+	  std::string componentName = it.first;
+	  const Material& uncorrectedMat = it.second;
+	  const Material& correctedMat = computeCorrectedMat(uncorrectedMat, theta, inactive->isVertical());	    
+
+	  fillRIComponentsHistos(rComponentsServicesDetailsOuterTrackingVolume, iComponentsServicesDetailsOuterTrackingVolume,
+				 componentName,
+				 correctedMat, eta, 
+				 nTracks, etaMax);
+	}
+      }	  
+    }
+
+
+  }
+
+
 
 
 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1151,19 +1151,16 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 	  InactiveElement* inactive = hit->getHitInactiveElement();
 	  std::map<std::string, Material> servicesComponentsRI = inactive->getComponentsRI();
 	  for (const auto& it : servicesComponentsRI) {
-	    Material res;
-	    res.radiation = it.second.radiation / (inactive->isVertical() ? cos(theta) : sin(theta));  
-	    res.interaction = it.second.interaction / (inactive->isVertical() ? cos(theta) : sin(theta));
-	    if (rComponentsServicesDetails[it.first]==NULL) {
-	      rComponentsServicesDetails[it.first] = new TH1D();
-	      rComponentsServicesDetails[it.first]->SetBins(nTracks, 0.0, getEtaMaxMaterial()); 
-	    }
-	    rComponentsServicesDetails[it.first]->Fill(eta, res.radiation);
-	    if (iComponentsServicesDetails[it.first]==NULL) { 
-	      iComponentsServicesDetails[it.first] = new TH1D();
-	      iComponentsServicesDetails[it.first]->SetBins(nTracks, 0.0, getEtaMaxMaterial()); 
-	    }
-	    iComponentsServicesDetails[it.first]->Fill(eta, res.interaction);
+	    std::string componentName = it.first;
+
+	    Material correctedMat;
+	    correctedMat.radiation = it.second.radiation / (inactive->isVertical() ? cos(theta) : sin(theta));  
+	    correctedMat.interaction = it.second.interaction / (inactive->isVertical() ? cos(theta) : sin(theta));
+
+	    fillRIComponentsHistos(rComponentsServicesDetails, iComponentsServicesDetails,
+				   componentName,
+				   correctedMat, eta, 
+				   nTracks, etaMax);
 	  }
 	}
       }
@@ -1173,38 +1170,7 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-    void fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax) {
-
-      // RADIATION LENGTH HISTOGRAM
-      // If histo does not exist yet, create it!
-      if (rComponentsHistos[componentName] == NULL) {
-	rComponentsHistos[componentName] = new TH1D();
-	rComponentsHistos[componentName]->SetBins(nTracks, 0.0, etaMax); 
-      }
-      // Fill!
-      rComponentsHistos[componentName]->Fill(eta, correctedMat.radiation);
-
-      // INTERACTION LENGTH HISTOGRAM
-      // If histo does not exist yet, create it!
-      if (iComponentsHistos[componentName] == NULL) {
-	iComponentsHistos[componentName] = new TH1D();
-	iComponentsHistos[componentName]->SetBins(nTracks, 0.0, etaMax); 
-      }
-      // Fill!
-      iComponentsHistos[componentName]->Fill(eta, correctedMat.interaction);
-    }
+    
 
 
 
@@ -1341,10 +1307,8 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 				   nTracks, etaMax);
 	  }
 	}	  
-	//}
 
 	// SERVICES DETAILS: OUTER TRACKING VOLUME
-	// for (const auto& hit : track.getHitV()) {
 	if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
 	  
 	  InactiveElement* inactive = hit->getHitInactiveElement();
@@ -1370,6 +1334,30 @@ void Analyzer::analyzeMaterialBudget(MaterialBudget& mb, const std::vector<doubl
 
     }
 
+  }
+
+
+
+
+  void Analyzer::fillRIComponentsHistos(std::map<std::string, TH1D*>& rComponentsHistos, std::map<std::string, TH1D*>& iComponentsHistos, const std::string componentName, const Material& correctedMat, const double eta, const int nTracks, const double etaMax) {
+
+    // RADIATION LENGTH HISTOGRAM
+    // If histo does not exist yet, create it!
+    if (rComponentsHistos[componentName] == NULL) {
+      rComponentsHistos[componentName] = new TH1D();
+      rComponentsHistos[componentName]->SetBins(nTracks, 0.0, etaMax); 
+    }
+    // Fill!
+    rComponentsHistos[componentName]->Fill(eta, correctedMat.radiation);
+
+    // INTERACTION LENGTH HISTOGRAM
+    // If histo does not exist yet, create it!
+    if (iComponentsHistos[componentName] == NULL) {
+      iComponentsHistos[componentName] = new TH1D();
+      iComponentsHistos[componentName]->SetBins(nTracks, 0.0, etaMax); 
+    }
+    // Fill!
+    iComponentsHistos[componentName]->Fill(eta, correctedMat.interaction);
   }
 
 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3573,6 +3573,7 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			       nTracks, etaMax);
       }
 
+
       // MATERIAL BUDGET UNDER INNER TRACKER TRACKING VOLUME
       // Material not belonging to the Beam Pipe, and located before an active hit on the Inner Tracker.
       if (hit->isPixelIntersticeVolume() && hit->getObjectCategory() != Hit::BeamPipe) {
@@ -3583,7 +3584,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			       nTracks, etaMax);
       }
     }
-    
 
 
     // MATERIAL BUDGET WITHIN INNER TRACKER TRACKING VOLUME: A + B + C
@@ -3599,9 +3599,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			     nTracks, etaMax);
     }
 
-
-
-
     for (const auto& hit : track.getHitV()) {
       // B: services
       if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
@@ -3612,7 +3609,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			       nTracks, etaMax);
       }
 
-
       // C: supports
       if (hit->isPixelTrackingVolume() && hit->getObjectCategory() == Hit::Support) {
 	const Material& correctedMat = hit->getCorrectedMaterial();
@@ -3621,7 +3617,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			       correctedMat, eta, 
 			       nTracks, etaMax);
       }
-
 
 
       // MATERIAL BUDGET BETWEEN INNER TRACKER AND OUTER TRACKER TRACKING VOLUMES
@@ -3648,10 +3643,8 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			     correctedMat, eta, 
 			     nTracks, etaMax);
     }
- 
 
     for (const auto& hit : track.getHitV()) {
-
       // E: services
       if (hit->isOuterTrackingVolume() && hit->getObjectCategory() == Hit::Service) {
 	const Material& correctedMat = hit->getCorrectedMaterial();
@@ -3670,7 +3663,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 			       nTracks, etaMax);
       }
     }
-
 
 
     // EXTRA PLOTS: SERVICES DETAILS (TRACKING VOLUMES)
@@ -3733,7 +3725,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
       rComponentsHisto = new TH1D();
       rComponentsHisto->SetBins(nTracks, 0.0, etaMax); 
     }
-
     // Fill!
     rComponentsHisto->Fill(eta, correctedMat.radiation);
 
@@ -3746,7 +3737,6 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
       iComponentsHisto = new TH1D();
       iComponentsHisto->SetBins(nTracks, 0.0, etaMax);
     }
-
     // Fill!
     iComponentsHisto->Fill(eta, correctedMat.interaction);
   }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -905,6 +905,88 @@ namespace insur {
 
 
 
+      // SERVICES DETAILS (TRACKING VOLUME)
+      myContent = new RootWContent("Services details (Tracking volume)", false);
+      myPage->addContent(myContent);
+
+      myTable = new RootWTable();
+      sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+      myTable->setContent(0, 0, titleString);
+      myTable->setContent(0, 1, "Radiation length");
+      myTable->setContent(0, 2, "Interaction length");
+
+      THStack* rServicesDetailsTrackingVolumeStack = new THStack("rservicescomptrackingvolumestack", "Radiation Length by Component");
+      THStack* iServicesDetailsTrackingVolumeStack = new THStack("iservicescomptrackingvolumestack", "Interaction Length by Component");
+
+      TLegend* servicesTrackingVolumeLegend = new TLegend(0.1,0.6,0.35,0.9);
+
+      myCanvas = new TCanvas(("ServicesDetailsTrackingVolumeRI"+name).c_str());
+      myCanvas->SetFillColor(color_plot_background);
+      myCanvas->Divide(2, 1);
+      myPad = myCanvas->GetPad(0);
+      myPad->SetFillColor(color_pad_background);
+
+      myPad = myCanvas->GetPad(1);
+      myPad->cd();
+      std::map<std::string, TH1D*> rServicesDetailsTrackingVolume;
+      if (name == "outer") {
+	rServicesDetailsTrackingVolume = a.getHistoServicesDetailsOuterTrackingVolumeR();
+	rServicesDetailsPixelTrackingVolume_ = a.getHistoServicesDetailsPixelTrackingVolumeR();
+      }
+      else rServicesDetailsTrackingVolume = rServicesDetailsPixelTrackingVolume_;
+      int servicesTrackingVolumeIndex = 1;
+      for (const auto& it : rServicesDetailsTrackingVolume) {
+	prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
+	histo = prof->ProjectionX();     
+	histo->SetLineColor(Palette::color(servicesTrackingVolumeIndex));
+	histo->SetFillColor(Palette::color(servicesTrackingVolumeIndex));
+	histo->SetTitle(it.first.c_str());
+	servicesTrackingVolumeLegend->AddEntry(histo, it.first.c_str());
+	rServicesDetailsTrackingVolumeStack->Add(histo);
+	myTable->setContent(servicesTrackingVolumeIndex, 0, it.first);
+	myTable->setContent(servicesTrackingVolumeIndex++, 1, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
+      }
+      rServicesDetailsTrackingVolumeStack->Draw("hist");  
+      //rServicesDetailsTrackingVolumeStack->GetXaxis()->SetTitle("#eta"); 
+      //myCanvas->Modified();
+      servicesTrackingVolumeLegend->Draw();
+
+      myPad = myCanvas->GetPad(2);
+      myPad->cd();
+      std::map<std::string, TH1D*> iServicesDetailsTrackingVolume;
+      if (name == "outer") {
+	iServicesDetailsTrackingVolume = a.getHistoServicesDetailsOuterTrackingVolumeI();
+	iServicesDetailsPixelTrackingVolume_ = a.getHistoServicesDetailsPixelTrackingVolumeI();
+      }
+      else iServicesDetailsTrackingVolume = iServicesDetailsPixelTrackingVolume_;
+
+      servicesTrackingVolumeIndex = 1;
+      for (const auto& it : iServicesDetailsTrackingVolume) {
+	prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
+	histo = prof->ProjectionX();
+	histo->SetLineColor(Palette::color(servicesTrackingVolumeIndex));
+	histo->SetFillColor(Palette::color(servicesTrackingVolumeIndex));
+	histo->SetTitle(it.first.c_str());
+	iServicesDetailsTrackingVolumeStack->Add(histo);
+	myTable->setContent(servicesTrackingVolumeIndex++, 2, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
+      }
+      iServicesDetailsTrackingVolumeStack->Draw("hist");
+      //rServicesCompStack->GetXaxis()->SetTitle("#eta"); 
+      //myCanvas->Modified();
+      servicesTrackingVolumeLegend->Draw();
+
+      myContent->addItem(myTable);
+      myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      myImage->setComment("Radiation and interaction length distribution in eta by component type in services");
+      myImage->setName("matServicesDetailsTrackingVolume");
+      myContent->addItem(myImage);
+
+
+
+
+
+
+
     // Work area re-init
     myCanvas = new TCanvas(name_countourMaterial.c_str());
     myCanvas->SetFillColor(color_plot_background);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -711,7 +711,6 @@ namespace insur {
 
 
 
-
     // SERVICES DETAILS (FULL VOLUME)
     myContent = new RootWContent("Services details (Full volume)", false);
     myPage->addContent(myContent);
@@ -779,211 +778,207 @@ namespace insur {
 
 
 
-      // COMPONENTS DETAILS (TRACKING VOLUME)
-      myContentDetails = new RootWContent("Components details (Tracking volume)", false);
+    // COMPONENTS DETAILS (TRACKING VOLUME)
+    myContentDetails = new RootWContent("Components details (Tracking volume)", false);
 
-      myTable = new RootWTable();
-      sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
-      myTable->setContent(0, 0, titleString);
-      myTable->setContent(0, 1, "Radiation length");
-      myTable->setContent(0, 2, "Interaction length");
-
-
-      THStack* rCompTrackingVolumeStack = new THStack("rcomptrackingvolumestack", "Radiation Length by Component in tracking volume");
-      THStack* iCompTrackingVolumeStack = new THStack("icomptrackingvolumestack", "Interaction Length by Component in tracking volume");
-
-      TLegend* compLegendTrackingVolume = new TLegend(0.1,0.6,0.35,0.9);
-
-      myCanvas = new TCanvas(("componentsTrackingVolumeRI"+name).c_str());
-      myCanvas->SetFillColor(color_plot_background);
-      myCanvas->Divide(2, 1);
-      myPad = myCanvas->GetPad(0);
-      myPad->SetFillColor(color_pad_background);
-
-      myPad = myCanvas->GetPad(1);
-      myPad->cd();
-      std::map<std::string, TH1D*> rCompsTrackingVolume;
-      if (name == "outer") {
-	rCompsTrackingVolume = a.getHistoOuterTrackingVolumeR();
-	rCompsPixelTrackingVolume_ = a.getHistoPixelTrackingVolumeR();
-      }
-      else rCompsTrackingVolume = rCompsPixelTrackingVolume_;
-      int compIndexTrackingVolume = 1;
-
-      for (const auto& it : rCompsTrackingVolume) {
-	prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
-	histo = prof->ProjectionX();
-	histo->SetLineColor(Palette::color(compIndexTrackingVolume));
-	histo->SetFillColor(Palette::color(compIndexTrackingVolume));
-	histo->SetTitle(it.first.c_str());
-	compLegendTrackingVolume->AddEntry(histo, it.first.c_str());
-	rCompTrackingVolumeStack->Add(histo);
-	myTable->setContent(compIndexTrackingVolume, 0, it.first);
-	myTable->setContent(compIndexTrackingVolume++, 1, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
-      }
-      rCompTrackingVolumeStack->Draw("hist");
-      compLegendTrackingVolume->Draw();
-
-      myPad = myCanvas->GetPad(2);
-      myPad->cd();
-      std::map<std::string, TH1D*> iCompsTrackingVolume;
-      if (name == "outer") {
-	iCompsTrackingVolume = a.getHistoOuterTrackingVolumeI();
-	iCompsPixelTrackingVolume_ = a.getHistoPixelTrackingVolumeI();
-      }
-      else iCompsTrackingVolume = iCompsPixelTrackingVolume_;
-      compIndexTrackingVolume = 1;
-
-      for (const auto& it : iCompsTrackingVolume) {
-	prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
-	histo = prof->ProjectionX();
-	histo->SetLineColor(Palette::color(compIndexTrackingVolume));
-	histo->SetFillColor(Palette::color(compIndexTrackingVolume));
-	histo->SetTitle(it.first.c_str());
-	iCompTrackingVolumeStack->Add(histo);
-	myTable->setContent(compIndexTrackingVolume++, 2, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
-      }
-      iCompTrackingVolumeStack->Draw("hist");
-      compLegendTrackingVolume->Draw();
-
-      myContentDetails->addItem(myTable);
-
-      myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Radiation and interaction length distribution in eta by component type in total tracking volume");
-      myImage->setName("matComponentsTrackingVolume");
-      myContentDetails->addItem(myImage);
+    myTable = new RootWTable();
+    sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+    myTable->setContent(0, 0, titleString);
+    myTable->setContent(0, 1, "Radiation length");
+    myTable->setContent(0, 2, "Interaction length");
 
 
+    THStack* rCompTrackingVolumeStack = new THStack("rcomptrackingvolumestack", "Radiation Length by Component in tracking volume");
+    THStack* iCompTrackingVolumeStack = new THStack("icomptrackingvolumestack", "Interaction Length by Component in tracking volume");
 
+    TLegend* compLegendTrackingVolume = new TLegend(0.1,0.6,0.35,0.9);
 
-      // 1D OVERVIEW (TRACKING VOLUME)
-      TH1D *rTrackingVolume = NULL, *iTrackingVolume = NULL;
-      TProfile *rTrackingVolumeProf = NULL, *iTrackingVolumeProf = NULL;
-      myContent = new RootWContent("1D Overview (Tracking volume)", false);
-      myPage->addContent(myContent);
-      // Work area re-init
-      myCanvas = new TCanvas(name_overviewMaterialTrackingVolume.c_str());
-      myCanvas->SetFillColor(color_plot_background);
-      myCanvas->Divide(2, 1);
-      myPad = myCanvas->GetPad(0);
-      myPad->SetFillColor(color_pad_background);
-      myPad = myCanvas->GetPad(1);
-      myPad->cd();
-      // global plots in tracking volume: radiation length      
-      if (rCompTrackingVolumeStack->GetHists()) {
-	rTrackingVolume = (TH1D*)rCompTrackingVolumeStack->GetStack()->Last()->Clone();
-	rTrackingVolumeProf = newProfile(rTrackingVolume, 0., a.getEtaMaxMaterial(), materialNBins);
-	rTrackingVolumeProf->SetFillColor(kGray + 2);
-	rTrackingVolumeProf->SetTitle("Radiation Length within Tracking Volume; #eta; x/X_{0}");
-	rTrackingVolumeProf->Draw("hist");
-      }
-      myPad = myCanvas->GetPad(2);
-      myPad->cd();
-      // global plots in tracking volume: interaction length
-      if (iCompTrackingVolumeStack->GetHists()) {
-	iTrackingVolume = (TH1D*)iCompTrackingVolumeStack->GetStack()->Last()->Clone();
-	iTrackingVolumeProf = newProfile(iTrackingVolume, 0., a.getEtaMaxMaterial(), materialNBins);
-	iTrackingVolumeProf->SetFillColor(kGray + 2);
-	iTrackingVolumeProf->SetTitle("Interaction Length within Tracking Volume; #eta; #lambda/#lambda_{0}");
-	iTrackingVolumeProf->Draw("hist");
-      }
-      // Write global tracking volume plots to web pag
-      myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Material in tracking volume");
-      myImage->setName("matOverviewTrackingVolume");
-      myTable = new RootWTable();
-      sprintf(titleString, "Average radiation length in tracking volume (eta = [0, %.1f])", a.getEtaMaxMaterial());
-      myTable->setContent(1, 1, titleString);
-      sprintf(titleString, "Average interaction length in tracking volume (eta = [0, %.1f])", a.getEtaMaxMaterial());
-      myTable->setContent(2, 1, titleString);
-      if (rTrackingVolume) myTable->setContent(1, 2, averageHistogramValues(*rTrackingVolume, a.getEtaMaxMaterial()), 5);
-      if (iTrackingVolume) myTable->setContent(2, 2, averageHistogramValues(*iTrackingVolume, a.getEtaMaxMaterial()), 5);
-      myContent->addItem(myTable);
-      myContent->addItem(myImage);
+    myCanvas = new TCanvas(("componentsTrackingVolumeRI"+name).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    myPad = myCanvas->GetPad(0);
+    myPad->SetFillColor(color_pad_background);
 
-      myPage->addContent(myContentDetails);
+    myPad = myCanvas->GetPad(1);
+    myPad->cd();
+    std::map<std::string, TH1D*> rCompsTrackingVolume;
+    if (name == "outer") {
+      rCompsTrackingVolume = a.getHistoOuterTrackingVolumeR();
+      rCompsPixelTrackingVolume_ = a.getHistoPixelTrackingVolumeR();
+    }
+    else rCompsTrackingVolume = rCompsPixelTrackingVolume_;
+    int compIndexTrackingVolume = 1;
 
+    for (const auto& it : rCompsTrackingVolume) {
+      prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
+      histo = prof->ProjectionX();
+      histo->SetLineColor(Palette::color(compIndexTrackingVolume));
+      histo->SetFillColor(Palette::color(compIndexTrackingVolume));
+      histo->SetTitle(it.first.c_str());
+      compLegendTrackingVolume->AddEntry(histo, it.first.c_str());
+      rCompTrackingVolumeStack->Add(histo);
+      myTable->setContent(compIndexTrackingVolume, 0, it.first);
+      myTable->setContent(compIndexTrackingVolume++, 1, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
+    }
+    rCompTrackingVolumeStack->Draw("hist");
+    compLegendTrackingVolume->Draw();
 
+    myPad = myCanvas->GetPad(2);
+    myPad->cd();
+    std::map<std::string, TH1D*> iCompsTrackingVolume;
+    if (name == "outer") {
+      iCompsTrackingVolume = a.getHistoOuterTrackingVolumeI();
+      iCompsPixelTrackingVolume_ = a.getHistoPixelTrackingVolumeI();
+    }
+    else iCompsTrackingVolume = iCompsPixelTrackingVolume_;
+    compIndexTrackingVolume = 1;
 
-      // SERVICES DETAILS (TRACKING VOLUME)
-      myContent = new RootWContent("Services details (Tracking volume)", false);
-      myPage->addContent(myContent);
+    for (const auto& it : iCompsTrackingVolume) {
+      prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
+      histo = prof->ProjectionX();
+      histo->SetLineColor(Palette::color(compIndexTrackingVolume));
+      histo->SetFillColor(Palette::color(compIndexTrackingVolume));
+      histo->SetTitle(it.first.c_str());
+      iCompTrackingVolumeStack->Add(histo);
+      myTable->setContent(compIndexTrackingVolume++, 2, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
+    }
+    iCompTrackingVolumeStack->Draw("hist");
+    compLegendTrackingVolume->Draw();
 
-      myTable = new RootWTable();
-      sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
-      myTable->setContent(0, 0, titleString);
-      myTable->setContent(0, 1, "Radiation length");
-      myTable->setContent(0, 2, "Interaction length");
+    myContentDetails->addItem(myTable);
 
-      THStack* rServicesDetailsTrackingVolumeStack = new THStack("rservicescomptrackingvolumestack", "Radiation Length by Component");
-      THStack* iServicesDetailsTrackingVolumeStack = new THStack("iservicescomptrackingvolumestack", "Interaction Length by Component");
-
-      TLegend* servicesTrackingVolumeLegend = new TLegend(0.1,0.6,0.35,0.9);
-
-      myCanvas = new TCanvas(("ServicesDetailsTrackingVolumeRI"+name).c_str());
-      myCanvas->SetFillColor(color_plot_background);
-      myCanvas->Divide(2, 1);
-      myPad = myCanvas->GetPad(0);
-      myPad->SetFillColor(color_pad_background);
-
-      myPad = myCanvas->GetPad(1);
-      myPad->cd();
-      std::map<std::string, TH1D*> rServicesDetailsTrackingVolume;
-      if (name == "outer") {
-	rServicesDetailsTrackingVolume = a.getHistoServicesDetailsOuterTrackingVolumeR();
-	rServicesDetailsPixelTrackingVolume_ = a.getHistoServicesDetailsPixelTrackingVolumeR();
-      }
-      else rServicesDetailsTrackingVolume = rServicesDetailsPixelTrackingVolume_;
-      int servicesTrackingVolumeIndex = 1;
-      for (const auto& it : rServicesDetailsTrackingVolume) {
-	prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
-	histo = prof->ProjectionX();     
-	histo->SetLineColor(Palette::color(servicesTrackingVolumeIndex));
-	histo->SetFillColor(Palette::color(servicesTrackingVolumeIndex));
-	histo->SetTitle(it.first.c_str());
-	servicesTrackingVolumeLegend->AddEntry(histo, it.first.c_str());
-	rServicesDetailsTrackingVolumeStack->Add(histo);
-	myTable->setContent(servicesTrackingVolumeIndex, 0, it.first);
-	myTable->setContent(servicesTrackingVolumeIndex++, 1, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
-      }
-      rServicesDetailsTrackingVolumeStack->Draw("hist");  
-      //rServicesDetailsTrackingVolumeStack->GetXaxis()->SetTitle("#eta"); 
-      //myCanvas->Modified();
-      servicesTrackingVolumeLegend->Draw();
-
-      myPad = myCanvas->GetPad(2);
-      myPad->cd();
-      std::map<std::string, TH1D*> iServicesDetailsTrackingVolume;
-      if (name == "outer") {
-	iServicesDetailsTrackingVolume = a.getHistoServicesDetailsOuterTrackingVolumeI();
-	iServicesDetailsPixelTrackingVolume_ = a.getHistoServicesDetailsPixelTrackingVolumeI();
-      }
-      else iServicesDetailsTrackingVolume = iServicesDetailsPixelTrackingVolume_;
-
-      servicesTrackingVolumeIndex = 1;
-      for (const auto& it : iServicesDetailsTrackingVolume) {
-	prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
-	histo = prof->ProjectionX();
-	histo->SetLineColor(Palette::color(servicesTrackingVolumeIndex));
-	histo->SetFillColor(Palette::color(servicesTrackingVolumeIndex));
-	histo->SetTitle(it.first.c_str());
-	iServicesDetailsTrackingVolumeStack->Add(histo);
-	myTable->setContent(servicesTrackingVolumeIndex++, 2, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
-      }
-      iServicesDetailsTrackingVolumeStack->Draw("hist");
-      //rServicesCompStack->GetXaxis()->SetTitle("#eta"); 
-      //myCanvas->Modified();
-      servicesTrackingVolumeLegend->Draw();
-
-      myContent->addItem(myTable);
-      myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Radiation and interaction length distribution in eta by component type in services");
-      myImage->setName("matServicesDetailsTrackingVolume");
-      myContent->addItem(myImage);
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Radiation and interaction length distribution in eta by component type in total tracking volume");
+    myImage->setName("matComponentsTrackingVolume");
+    myContentDetails->addItem(myImage);
 
 
 
 
+    // 1D OVERVIEW (TRACKING VOLUME)
+    TH1D *rTrackingVolume = NULL, *iTrackingVolume = NULL;
+    TProfile *rTrackingVolumeProf = NULL, *iTrackingVolumeProf = NULL;
+    myContent = new RootWContent("1D Overview (Tracking volume)", false);
+    myPage->addContent(myContent);
+    // Work area re-init
+    myCanvas = new TCanvas(name_overviewMaterialTrackingVolume.c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    myPad = myCanvas->GetPad(0);
+    myPad->SetFillColor(color_pad_background);
+    myPad = myCanvas->GetPad(1);
+    myPad->cd();
+    // global plots in tracking volume: radiation length      
+    if (rCompTrackingVolumeStack->GetHists()) {
+      rTrackingVolume = (TH1D*)rCompTrackingVolumeStack->GetStack()->Last()->Clone();
+      rTrackingVolumeProf = newProfile(rTrackingVolume, 0., a.getEtaMaxMaterial(), materialNBins);
+      rTrackingVolumeProf->SetFillColor(kGray + 2);
+      rTrackingVolumeProf->SetTitle("Radiation Length within Tracking Volume; #eta; x/X_{0}");
+      rTrackingVolumeProf->Draw("hist");
+    }
+    myPad = myCanvas->GetPad(2);
+    myPad->cd();
+    // global plots in tracking volume: interaction length
+    if (iCompTrackingVolumeStack->GetHists()) {
+      iTrackingVolume = (TH1D*)iCompTrackingVolumeStack->GetStack()->Last()->Clone();
+      iTrackingVolumeProf = newProfile(iTrackingVolume, 0., a.getEtaMaxMaterial(), materialNBins);
+      iTrackingVolumeProf->SetFillColor(kGray + 2);
+      iTrackingVolumeProf->SetTitle("Interaction Length within Tracking Volume; #eta; #lambda/#lambda_{0}");
+      iTrackingVolumeProf->Draw("hist");
+    }
+    // Write global tracking volume plots to web pag
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Material in tracking volume");
+    myImage->setName("matOverviewTrackingVolume");
+    myTable = new RootWTable();
+    sprintf(titleString, "Average radiation length in tracking volume (eta = [0, %.1f])", a.getEtaMaxMaterial());
+    myTable->setContent(1, 1, titleString);
+    sprintf(titleString, "Average interaction length in tracking volume (eta = [0, %.1f])", a.getEtaMaxMaterial());
+    myTable->setContent(2, 1, titleString);
+    if (rTrackingVolume) myTable->setContent(1, 2, averageHistogramValues(*rTrackingVolume, a.getEtaMaxMaterial()), 5);
+    if (iTrackingVolume) myTable->setContent(2, 2, averageHistogramValues(*iTrackingVolume, a.getEtaMaxMaterial()), 5);
+    myContent->addItem(myTable);
+    myContent->addItem(myImage);
+
+    myPage->addContent(myContentDetails);
+
+
+
+    // SERVICES DETAILS (TRACKING VOLUME)
+    myContent = new RootWContent("Services details (Tracking volume)", false);
+    myPage->addContent(myContent);
+
+    myTable = new RootWTable();
+    sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+    myTable->setContent(0, 0, titleString);
+    myTable->setContent(0, 1, "Radiation length");
+    myTable->setContent(0, 2, "Interaction length");
+
+    THStack* rServicesDetailsTrackingVolumeStack = new THStack("rservicescomptrackingvolumestack", "Radiation Length by Component");
+    THStack* iServicesDetailsTrackingVolumeStack = new THStack("iservicescomptrackingvolumestack", "Interaction Length by Component");
+
+    TLegend* servicesTrackingVolumeLegend = new TLegend(0.1,0.6,0.35,0.9);
+
+    myCanvas = new TCanvas(("ServicesDetailsTrackingVolumeRI"+name).c_str());
+    myCanvas->SetFillColor(color_plot_background);
+    myCanvas->Divide(2, 1);
+    myPad = myCanvas->GetPad(0);
+    myPad->SetFillColor(color_pad_background);
+
+    myPad = myCanvas->GetPad(1);
+    myPad->cd();
+    std::map<std::string, TH1D*> rServicesDetailsTrackingVolume;
+    if (name == "outer") {
+      rServicesDetailsTrackingVolume = a.getHistoServicesDetailsOuterTrackingVolumeR();
+      rServicesDetailsPixelTrackingVolume_ = a.getHistoServicesDetailsPixelTrackingVolumeR();
+    }
+    else rServicesDetailsTrackingVolume = rServicesDetailsPixelTrackingVolume_;
+    int servicesTrackingVolumeIndex = 1;
+    for (const auto& it : rServicesDetailsTrackingVolume) {
+      prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
+      histo = prof->ProjectionX();     
+      histo->SetLineColor(Palette::color(servicesTrackingVolumeIndex));
+      histo->SetFillColor(Palette::color(servicesTrackingVolumeIndex));
+      histo->SetTitle(it.first.c_str());
+      servicesTrackingVolumeLegend->AddEntry(histo, it.first.c_str());
+      rServicesDetailsTrackingVolumeStack->Add(histo);
+      myTable->setContent(servicesTrackingVolumeIndex, 0, it.first);
+      myTable->setContent(servicesTrackingVolumeIndex++, 1, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
+    }
+    rServicesDetailsTrackingVolumeStack->Draw("hist");  
+    //rServicesDetailsTrackingVolumeStack->GetXaxis()->SetTitle("#eta"); 
+    //myCanvas->Modified();
+    servicesTrackingVolumeLegend->Draw();
+
+    myPad = myCanvas->GetPad(2);
+    myPad->cd();
+    std::map<std::string, TH1D*> iServicesDetailsTrackingVolume;
+    if (name == "outer") {
+      iServicesDetailsTrackingVolume = a.getHistoServicesDetailsOuterTrackingVolumeI();
+      iServicesDetailsPixelTrackingVolume_ = a.getHistoServicesDetailsPixelTrackingVolumeI();
+    }
+    else iServicesDetailsTrackingVolume = iServicesDetailsPixelTrackingVolume_;
+
+    servicesTrackingVolumeIndex = 1;
+    for (const auto& it : iServicesDetailsTrackingVolume) {
+      prof = newProfile((TH1D*)it.second, 0., a.getEtaMaxMaterial(), materialNBins);
+      histo = prof->ProjectionX();
+      histo->SetLineColor(Palette::color(servicesTrackingVolumeIndex));
+      histo->SetFillColor(Palette::color(servicesTrackingVolumeIndex));
+      histo->SetTitle(it.first.c_str());
+      iServicesDetailsTrackingVolumeStack->Add(histo);
+      myTable->setContent(servicesTrackingVolumeIndex++, 2, averageHistogramValues(*histo, a.getEtaMaxMaterial()), 5);
+    }
+    iServicesDetailsTrackingVolumeStack->Draw("hist");
+    //rServicesCompStack->GetXaxis()->SetTitle("#eta"); 
+    //myCanvas->Modified();
+    servicesTrackingVolumeLegend->Draw();
+
+    myContent->addItem(myTable);
+    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Radiation and interaction length distribution in eta by component type in services");
+    myImage->setName("matServicesDetailsTrackingVolume");
+    myContent->addItem(myImage);
 
 
 


### PR DESCRIPTION
Fully checked against regressions.
Added Tracking Volumes Services Detailed plots + cleaned Tracking Volume code.


Note: (Not included in this PR)
For the moment we have:
- OT tab: all MB (belonging to OT or IT) located between first OT active hit and last OT active hit.
- IT tab: all MB (belonging to OT or IT) located between first IT active hit and last IT active hit.

Now it would take not more than 1 hour to switch it to:
- OT tab: all MB belonging to OT and located until last Tracker active hit.
- IT tab: all MB belonging to IT and located until last Tracker active hit.

Shall I switch to that, or we keep things as they are?

Cheers