### PR TITLE
Fixed issue in Giovanni s code, spotted a while ago but pushed back b…

### DIFF
--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -228,7 +228,7 @@ public:
     decorated().translate(v);
     clearSensorPolys();
   }
-  void mirrorZ() { 
+  void mirrorZ() {
     side(-side());
     double zTranslation = -center().Z();
     double zRotation = -center().Phi();
@@ -236,7 +236,7 @@ public:
     rotateZ(zRotation);
     rotateY(M_PI);
     translateZ(zTranslation);
-    rotateZ(-zRotation);
+    rotateZ(zRotation);
     //decorated().mirror(XYZVector(1., 1., -1.));
     clearSensorPolys();
   }

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -228,16 +228,9 @@ public:
     decorated().translate(v);
     clearSensorPolys();
   }
-  void mirrorZ() {
+  void rotateToNegativeZSide() {
     side(-side());
-    double zTranslation = -center().Z();
-    double zRotation = -center().Phi();
-    translateZ(zTranslation);
-    rotateZ(zRotation);
-    rotateY(M_PI);
-    translateZ(zTranslation);
-    rotateZ(zRotation);
-    //decorated().mirror(XYZVector(1., 1., -1.));
+    rotateY(M_PI);  // Rotation around CMS_Y of angle Pi
     clearSensorPolys();
   }
 

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -104,7 +104,7 @@ public:
   void check() override;
   void build(const ScanEndcapInfo& extremaDisksInfo);
   void translateZ(double z);
-  void mirrorZ();
+  void rotateToNegativeZSide();
   void cutAtEta(double eta);
 
   double averageZ() const { return averageZ_; }

--- a/include/Ring.hh
+++ b/include/Ring.hh
@@ -224,7 +224,7 @@ public:
   void check() override;
 
   void translateZ(double z);
-  void mirrorZ();
+  void rotateToNegativeZSide();
   double averageZ() const {
     double averageZ = 0;
     for (const auto& m : modules_) { averageZ = averageZ + m.center().Z(); } 

--- a/include/Tracker.hh
+++ b/include/Tracker.hh
@@ -142,7 +142,7 @@ public:
 	    // check whether all endcaps outer radii are identical with each other
 	    // if radii are not all identical, there is an endcap step !
 	    hasStep = !std::equal(endcaps_.begin() + 1, endcaps_.end(), endcaps_.begin(), 
-				  [&](const Endcap& e1, const Endcap& e2) { return (e1.maxRwithHybrids() == e2.maxRwithHybrids()); });
+				  [&](const Endcap& e1, const Endcap& e2) { return (fabs(e1.maxRwithHybrids() - e2.maxRwithHybrids()) < insur::geom_epsilon); });
 	  }
 	  return hasStep;
 	});

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -332,9 +332,9 @@ void Disk::computeActualCoverage() {
 
 void Disk::translateZ(double z) { averageZ_ += z; for (auto& r : rings_) r.translateZ(z); }
 
-void Disk::mirrorZ() {
+void Disk::rotateToNegativeZSide() {
   averageZ_ = -averageZ_;
-  for (auto& r : rings_) r.mirrorZ();
+  for (auto& r : rings_) r.rotateToNegativeZSide();
 }
 
 const MaterialObject& Disk::materialObject() const {

--- a/src/Endcap.cc
+++ b/src/Endcap.cc
@@ -73,9 +73,11 @@ void Endcap::build() {
       // Build
       diskp->build(extremaDisksInfo);
 
-      // Mirror discs
+      // Disk on (+Z) side is duplicated to (-Z) side.
+      // Please note that the duplication is a rotation of axis CMS_Y and angle Pi !
+      // This is because one does not want to build different disks for both sides, so no 'mirror' should be considered!
       Disk* diskn = GeometryFactory::clone(*diskp);
-      diskn->mirrorZ();
+      diskn->rotateToNegativeZSide();
 
       // Compute coverage on +Z side after built (TO DO : adapt for -Z side, and add a Tracker::computeActualCoverage(), completely independant from build() )
       diskp->computeActualCoverage();

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -213,9 +213,9 @@ void Ring::translateZ(double z) {
   }
 }
 
-void Ring::mirrorZ() {
+void Ring::rotateToNegativeZSide() {
   for (auto& m : modules_) {
-    m.mirrorZ();
+    m.rotateToNegativeZSide();
   }
 }
 


### PR DESCRIPTION
…ecause no effect anyway: mistake on disks duplication on (-Z) side. 
With the current (brainstorming), the disks in (-Z) side are neither mirrored neither rotated of 180 degrees around CMS_Y.
This has no effect because analysis and export of the Forwards are based on (+Z) side only anyway.

This fix makes the disks rotated of 180 degrees along CMS_Y.
Cleaner code and renamings to come in a few minutes.