### PR TITLE
Take sensorThickness into account for rings building in TEDD

### DIFF
--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -21,7 +21,7 @@ namespace material {
 using material::MaterialObject;
 using material::ConversionStation;
 
-typedef std::pair<std::vector<double>, std::vector<double> > ScanDiskInfo;
+typedef std::tuple<std::vector<double>, std::vector<double>, double > ScanDiskInfo;
 typedef std::pair<ScanDiskInfo, ScanDiskInfo> ScanEndcapInfo;
 
 class Disk : public PropertyObject, public Buildable, public Identifiable<int>, public Visitable {
@@ -49,6 +49,7 @@ private:
 
   const std::vector<double> scanSmallDeltas() const;
   const std::vector<double> scanDsDistances() const;
+  const double scanSensorThickness() const;
   inline const double getRingInfo(const vector<double>& ringsInfo, int ringNumber) const;
 
   std::pair<double, double> computeStringentZ(int i, int parity, const ScanEndcapInfo& extremaDisksInfo);
@@ -99,7 +100,7 @@ public:
     maxRingThickness.setup([this]() { double max = 0; for (const Ring& r : rings_) { max = MAX(max, r.thickness()); } return max; });
     totalModules.setup([this]() { int cnt = 0; for (const Ring& r : rings_) { cnt += r.numModules(); } return cnt; });
   }
-  const std::pair<std::vector<double>, std::vector<double> > scanPropertyTree() const;
+  const ScanDiskInfo scanPropertyTree() const;
 
   void check() override;
   void build(const ScanEndcapInfo& extremaDisksInfo);

--- a/include/GeometricModule.hh
+++ b/include/GeometricModule.hh
@@ -45,11 +45,13 @@ protected:
   double triangleCross(const XYZVector& P1, const XYZVector& P2, const XYZVector& P3, const XYZVector& PL, const XYZVector& PU);
 public:
   Property<double, Default> dsDistance; // a GeometricModule is a purely 2d geometric object represented in 3d space with just a polygon and an additional for thickness value for tracker geometry construction
+  ReadonlyProperty<double, NoDefault> sensorThickness;
   Property<double, Default> physicalLength;
   PropertyNode<int> contourPointNode;
 
   GeometricModule() :
       dsDistance("dsDistance", parsedAndChecked(), 0.),
+      sensorThickness("sensorThickness", parsedAndChecked()),
       contourPointNode("ContourPoint", parsedOnly()),
       physicalLength("physicalLength", parsedOnly(), 0.)
   {}

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -110,7 +110,6 @@ std::pair<double, double> Disk::computeStringentZ(int i, int parity, const ScanE
     const vector<double>& innermostDiskSmallDeltas = std::get<0>(innermostDiskInfo);
     const vector<double>& innermostDiskDsDistances = std::get<1>(innermostDiskInfo);
     double sensorThickness = std::get<2>(innermostDiskInfo);
-    std::cout << " sensorThickness = " <<  sensorThickness << std::endl;
 
     lastSmallDelta = getRingInfo(innermostDiskSmallDeltas, i+1);
     newSmallDelta = getRingInfo(innermostDiskSmallDeltas, i);
@@ -130,7 +129,6 @@ std::pair<double, double> Disk::computeStringentZ(int i, int parity, const ScanE
     const vector<double>& outermostDiskSmallDeltas = std::get<0>(outermostDiskInfo);
     const vector<double>& outermostDiskDsDistances = std::get<1>(outermostDiskInfo);
     double sensorThickness = std::get<2>(outermostDiskInfo);
-    std::cout << " sensorThickness = " <<  sensorThickness << std::endl;
 
     lastSmallDelta = getRingInfo(outermostDiskSmallDeltas, i+1);
     newSmallDelta = getRingInfo(outermostDiskSmallDeltas, i);

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -154,11 +154,10 @@ double Disk::computeNextRho(int parity, double lastZ, double newZ, double lastRh
   double nextRhoWithZError   = lastRho / (lastZ - zErrorShift) * (newZ - zErrorShift);
 
   // Case B : Consider rOverlap
-  //double nextRhoWithROverlap  = (lastRho + rOverlap()) / lastZ * newZ;
+  double nextRhoWithROverlap  = (lastRho + rOverlap()) / lastZ * newZ;
       
   // Takes the most stringent of cases A and B
-  //double nextRho = MAX(nextRhoWithZError, nextRhoWithROverlap);
-  double nextRho = nextRhoWithZError;
+  double nextRho = MAX(nextRhoWithZError, nextRhoWithROverlap);
 
   return nextRho;
 }


### PR DESCRIPTION
Make sensorThickness included in the building of rings in TEDD. 

sensorThickness was not taken into account for the building of rings in TEDD. 
It was taken into account for the calculation of zError 'a posteriori', once the rings are built.
This showed that there was a significant discrepancy introduced when not taking into account sensorThickness (zError 20 mm instead of 70 mm for example).
This is due to the fact that the disks in TEDD are far away from the interaction point, hence a tiny angular difference has big effects.

This PR allows to have the zError specified in cfg and zError calculated 'a posteriori' perfectly matching.
