### PR TITLE
Fixed issue in Giovanni s code, spotted a while ago but pushed back.

### DIFF
--- a/source/Geometry/include/DetectorModule.h
+++ b/source/Geometry/include/DetectorModule.h
@@ -170,7 +170,7 @@ public:
   void mirror(   const XYZVector& vector) { m_moduleGeom->mirror(vector); clearSensorPolys(); }
   void translateZ(double z)               { m_moduleGeom->translate(XYZVector(0, 0, z)); clearSensorPolys(); }
   void translateR(double radius)          { XYZVector v = m_rAxis.Unit()*radius; m_moduleGeom->translate(v); clearSensorPolys();}
-  void mirrorZ();
+  void rotateToNegativeZSide();
   void rotateX(double angle)              { m_moduleGeom->rotateX(angle); clearSensorPolys(); }
   void rotateY(double angle)              { m_moduleGeom->rotateY(angle); clearSensorPolys(); }
   void rotateZ(double angle)              { m_moduleGeom->rotateZ(angle); clearSensorPolys(); m_rAxis = ROOT::Math::RotationZ(angle)(m_rAxis); }

--- a/source/Geometry/include/Disk.h
+++ b/source/Geometry/include/Disk.h
@@ -39,9 +39,10 @@ class Disk : public PropertyObject, public Buildable, public Identifiable<int>, 
 
   //! Build recursively individual subdetector systems: rings -> modules & conversion stations
   void build(const vector<double>& buildDsDistances);
-
-  //! Position newly individual rings of given disc -> mirror them in Z after cloning positive <->negative Disk
-  void buildMirror(int id) { myid(id); mirrorZ(); }
+   
+  //! Position newly individual rings of given disc -> clone (+Z) side disks and rotate them around FCC_Y with angle Pi.
+  // One does not want to build different disks for both sides, hence no 'mirror' should be considered.
+  void buildMirror(int id) { myid(id); rotateToNegativeZSide(); }
 
   //! Position newly individual rings of given disc -> offset them in Z after cloning
   void buildClone(int id, double offset) { myid(id); translateZ(offset); }
@@ -107,7 +108,7 @@ class Disk : public PropertyObject, public Buildable, public Identifiable<int>, 
   void translateZ(double z);
 
   //! Helper method mirroring the whole Disc from zPos to -zPos or vice versa
-  void mirrorZ();
+  void rotateToNegativeZSide();
 
   Rings          m_rings;             //!< Disk rings
   RingIndexMap   m_ringIndexMap;

--- a/source/Geometry/include/Ring.h
+++ b/source/Geometry/include/Ring.h
@@ -146,8 +146,8 @@ public:
   //! Helper method translating Ring z position by given offset
   void translateZ(double zOffset);
 
-  //! Helper method mirroring the whole Ringc from zPos to -zPos or vice versa
-  void mirrorZ();
+  //! Helper method duplicating the whole Ring from zPos to -zPos or vice versa
+  void rotateToNegativeZSide();
 
   //! Return average disc Z position
   double averageZ()  const { return m_averageZ; }

--- a/source/Geometry/src/DetectorModule.cc
+++ b/source/Geometry/src/DetectorModule.cc
@@ -242,16 +242,9 @@ void DetectorModule::setModuleCap(ModuleCap* newCap)
   m_moduleCap = newCap ;
 }
 
-void DetectorModule::mirrorZ() {
+void DetectorModule::rotateToNegativeZSide() {
   side(-side());
-  double zTranslation = -center().Z();
-  double zRotation = -center().Phi();
-  translateZ(zTranslation);
-  rotateZ(zRotation);
-  rotateY(M_PI);
-  translateZ(zTranslation);
-  rotateZ(-zRotation);
-  //decorated().mirror(XYZVector(1., 1., -1.));
+  rotateY(M_PI);  // Rotation around FCC_Y of angle Pi
   clearSensorPolys();
 }
 

--- a/source/Geometry/src/Disk.cc
+++ b/source/Geometry/src/Disk.cc
@@ -254,9 +254,9 @@ void Disk::accept(ConstGeometryVisitor& v) const {
 void Disk::translateZ(double z) { m_averageZ += z; for (auto& r : m_rings) r.translateZ(z); }
 
 //
-// Helper method mirroring the whole Disc from zPos to -zPos or vice versa
+// Helper method to place the whole Disc from zPos to -zPos or vice versa (rotation around axis FCC_Y with angle Pi).
 //
-void Disk::mirrorZ() {
+void Disk::rotateToNegativeZSide() {
   m_averageZ = -m_averageZ;
-  for (auto& r : m_rings) r.mirrorZ();
+  for (auto& r : m_rings) r.rotateToNegativeZSide();
 }

--- a/source/Geometry/src/Ring.cc
+++ b/source/Geometry/src/Ring.cc
@@ -105,12 +105,12 @@ void Ring::translateZ(double zOffset) {
 }
 
 //
-// Helper method mirroring the whole Ringc from zPos to -zPos or vice versa
+// Helper method duplicating the whole Ring from zPos to -zPos or vice versa
 //
-void Ring::mirrorZ() {
+void Ring::rotateToNegativeZSide() {
   m_averageZ *= -1;
   for (auto& m : m_modules) {
-    m.mirrorZ();
+    m.rotateToNegativeZSide();
   }
 }
 


### PR DESCRIPTION
Feature copied here.
Disks on (-Z) side are presently neither mirrored, neither rotated around FCC_Y of angle Pi. 
They are now rotated around FCC_Y with angle Pi.
See #388 

Details:
The previous 'mirrorZ' was actually doing a rotation around FCC_Y and angle Pi.
But it was not working for certain geometries (case where the Ring is not invariant by rotation of axis FCC_Z and angle Pi).

