### PR TITLE
Updated calculation of zError in TEDD

### DIFF
--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -283,24 +283,16 @@ void Disk::computeActualZCoverage() {
       std::pair<double, bool> intersectionWithZAxisA = computeIntersectionWithZAxis(lastMinZ, lastMinRho, newMaxZ, newMaxRho);
       double zErrorCoverageA = intersectionWithZAxisA.first;
       bool isPositiveSlopeA = intersectionWithZAxisA.second;
-
-      // Calculation B : Max coordinates of ring (i+1) with min coordinates of ring (i)
-      // Find the radii and Z of the most stringent points in ring (i).
-      double newMinRho = rings_.at(i-1).minR();
-      double newMinZ = rings_.at(i-1).minZ();
-
-      std::pair<double, bool> intersectionWithZAxisB = computeIntersectionWithZAxis(lastMaxZ, lastMaxRho, newMinZ, newMinRho);
-      double zErrorCoverageB = intersectionWithZAxisB.first;
       
       // CASE WHERE RING (i+1) IS THE INNERMOST RING, AND RING (i) IS THE OUTERMOST RING.
       if (parity > 0.) {
-	zErrorCoverage = zErrorCoverageA; // Only consider calculation A
+	zErrorCoverage = zErrorCoverageA;
 	if (!isPositiveSlopeA) 	zErrorCoverage = -std::numeric_limits<double>::infinity();
       }
 
       // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
       else {
-	zErrorCoverage = -zErrorCoverageA;  // Only consider calculation A
+	zErrorCoverage = -zErrorCoverageA;
 	if (!isPositiveSlopeA) 	zErrorCoverage = std::numeric_limits<double>::infinity();
       }
       

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -287,7 +287,7 @@ void Disk::computeActualZCoverage() {
       // CASE WHERE RING (i+1) IS THE INNERMOST RING, AND RING (i) IS THE OUTERMOST RING.
       if (parity > 0.) {
 	zErrorCoverage = zErrorCoverageA; // Only consider calculation A
-	if (zErrorCoverage <= 0. || !isPositiveSlopeA) zErrorCoverage = 0.;  // doesn't really make sense to have negative zError!
+	//if (zErrorCoverage <= 0. || !isPositiveSlopeA) zErrorCoverage = 0.;  // doesn't really make sense to have negative zError!
       }
 
       // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
@@ -301,8 +301,11 @@ void Disk::computeActualZCoverage() {
 	double zErrorCoverageB = intersectionWithZAxisB.first;
 
 	// Consider the most stringent of calculations A and B
-	if (zErrorCoverageA * zErrorCoverageB < 0. || !isPositiveSlopeA) zErrorCoverage = MIN( fabs(zErrorCoverageA), fabs(zErrorCoverageB));
-	else zErrorCoverage = 0.;
+	/*
+	if (zErrorCoverageA * zErrorCoverageB < 0. || !isPositiveSlopeA) zErrorCoverage = MIN( fabs(zErrorCoverageA), fabs(zErrorCoverageB));	
+	else zErrorCoverage = 0.;*/
+	zErrorCoverage = zErrorCoverageB;
+	if (!isPositiveSlopeA) 	zErrorCoverage = -std::numeric_limits<double>::infinity();  // case not handled yet
       }
       
       // STORE THE RESULT

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -273,27 +273,26 @@ void Disk::computeActualZCoverage() {
 
     if (i != numRings()) {
       // Calculate the coverage in Z of ring (i) with respect to ring (i+1).
-      double zErrorCoverage;
 
-      // Calculation A : Min coordinates of ring (i+1) with max coordinates of ring (i)
+      // Calculation : Min coordinates of ring (i+1) with max coordinates of ring (i)
       // Find the radii and Z of the most stringent points in ring (i).
       double newMaxRho = rings_.at(i-1).buildStartRadius();
       double newMaxZ = rings_.at(i-1).maxZ();
 
-      std::pair<double, bool> intersectionWithZAxisA = computeIntersectionWithZAxis(lastMinZ, lastMinRho, newMaxZ, newMaxRho);
-      double zErrorCoverageA = intersectionWithZAxisA.first;
-      bool isPositiveSlopeA = intersectionWithZAxisA.second;
+      std::pair<double, bool> intersectionWithZAxis = computeIntersectionWithZAxis(lastMinZ, lastMinRho, newMaxZ, newMaxRho);
+      double zErrorCoverage = intersectionWithZAxis.first;
+      bool isPositiveSlope = intersectionWithZAxis.second;
       
       // CASE WHERE RING (i+1) IS THE INNERMOST RING, AND RING (i) IS THE OUTERMOST RING.
       if (parity > 0.) {
-	zErrorCoverage = zErrorCoverageA;
-	if (!isPositiveSlopeA) 	zErrorCoverage = -std::numeric_limits<double>::infinity();
+	zErrorCoverage = zErrorCoverage;
+	if (!isPositiveSlope) 	zErrorCoverage = -std::numeric_limits<double>::infinity();
       }
 
       // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
       else {
-	zErrorCoverage = -zErrorCoverageA;
-	if (!isPositiveSlopeA) 	zErrorCoverage = std::numeric_limits<double>::infinity();
+	zErrorCoverage = -zErrorCoverage;
+	if (!isPositiveSlope) 	zErrorCoverage = std::numeric_limits<double>::infinity();
       }
       
       // STORE THE RESULT

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -283,29 +283,25 @@ void Disk::computeActualZCoverage() {
       std::pair<double, bool> intersectionWithZAxisA = computeIntersectionWithZAxis(lastMinZ, lastMinRho, newMaxZ, newMaxRho);
       double zErrorCoverageA = intersectionWithZAxisA.first;
       bool isPositiveSlopeA = intersectionWithZAxisA.second;
+
+      // Calculation B : Max coordinates of ring (i+1) with min coordinates of ring (i)
+      // Find the radii and Z of the most stringent points in ring (i).
+      double newMinRho = rings_.at(i-1).minR();
+      double newMinZ = rings_.at(i-1).minZ();
+
+      std::pair<double, bool> intersectionWithZAxisB = computeIntersectionWithZAxis(lastMaxZ, lastMaxRho, newMinZ, newMinRho);
+      double zErrorCoverageB = intersectionWithZAxisB.first;
       
       // CASE WHERE RING (i+1) IS THE INNERMOST RING, AND RING (i) IS THE OUTERMOST RING.
       if (parity > 0.) {
 	zErrorCoverage = zErrorCoverageA; // Only consider calculation A
-	//if (zErrorCoverage <= 0. || !isPositiveSlopeA) zErrorCoverage = 0.;  // doesn't really make sense to have negative zError!
+	if (!isPositiveSlopeA) 	zErrorCoverage = -std::numeric_limits<double>::infinity();
       }
 
       // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
       else {
-	// Calculation B : Max coordinates of ring (i+1) with min coordinates of ring (i)
-	// Find the radii and Z of the most stringent points in ring (i).
-	double newMinRho = rings_.at(i-1).minR();
-	double newMinZ = rings_.at(i-1).minZ();
-
-	std::pair<double, bool> intersectionWithZAxisB = computeIntersectionWithZAxis(lastMaxZ, lastMaxRho, newMinZ, newMinRho);
-	double zErrorCoverageB = intersectionWithZAxisB.first;
-
-	// Consider the most stringent of calculations A and B
-	/*
-	if (zErrorCoverageA * zErrorCoverageB < 0. || !isPositiveSlopeA) zErrorCoverage = MIN( fabs(zErrorCoverageA), fabs(zErrorCoverageB));	
-	else zErrorCoverage = 0.;*/
-	zErrorCoverage = zErrorCoverageB;
-	if (!isPositiveSlopeA) 	zErrorCoverage = -std::numeric_limits<double>::infinity();  // case not handled yet
+	zErrorCoverage = -zErrorCoverageA;  // Only consider calculation B
+	if (!isPositiveSlopeA) 	zErrorCoverage = std::numeric_limits<double>::infinity();
       }
       
       // STORE THE RESULT

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -272,27 +272,28 @@ void Disk::computeActualZCoverage() {
   for (int i = numRings(), parity = -bigParity(); i > 0; i--, parity *= -1) {
 
     if (i != numRings()) {
-      // Calculate the coverage in Z of ring (i) with respect to ring (i+1).
-
-      // Calculation : Min coordinates of ring (i+1) with max coordinates of ring (i)
+      // CALCULATE THE COVERAGE IN Z OF RING (i) WITH RESPECT TO RING (i+1).
+      // RING (i+1) HAS BIGGER RADIUS, ring (i) HAS SMALLER RADIUS.
+     
       // Find the radii and Z of the most stringent points in ring (i).
       double newMaxRho = rings_.at(i-1).buildStartRadius();
       double newMaxZ = rings_.at(i-1).maxZ();
 
+      // Calculation : Min coordinates of ring (i+1) with max coordinates of ring (i)
       std::pair<double, bool> intersectionWithZAxis = computeIntersectionWithZAxis(lastMinZ, lastMinRho, newMaxZ, newMaxRho);
       double zErrorCoverage = intersectionWithZAxis.first;
       bool isPositiveSlope = intersectionWithZAxis.second;
       
-      // CASE WHERE RING (i+1) IS THE INNERMOST RING, AND RING (i) IS THE OUTERMOST RING.
+      // CASE WHERE RING (i+1) HAS SMALLER Z, AND RING (i) HAS BIGGER Z.
       if (parity > 0.) {
-	zErrorCoverage = zErrorCoverage;
-	if (!isPositiveSlope) zErrorCoverage = -std::numeric_limits<double>::infinity();
+	if (isPositiveSlope) zErrorCoverage = zErrorCoverage;
+	else zErrorCoverage = -std::numeric_limits<double>::infinity();
       }
 
-      // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
+      // CASE WHERE RING (i+1) HAS BIGGER Z, AND RING (i) HAS SMALLER Z.
       else {
-	zErrorCoverage = -zErrorCoverage;
-	if (!isPositiveSlope) zErrorCoverage = std::numeric_limits<double>::infinity();
+	if (isPositiveSlope) zErrorCoverage = -zErrorCoverage;
+	else zErrorCoverage = std::numeric_limits<double>::infinity();
       }
       
       // STORE THE RESULT

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -300,7 +300,7 @@ void Disk::computeActualZCoverage() {
 
       // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
       else {
-	zErrorCoverage = -zErrorCoverageA;  // Only consider calculation B
+	zErrorCoverage = -zErrorCoverageA;  // Only consider calculation A
 	if (!isPositiveSlopeA) 	zErrorCoverage = std::numeric_limits<double>::infinity();
       }
       

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -286,13 +286,13 @@ void Disk::computeActualZCoverage() {
       // CASE WHERE RING (i+1) IS THE INNERMOST RING, AND RING (i) IS THE OUTERMOST RING.
       if (parity > 0.) {
 	zErrorCoverage = zErrorCoverage;
-	if (!isPositiveSlope) 	zErrorCoverage = -std::numeric_limits<double>::infinity();
+	if (!isPositiveSlope) zErrorCoverage = -std::numeric_limits<double>::infinity();
       }
 
       // CASE WHERE RING (i+1) IS THE OUTERMOST RING, AND RING (i) IS THE INNERMOST RING.
       else {
 	zErrorCoverage = -zErrorCoverage;
-	if (!isPositiveSlope) 	zErrorCoverage = std::numeric_limits<double>::infinity();
+	if (!isPositiveSlope) zErrorCoverage = std::numeric_limits<double>::infinity();
       }
       
       // STORE THE RESULT


### PR DESCRIPTION
Should not display 0, but a negative value in case the interaction point is not included within the coverage interval.