### PR TITLE
TEDD design: Automatic ring placement.

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -3,10 +3,9 @@ Endcap TEDD_1 {
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD1_V351.cfg
 
   // Layout construction parameters
-  //zError 70
+  zError 70
   zOverlap 0
-  rSafetyMargin 1.0
-  
+  rOverlap 0
   etaCut 10
   smallParity 1
   trackingTags trigger,tracker
@@ -21,21 +20,21 @@ Endcap TEDD_1 {
   maxZ 1550.00
   bigParity 1
 
-  Ring 15 { ringOuterRadius 1100 }  // TDR
-  Ring 14 { zError 50 }  // TDR ringOuterRadius 1032.765 
-  Ring 13 { zError -285 } // TDR ringOuterRadius 923.694 
-  Ring 12 { zError -285 } // TDR ringOuterRadius 850.306 
-  Ring 11 { zError -285 } // TDR ringOuterRadius 742.595 
-  Ring 10 { zError -285 } // TDR ringOuterRadius 659.981 
-  Ring 9 { zError -285 } // TDR ringOuterRadius 604.591 
-  Ring 8 { zError -285 } // TDR ringOuterRadius 577.117 
-  Ring 7 { zError -285 } // TDR ringOuterRadius 526.011 
-  Ring 6 { zError -285 } // TDR ringOuterRadius 495.661 
-  Ring 5 { zError -285 } // TDR ringOuterRadius 445.051 
-  Ring 4 { zError -285 } // TDR ringOuterRadius 411.739 
-  Ring 3 { zError -285 } // TDR ringOuterRadius 361.639 
-  Ring 2 { zError -285 } // TDR ringOuterRadius 325.275 
-  Ring 1 { ringOuterRadius 275.701 }  // TDR
+  Ring 15 { ringOuterRadius 1100 }
+  //Ring 14 { ringOuterRadius 1032.765 }
+  //Ring 13 { ringOuterRadius 923.694 }
+  //Ring 12 { ringOuterRadius 850.306 }
+  //Ring 11 { ringOuterRadius 742.595 }
+  //Ring 10 { ringOuterRadius 659.981 }
+  //Ring 9 { ringOuterRadius 604.591 }
+  //Ring 8 { ringOuterRadius 577.117 }
+  //Ring 7 { ringOuterRadius 526.011 }
+  //Ring 6 { ringOuterRadius 495.661 }
+  //Ring 5 { ringOuterRadius 445.051 }
+  //Ring 4 { ringOuterRadius 411.739 }
+  //Ring 3 { ringOuterRadius 361.639 }
+  //Ring 2 { ringOuterRadius 325.275 }
+  //Ring 1 { ringOuterRadius 275.701 }
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -1,25 +1,23 @@
 Endcap TEDD_1 {
-  smallParity 1
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD1_V351.cfg
-
-  // Layout construction parameters
-  zError 70
-  zOverlap 0
-  rSafetyMargin 1.0 
   
   etaCut 10
+  trackingTags trigger,tracker 
+
+  // Layout construction parameters
+  numDisks 2
+  bigParity 1
   smallParity 1
-  trackingTags trigger,tracker
   bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
   smallDelta 7.42 // PS NICK 2017
-  phiSegments 4
-  numDisks 2
-  phiOverlap -2 // which saves 4 modules in ring 6 
-  numRings 15
-  outerRadius 1100.00 // Nick 2017-02-24
   minZ 1311.80 // Stefano&Duccio 2017-03-17 reducing clearance from 20 mm to 5 mm
   maxZ 1550.00
-  bigParity 1
+  
+  phiSegments 4
+  phiOverlap -2 // which saves 4 modules in ring 6 
+  
+  numRings 15  
+  outerRadius 1100.00 // Nick 2017-02-24  
 
   Ring 15 { ringOuterRadius 1100 }
   Ring 14 { ringOuterRadius 1032.765 }
@@ -35,7 +33,29 @@ Endcap TEDD_1 {
   Ring 4 { ringOuterRadius 411.739 }
   Ring 3 { ringOuterRadius 361.639 }
   Ring 2 { ringOuterRadius 325.275 }
-  Ring 1 { ringOuterRadius 275.701 }
+  Ring 1 { ringOuterRadius 275.701 }  
+  
+  ////////////////////////////////////////////////////////////////////////////////////////////
+  /// NB: Also possible to specifiy zError per ring, and use automatic placement. Example. ///
+  ////////////////////////////////////////////////////////////////////////////////////////////
+  // zError 70
+  // rSafetyMargin 15.0  // minimal radial space between sensors from ring (i+2) and ring (i) (used in automatic placement mode only)
+  // Ring 15 { ringOuterRadius 1100 }  // TDR
+  // Ring 14 { zError 50 }  // TDR ringOuterRadius 1032.765 
+  // Ring 13 { zError -285 } // TDR ringOuterRadius 923.694 
+  // Ring 12 { zError -285 } // TDR ringOuterRadius 850.306 
+  // Ring 11 { zError -285 } // TDR ringOuterRadius 742.595 
+  // Ring 10 { zError -285 } // TDR ringOuterRadius 659.981 
+  // Ring 9 { zError -285 } // TDR ringOuterRadius 604.591 
+  // Ring 8 { zError -285 } // TDR ringOuterRadius 577.117 
+  // Ring 7 { zError -285 } // TDR ringOuterRadius 526.011 
+  // Ring 6 { zError -285 } // TDR ringOuterRadius 495.661 
+  // Ring 5 { zError -285 } // TDR ringOuterRadius 445.051 
+  // Ring 4 { zError -285 } // TDR ringOuterRadius 411.739 
+  // Ring 3 { zError -285 } // TDR ringOuterRadius 361.639 
+  // Ring 2 { zError -285 } // TDR ringOuterRadius 325.275 
+  // Ring 1 { ringOuterRadius 275.701 }  // TDR 
+
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -5,7 +5,8 @@ Endcap TEDD_1 {
   // Layout construction parameters
   zError 70
   zOverlap 0
-  rOverlap 0
+  rSafetyMargin 50
+  
   etaCut 10
   smallParity 1
   trackingTags trigger,tracker

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -39,7 +39,8 @@ Endcap TEDD_1 {
   /// NB: Also possible to specifiy zError per ring, and use automatic placement. Example. ///
   ////////////////////////////////////////////////////////////////////////////////////////////
   // zError 70
-  // rSafetyMargin 15.0  // minimal radial space between sensors from ring (i+2) and ring (i) (used in automatic placement mode only)
+  // rSafetyMargin 15.0  // minimal radial space between sensors from ring (i+2) and ring (i) (used in automatic placement mode only).
+  // zError and rSafetyMargin can be specified per ring.
   // Ring 15 { ringOuterRadius 1100 }  // TDR
   // Ring 14 { zError 50 }  // TDR ringOuterRadius 1032.765 
   // Ring 13 { zError -285 } // TDR ringOuterRadius 923.694 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -3,9 +3,9 @@ Endcap TEDD_1 {
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD1_V351.cfg
 
   // Layout construction parameters
-  zError 70
+  //zError 70
   zOverlap 0
-  rSafetyMargin 50
+  rSafetyMargin 1.0
   
   etaCut 10
   smallParity 1
@@ -21,21 +21,21 @@ Endcap TEDD_1 {
   maxZ 1550.00
   bigParity 1
 
-  Ring 15 { ringOuterRadius 1100 }
-  //Ring 14 { ringOuterRadius 1032.765 }
-  //Ring 13 { ringOuterRadius 923.694 }
-  //Ring 12 { ringOuterRadius 850.306 }
-  //Ring 11 { ringOuterRadius 742.595 }
-  //Ring 10 { ringOuterRadius 659.981 }
-  //Ring 9 { ringOuterRadius 604.591 }
-  //Ring 8 { ringOuterRadius 577.117 }
-  //Ring 7 { ringOuterRadius 526.011 }
-  //Ring 6 { ringOuterRadius 495.661 }
-  //Ring 5 { ringOuterRadius 445.051 }
-  //Ring 4 { ringOuterRadius 411.739 }
-  //Ring 3 { ringOuterRadius 361.639 }
-  //Ring 2 { ringOuterRadius 325.275 }
-  //Ring 1 { ringOuterRadius 275.701 }
+  Ring 15 { ringOuterRadius 1100 }  // TDR
+  Ring 14 { zError 50 }  // TDR ringOuterRadius 1032.765 
+  Ring 13 { zError -285 } // TDR ringOuterRadius 923.694 
+  Ring 12 { zError -285 } // TDR ringOuterRadius 850.306 
+  Ring 11 { zError -285 } // TDR ringOuterRadius 742.595 
+  Ring 10 { zError -285 } // TDR ringOuterRadius 659.981 
+  Ring 9 { zError -285 } // TDR ringOuterRadius 604.591 
+  Ring 8 { zError -285 } // TDR ringOuterRadius 577.117 
+  Ring 7 { zError -285 } // TDR ringOuterRadius 526.011 
+  Ring 6 { zError -285 } // TDR ringOuterRadius 495.661 
+  Ring 5 { zError -285 } // TDR ringOuterRadius 445.051 
+  Ring 4 { zError -285 } // TDR ringOuterRadius 411.739 
+  Ring 3 { zError -285 } // TDR ringOuterRadius 361.639 
+  Ring 2 { zError -285 } // TDR ringOuterRadius 325.275 
+  Ring 1 { ringOuterRadius 275.701 }  // TDR
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -3,7 +3,7 @@ Endcap TEDD_1 {
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD1_V351.cfg
 
   // Layout construction parameters
-  zError 0
+  zError 70
   zOverlap 0
   rOverlap 0
   etaCut 10
@@ -21,20 +21,20 @@ Endcap TEDD_1 {
   bigParity 1
 
   Ring 15 { ringOuterRadius 1100 }
-  Ring 14 { ringOuterRadius 1032.765 }
-  Ring 13 { ringOuterRadius 923.694 }
-  Ring 12 { ringOuterRadius 850.306 }
-  Ring 11 { ringOuterRadius 742.595 }
-  Ring 10 { ringOuterRadius 659.981 }
-  Ring 9 { ringOuterRadius 604.591 }
-  Ring 8 { ringOuterRadius 577.117 }
-  Ring 7 { ringOuterRadius 526.011 }
-  Ring 6 { ringOuterRadius 495.661 }
-  Ring 5 { ringOuterRadius 445.051 }
-  Ring 4 { ringOuterRadius 411.739 }
-  Ring 3 { ringOuterRadius 361.639 }
-  Ring 2 { ringOuterRadius 325.275 }
-  Ring 1 { ringOuterRadius 275.701 }
+  //Ring 14 { ringOuterRadius 1032.765 }
+  //Ring 13 { ringOuterRadius 923.694 }
+  //Ring 12 { ringOuterRadius 850.306 }
+  //Ring 11 { ringOuterRadius 742.595 }
+  //Ring 10 { ringOuterRadius 659.981 }
+  //Ring 9 { ringOuterRadius 604.591 }
+  //Ring 8 { ringOuterRadius 577.117 }
+  //Ring 7 { ringOuterRadius 526.011 }
+  //Ring 6 { ringOuterRadius 495.661 }
+  //Ring 5 { ringOuterRadius 445.051 }
+  //Ring 4 { ringOuterRadius 411.739 }
+  //Ring 3 { ringOuterRadius 361.639 }
+  //Ring 2 { ringOuterRadius 325.275 }
+  //Ring 1 { ringOuterRadius 275.701 }
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -5,7 +5,8 @@ Endcap TEDD_1 {
   // Layout construction parameters
   zError 70
   zOverlap 0
-  rOverlap 0
+  rSafetyMargin 1.0 
+  
   etaCut 10
   smallParity 1
   trackingTags trigger,tracker
@@ -21,20 +22,20 @@ Endcap TEDD_1 {
   bigParity 1
 
   Ring 15 { ringOuterRadius 1100 }
-  //Ring 14 { ringOuterRadius 1032.765 }
-  //Ring 13 { ringOuterRadius 923.694 }
-  //Ring 12 { ringOuterRadius 850.306 }
-  //Ring 11 { ringOuterRadius 742.595 }
-  //Ring 10 { ringOuterRadius 659.981 }
-  //Ring 9 { ringOuterRadius 604.591 }
-  //Ring 8 { ringOuterRadius 577.117 }
-  //Ring 7 { ringOuterRadius 526.011 }
-  //Ring 6 { ringOuterRadius 495.661 }
-  //Ring 5 { ringOuterRadius 445.051 }
-  //Ring 4 { ringOuterRadius 411.739 }
-  //Ring 3 { ringOuterRadius 361.639 }
-  //Ring 2 { ringOuterRadius 325.275 }
-  //Ring 1 { ringOuterRadius 275.701 }
+  Ring 14 { ringOuterRadius 1032.765 }
+  Ring 13 { ringOuterRadius 923.694 }
+  Ring 12 { ringOuterRadius 850.306 }
+  Ring 11 { ringOuterRadius 742.595 }
+  Ring 10 { ringOuterRadius 659.981 }
+  Ring 9 { ringOuterRadius 604.591 }
+  Ring 8 { ringOuterRadius 577.117 }
+  Ring 7 { ringOuterRadius 526.011 }
+  Ring 6 { ringOuterRadius 495.661 }
+  Ring 5 { ringOuterRadius 445.051 }
+  Ring 4 { ringOuterRadius 411.739 }
+  Ring 3 { ringOuterRadius 361.639 }
+  Ring 2 { ringOuterRadius 325.275 }
+  Ring 1 { ringOuterRadius 275.701 }
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -4,7 +4,8 @@ Endcap TEDD_2 {
   // Layout construction parameters
   zError 70
   zOverlap 0
-  rOverlap 0
+  rSafetyMargin 0
+  
   etaCut 10
   smallParity 1
   trackingTags trigger,tracker

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -2,10 +2,9 @@ Endcap TEDD_2 {
 
   smallParity 1
   // Layout construction parameters
-  //zError 70
+  zError 70
   zOverlap 0
-  rSafetyMargin 1.0
-  
+  rOverlap 0
   etaCut 10
   smallParity 1
   trackingTags trigger,tracker
@@ -21,21 +20,21 @@ Endcap TEDD_2 {
   maxZ 2650.000
   bigParity 1
 
-  Ring 15 { ringOuterRadius 1100 }  // TDR
-  Ring 14 { zError -590 } // TDR ringOuterRadius 1021.566 
-  Ring 13 { zError -590 } // TDR  ringOuterRadius 914.543 
-  Ring 12 { zError -590 } // TDR  ringOuterRadius 831.55 
-  Ring 11 { zError -590 } // TDR  ringOuterRadius 726.567 
-  Ring 10 { zError -590 } // TDR  ringOuterRadius 639.434 
-  Ring 9 { zError -590 } // TDR  ringOuterRadius 587.563 
-  Ring 8 { zError -590 } // TDR  ringOuterRadius 552.73 
-  Ring 7 { zError -590 } // TDR  ringOuterRadius 502.168 
-  Ring 6 { zError -590 } // TDR  ringOuterRadius 465.136 
-  Ring 5 { zError -590 } // TDR  ringOuterRadius 414.885 
-  Ring 4 { ringOuterRadius 375.604 } // TDR
+  Ring 15 { ringOuterRadius 1100 }
+  //Ring 14 { ringOuterRadius 1021.566 }
+  //Ring 13 { ringOuterRadius 914.543 }
+  //Ring 12 { ringOuterRadius 831.55 }
+  //Ring 11 { ringOuterRadius 726.567 }
+  //Ring 10 { ringOuterRadius 639.434 }
+  //Ring 9 { ringOuterRadius 587.563 }
+  //Ring 8 { ringOuterRadius 552.73 }
+  //Ring 7 { ringOuterRadius 502.168 }
+  //Ring 6 { ringOuterRadius 465.136 }
+  //Ring 5 { ringOuterRadius 414.885 }
+  //Ring 4 { ringOuterRadius 375.604 }
   Ring 3 { removeModule true }
   Ring 2 { removeModule true }
-  Ring 1 { removeModule true }  
+  Ring 1 { removeModule true }
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -39,7 +39,8 @@ Endcap TEDD_2 {
   /// NB: Also possible to specifiy zError per ring, and use automatic placement. Example. ///
   ////////////////////////////////////////////////////////////////////////////////////////////  
   // zError 70
-  // rSafetyMargin 15.0  // minimal radial space between sensors from ring (i+2) and ring (i) (used in automatic placement mode only)
+  // rSafetyMargin 15.0  // minimal radial space between sensors from ring (i+2) and ring (i) (used in automatic placement mode only).
+  // zError and rSafetyMargin can be specified per ring.
   // Ring 15 { ringOuterRadius 1100 }  // TDR
   // Ring 14 { zError -590 } // TDR ringOuterRadius 1021.566 
   // Ring 13 { zError -590 } // TDR  ringOuterRadius 914.543 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -4,7 +4,8 @@ Endcap TEDD_2 {
   // Layout construction parameters
   zError 70
   zOverlap 0
-  rOverlap 0
+  rSafetyMargin 1.0  
+  
   etaCut 10
   smallParity 1
   trackingTags trigger,tracker
@@ -21,17 +22,17 @@ Endcap TEDD_2 {
   bigParity 1
 
   Ring 15 { ringOuterRadius 1100 }
-  //Ring 14 { ringOuterRadius 1021.566 }
-  //Ring 13 { ringOuterRadius 914.543 }
-  //Ring 12 { ringOuterRadius 831.55 }
-  //Ring 11 { ringOuterRadius 726.567 }
-  //Ring 10 { ringOuterRadius 639.434 }
-  //Ring 9 { ringOuterRadius 587.563 }
-  //Ring 8 { ringOuterRadius 552.73 }
-  //Ring 7 { ringOuterRadius 502.168 }
-  //Ring 6 { ringOuterRadius 465.136 }
-  //Ring 5 { ringOuterRadius 414.885 }
-  //Ring 4 { ringOuterRadius 375.604 }
+  Ring 14 { ringOuterRadius 1021.566 }
+  Ring 13 { ringOuterRadius 914.543 }
+  Ring 12 { ringOuterRadius 831.55 }
+  Ring 11 { ringOuterRadius 726.567 }
+  Ring 10 { ringOuterRadius 639.434 }
+  Ring 9 { ringOuterRadius 587.563 }
+  Ring 8 { ringOuterRadius 552.73 }
+  Ring 7 { ringOuterRadius 502.168 }
+  Ring 6 { ringOuterRadius 465.136 }
+  Ring 5 { ringOuterRadius 414.885 }
+  Ring 4 { ringOuterRadius 375.604 }
   Ring 3 { removeModule true }
   Ring 2 { removeModule true }
   Ring 1 { removeModule true }

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -2,9 +2,9 @@ Endcap TEDD_2 {
 
   smallParity 1
   // Layout construction parameters
-  zError 70
+  //zError 70
   zOverlap 0
-  rSafetyMargin 0
+  rSafetyMargin 1.0
   
   etaCut 10
   smallParity 1
@@ -21,21 +21,21 @@ Endcap TEDD_2 {
   maxZ 2650.000
   bigParity 1
 
-  Ring 15 { ringOuterRadius 1100 }
-  Ring 14 { ringOuterRadius 1021.566 }
-  Ring 13 { ringOuterRadius 914.543 }
-  Ring 12 { ringOuterRadius 831.55 }
-  Ring 11 { ringOuterRadius 726.567 }
-  Ring 10 { ringOuterRadius 639.434 }
-  Ring 9 { ringOuterRadius 587.563 }
-  Ring 8 { ringOuterRadius 552.73 }
-  Ring 7 { ringOuterRadius 502.168 }
-  Ring 6 { ringOuterRadius 465.136 }
-  Ring 5 { ringOuterRadius 414.885 }
-  Ring 4 { ringOuterRadius 375.604 }
+  Ring 15 { ringOuterRadius 1100 }  // TDR
+  Ring 14 { zError -590 } // TDR ringOuterRadius 1021.566 
+  Ring 13 { zError -590 } // TDR  ringOuterRadius 914.543 
+  Ring 12 { zError -590 } // TDR  ringOuterRadius 831.55 
+  Ring 11 { zError -590 } // TDR  ringOuterRadius 726.567 
+  Ring 10 { zError -590 } // TDR  ringOuterRadius 639.434 
+  Ring 9 { zError -590 } // TDR  ringOuterRadius 587.563 
+  Ring 8 { zError -590 } // TDR  ringOuterRadius 552.73 
+  Ring 7 { zError -590 } // TDR  ringOuterRadius 502.168 
+  Ring 6 { zError -590 } // TDR  ringOuterRadius 465.136 
+  Ring 5 { zError -590 } // TDR  ringOuterRadius 414.885 
+  Ring 4 { ringOuterRadius 375.604 } // TDR
   Ring 3 { removeModule true }
   Ring 2 { removeModule true }
-  Ring 1 { removeModule true }
+  Ring 1 { removeModule true }  
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -22,17 +22,17 @@ Endcap TEDD_2 {
   bigParity 1
 
   Ring 15 { ringOuterRadius 1100 }
-  //Ring 14 { ringOuterRadius 1021.566 }
-  //Ring 13 { ringOuterRadius 914.543 }
-  //Ring 12 { ringOuterRadius 831.55 }
-  //Ring 11 { ringOuterRadius 726.567 }
-  //Ring 10 { ringOuterRadius 639.434 }
-  //Ring 9 { ringOuterRadius 587.563 }
-  //Ring 8 { ringOuterRadius 552.73 }
-  //Ring 7 { ringOuterRadius 502.168 }
-  //Ring 6 { ringOuterRadius 465.136 }
-  //Ring 5 { ringOuterRadius 414.885 }
-  //Ring 4 { ringOuterRadius 375.604 }
+  Ring 14 { ringOuterRadius 1021.566 }
+  Ring 13 { ringOuterRadius 914.543 }
+  Ring 12 { ringOuterRadius 831.55 }
+  Ring 11 { ringOuterRadius 726.567 }
+  Ring 10 { ringOuterRadius 639.434 }
+  Ring 9 { ringOuterRadius 587.563 }
+  Ring 8 { ringOuterRadius 552.73 }
+  Ring 7 { ringOuterRadius 502.168 }
+  Ring 6 { ringOuterRadius 465.136 }
+  Ring 5 { ringOuterRadius 414.885 }
+  Ring 4 { ringOuterRadius 375.604 }
   Ring 3 { removeModule true }
   Ring 2 { removeModule true }
   Ring 1 { removeModule true }

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -1,25 +1,23 @@
 Endcap TEDD_2 {
 
-  smallParity 1
-  // Layout construction parameters
-  zError 70
-  zOverlap 0
-  rSafetyMargin 1.0  
-  
   etaCut 10
-  smallParity 1
   trackingTags trigger,tracker
-  bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
-  smallDelta 7.42 // PS NICK 2017
-  phiSegments 4
+  
+  // Layout construction parameters
   numDisks 3
-  phiOverlap -2
-  numRings 15
-  outerRadius 1100.00 // Nick 2017-02-24
+  bigParity 1
+  smallParity 1  
+  bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
+  smallDelta 7.42 // PS NICK 2017  
   minZ 1853.400
   Disk 2 { placeZ 2216.190 }
   maxZ 2650.000
-  bigParity 1
+    
+  phiSegments 4
+  phiOverlap -2
+  
+  numRings 15
+  outerRadius 1100.00 // Nick 2017-02-24
 
   Ring 15 { ringOuterRadius 1100 }
   Ring 14 { ringOuterRadius 1021.566 }
@@ -36,6 +34,27 @@ Endcap TEDD_2 {
   Ring 3 { removeModule true }
   Ring 2 { removeModule true }
   Ring 1 { removeModule true }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////
+  /// NB: Also possible to specifiy zError per ring, and use automatic placement. Example. ///
+  ////////////////////////////////////////////////////////////////////////////////////////////  
+  // zError 70
+  // rSafetyMargin 15.0  // minimal radial space between sensors from ring (i+2) and ring (i) (used in automatic placement mode only)
+  // Ring 15 { ringOuterRadius 1100 }  // TDR
+  // Ring 14 { zError -590 } // TDR ringOuterRadius 1021.566 
+  // Ring 13 { zError -590 } // TDR  ringOuterRadius 914.543 
+  // Ring 12 { zError -590 } // TDR  ringOuterRadius 831.55 
+  // Ring 11 { zError -590 } // TDR  ringOuterRadius 726.567 
+  // Ring 10 { zError -590 } // TDR  ringOuterRadius 639.434 
+  // Ring 9 { zError -590 } // TDR  ringOuterRadius 587.563 
+  // Ring 8 { zError -590 } // TDR  ringOuterRadius 552.73 
+  // Ring 7 { zError -590 } // TDR  ringOuterRadius 502.168 
+  // Ring 6 { zError -590 } // TDR  ringOuterRadius 465.136 
+  // Ring 5 { zError -590 } // TDR  ringOuterRadius 414.885 
+  // Ring 4 { ringOuterRadius 375.604 } // TDR
+  // Ring 3 { removeModule true }
+  // Ring 2 { removeModule true }
+  // Ring 1 { removeModule true }  
 
   alignEdges false
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -2,7 +2,7 @@ Endcap TEDD_2 {
 
   smallParity 1
   // Layout construction parameters
-  zError 0
+  zError 70
   zOverlap 0
   rOverlap 0
   etaCut 10
@@ -21,17 +21,17 @@ Endcap TEDD_2 {
   bigParity 1
 
   Ring 15 { ringOuterRadius 1100 }
-  Ring 14 { ringOuterRadius 1021.566 }
-  Ring 13 { ringOuterRadius 914.543 }
-  Ring 12 { ringOuterRadius 831.55 }
-  Ring 11 { ringOuterRadius 726.567 }
-  Ring 10 { ringOuterRadius 639.434 }
-  Ring 9 { ringOuterRadius 587.563 }
-  Ring 8 { ringOuterRadius 552.73 }
-  Ring 7 { ringOuterRadius 502.168 }
-  Ring 6 { ringOuterRadius 465.136 }
-  Ring 5 { ringOuterRadius 414.885 }
-  Ring 4 { ringOuterRadius 375.604 }
+  //Ring 14 { ringOuterRadius 1021.566 }
+  //Ring 13 { ringOuterRadius 914.543 }
+  //Ring 12 { ringOuterRadius 831.55 }
+  //Ring 11 { ringOuterRadius 726.567 }
+  //Ring 10 { ringOuterRadius 639.434 }
+  //Ring 9 { ringOuterRadius 587.563 }
+  //Ring 8 { ringOuterRadius 552.73 }
+  //Ring 7 { ringOuterRadius 502.168 }
+  //Ring 6 { ringOuterRadius 465.136 }
+  //Ring 5 { ringOuterRadius 414.885 }
+  //Ring 4 { ringOuterRadius 375.604 }
   Ring 3 { removeModule true }
   Ring 2 { removeModule true }
   Ring 1 { removeModule true }

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -41,7 +41,6 @@ private:
   Property<double, NoDefault> innerRadius;
   Property<double, NoDefault> outerRadius;
   Property<double, NoDefault> bigDelta;
-  Property<double, Default>   rSafetyMargin;
   Property<int   , Default>   bigParity;
 
   PropertyNode<int> ringNode;
@@ -53,7 +52,7 @@ private:
   inline const double getRingInfo(const vector<double>& ringsInfo, int ringNumber) const;
 
   std::pair<double, double> computeStringentZ(int i, int parity, const ScanEndcapInfo& extremaDisksInfo);
-  double computeNextRho(const int parity, const double zError, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho);
+  double computeNextRho(const int parity, const double zError, const double rSafetyMargin, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho);
   void buildTopDown(const ScanEndcapInfo& extremaDisksInfo);
 
   double averageZ_ = 0;
@@ -76,7 +75,6 @@ public:
     outerRadius( "outerRadius", parsedAndChecked()),
     bigDelta(    "bigDelta"   , parsedAndChecked()),
     zHalfLength( "zHalfLength", parsedAndChecked()),
-    rSafetyMargin("rSafetyMargin"   , parsedOnly(), 0.),
     bigParity(   "bigParity"  , parsedOnly(), 1),
     buildZ(      "buildZ"     , parsedOnly()),
     placeZ(      "placeZ"     , parsedOnly()),

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -42,6 +42,7 @@ private:
   Property<double, NoDefault> outerRadius;
   Property<double, NoDefault> bigDelta;
   Property<int   , Default>   bigParity;
+  Property<double, NoDefault> rOverlap;
 
   PropertyNode<int> ringNode;
   PropertyNodeUnique<std::string> stationsNode;
@@ -75,6 +76,7 @@ public:
     outerRadius( "outerRadius", parsedAndChecked()),
     bigDelta(    "bigDelta"   , parsedAndChecked()),
     zHalfLength( "zHalfLength", parsedAndChecked()),
+    rOverlap(    "rOverlap"   , parsedOnly()),
     bigParity(   "bigParity"  , parsedOnly(), 1),
     buildZ(      "buildZ"     , parsedOnly()),
     placeZ(      "placeZ"     , parsedOnly()),

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -53,13 +53,12 @@ private:
   inline const double getRingInfo(const vector<double>& ringsInfo, int ringNumber) const;
 
   std::pair<double, double> computeStringentZ(int i, int parity, const ScanEndcapInfo& extremaDisksInfo);
-  double computeNextRho(const int parity, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho);
+  double computeNextRho(const int parity, const double zError, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho);
   void buildTopDown(const ScanEndcapInfo& extremaDisksInfo);
 
   double averageZ_ = 0;
 public:
   Property<int, NoDefault>    numRings;
-  Property<double, NoDefault> zError;
   Property<double, NoDefault> zHalfLength;
   Property<double, NoDefault> buildZ;
   Property<double, NoDefault> placeZ;
@@ -76,7 +75,6 @@ public:
     innerRadius( "innerRadius", parsedAndChecked()),
     outerRadius( "outerRadius", parsedAndChecked()),
     bigDelta(    "bigDelta"   , parsedAndChecked()),
-    zError(      "zError"     , parsedAndChecked()),
     zHalfLength( "zHalfLength", parsedAndChecked()),
     rSafetyMargin("rSafetyMargin"   , parsedOnly(), 0.),
     bigParity(   "bigParity"  , parsedOnly(), 1),

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -41,7 +41,7 @@ private:
   Property<double, NoDefault> innerRadius;
   Property<double, NoDefault> outerRadius;
   Property<double, NoDefault> bigDelta;
-  Property<double, Default>   rOverlap;
+  Property<double, Default>   rSafetyMargin;
   Property<int   , Default>   bigParity;
 
   PropertyNode<int> ringNode;
@@ -53,7 +53,7 @@ private:
   inline const double getRingInfo(const vector<double>& ringsInfo, int ringNumber) const;
 
   std::pair<double, double> computeStringentZ(int i, int parity, const ScanEndcapInfo& extremaDisksInfo);
-  double computeNextRho(int parity, double lastZ, double newZ, double lastRho);
+  double computeNextRho(const int parity, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho);
   void buildTopDown(const ScanEndcapInfo& extremaDisksInfo);
 
   double averageZ_ = 0;
@@ -78,7 +78,7 @@ public:
     bigDelta(    "bigDelta"   , parsedAndChecked()),
     zError(      "zError"     , parsedAndChecked()),
     zHalfLength( "zHalfLength", parsedAndChecked()),
-    rOverlap(    "rOverlap"   , parsedOnly(), 0.),
+    rSafetyMargin("rSafetyMargin"   , parsedOnly(), 0.),
     bigParity(   "bigParity"  , parsedOnly(), 1),
     buildZ(      "buildZ"     , parsedOnly()),
     placeZ(      "placeZ"     , parsedOnly()),

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -21,7 +21,7 @@ namespace material {
 using material::MaterialObject;
 using material::ConversionStation;
 
-typedef std::tuple<std::vector<double>, std::vector<double>, double > ScanDiskInfo;
+typedef std::pair<std::vector<double>, std::vector<double> > ScanDiskInfo;
 typedef std::pair<ScanDiskInfo, ScanDiskInfo> ScanEndcapInfo;
 
 class Disk : public PropertyObject, public Buildable, public Identifiable<int>, public Visitable {

--- a/include/Ring.hh
+++ b/include/Ring.hh
@@ -163,6 +163,7 @@ public:
   ReadonlyProperty<double, Computable> maxModuleThickness;
   Property<BuildDirection, NoDefault> buildDirection;
   Property<int   , AutoDefault> disk;
+  Property<double, NoDefault> zError;
   Property<double, NoDefault> buildStartRadius;
   Property<double, NoDefault> buildCropRadius;
   Property<double, Computable> minZ, maxZ;
@@ -187,6 +188,7 @@ public:
   Ring() :
       materialObject_(MaterialObject::ROD),
       moduleShape           ("moduleShape"           , parsedAndChecked()),
+      zError                ("zError"                , parsedAndChecked()),
       phiOverlap            ("phiOverlap"            , parsedOnly(), 1.),
       requireOddModsPerSlice("requireOddModsPerSlice", parsedOnly(), false),
       phiSegments           ("phiSegments"           , parsedOnly(), 4),

--- a/include/Ring.hh
+++ b/include/Ring.hh
@@ -164,6 +164,7 @@ public:
   Property<BuildDirection, NoDefault> buildDirection;
   Property<int   , AutoDefault> disk;
   Property<double, NoDefault> zError;
+  Property<double, Default>   rSafetyMargin;
   Property<double, NoDefault> buildStartRadius;
   Property<double, NoDefault> buildCropRadius;
   Property<double, Computable> minZ, maxZ;
@@ -189,6 +190,7 @@ public:
       materialObject_(MaterialObject::ROD),
       moduleShape           ("moduleShape"           , parsedAndChecked()),
       zError                ("zError"                , parsedAndChecked()),
+      rSafetyMargin         ("rSafetyMargin"         , parsedOnly(), 0.),
       phiOverlap            ("phiOverlap"            , parsedOnly(), 1.),
       requireOddModsPerSlice("requireOddModsPerSlice", parsedOnly(), false),
       phiSegments           ("phiSegments"           , parsedOnly(), 4),

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -142,11 +142,12 @@ std::pair<double, double> Disk::computeStringentZ(int i, int parity, const ScanE
 
 
 /** Calculates ring (i) radiusHigh, using ring (i+1).
-   zError constraint is used, as well as a rSafetyMargin.
+    The most stringent of zError and rOverlap is used.
+    rSafetyMargin is also taken into account.
  */
 double Disk::computeNextRho(const int parity, const double zError, const double rSafetyMargin, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho) {
 
-  // // Case A: Consider zError.
+  // Case A: Consider zError.
   double zErrorShift   = (parity > 0 ? zError : - zError);
   double nextRho = lastRho / (lastZ - zErrorShift) * (newZ - zErrorShift);
 

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -149,15 +149,22 @@ std::pair<double, double> Disk::computeStringentZ(int i, int parity, const ScanE
  */
 double Disk::computeNextRho(const int parity, const double zError, const double rSafetyMargin, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho) {
 
-  // Consider zError.
+  // // Case A: Consider zError.
   double zErrorShift   = (parity > 0 ? zError : - zError);
   double nextRho = lastRho / (lastZ - zErrorShift) * (newZ - zErrorShift);
+
+  // Case B : Consider rOverlap
+  if (rOverlap.state()) {
+    double nextRhoWithROverlap  = (lastRho + rOverlap()) / lastZ * newZ;
+    // Takes the most stringent of cases A and B
+    double nextRho = MAX(nextRho, nextRhoWithROverlap);
+  }
 
   // If relevant, consider rSafetyMargin.
   if (oneBeforeLastRho > 1.) {
     double nextRhoSafe = oneBeforeLastRho - rSafetyMargin;
     nextRho = MIN(nextRho, nextRhoSafe);
-  }
+  }    
 
   return nextRho;
 }

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -147,10 +147,10 @@ std::pair<double, double> Disk::computeStringentZ(int i, int parity, const ScanE
 /** Calculates ring (i) radiusHigh, using ring (i+1).
    zError constraint is used, as well as a rSafetyMargin.
  */
-double Disk::computeNextRho(const int parity, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho) {
+double Disk::computeNextRho(const int parity, const double zError, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho) {
 
   // Consider zError.
-  double zErrorShift   = (parity > 0 ? zError() : - zError());
+  double zErrorShift   = (parity > 0 ? zError : - zError);
   double nextRho = lastRho / (lastZ - zErrorShift) * (newZ - zErrorShift);
 
   // If relevant, consider rSafetyMargin.
@@ -194,7 +194,8 @@ void Disk::buildTopDown(const ScanEndcapInfo& extremaDisksInfo) {
       double newZ = stringentZ.second;           // Z of the most stringent point in Ring (i)
       
       // 2) CALCULATES RING (i) RADIUSHIGH USING RING (i+1)
-      double nextRho = computeNextRho(parity, lastZ, newZ, lastRho, oneBeforeLastRho);
+      double zError = ring->zError();
+      double nextRho = computeNextRho(parity, zError, lastZ, newZ, lastRho, oneBeforeLastRho);
 
       // 3) NOW, CAN ASSIGN THE CALCULATED RADIUS TO RING (i) ! 
       ring->buildStartRadius(nextRho);

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -281,11 +281,11 @@ const std::pair<double, bool> Disk::computeIntersectionWithZAxis(double lastZ, d
 
 /** This computes the actual coverage in Z of a disk (after it is built).
     It calculates the actual zError, using the relevant coordinates of the disk.
- */
+*/
 void Disk::computeActualZCoverage() {
 
-  double lastMinRho, lastMaxRho;
-  double lastMinZ, lastMaxZ;
+  double lastMinRho;
+  double lastMinZ;
 
   for (int i = numRings(), parity = -bigParity(); i > 0; i--, parity *= -1) {
 
@@ -320,12 +320,9 @@ void Disk::computeActualZCoverage() {
       ringIndexMap_[i]->actualZError(zErrorCoverage);
     }
 
-    // Keep for next calculation : radii and Z of the most stringent points in ring (i+1).
+    // Keep for next calculation : radii and Z of the most stringent point in ring (i+1).
     lastMinRho = rings_.at(i-1).minR();
     lastMinZ = rings_.at(i-1).minZ();
-
-    lastMaxRho = rings_.at(i-1).maxR();
-    lastMaxZ = rings_.at(i-1).maxZ();
   }
 }
 

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -147,7 +147,7 @@ std::pair<double, double> Disk::computeStringentZ(int i, int parity, const ScanE
 /** Calculates ring (i) radiusHigh, using ring (i+1).
    zError constraint is used, as well as a rSafetyMargin.
  */
-double Disk::computeNextRho(const int parity, const double zError, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho) {
+double Disk::computeNextRho(const int parity, const double zError, const double rSafetyMargin, const double lastZ, const double newZ, const double lastRho, const double oneBeforeLastRho) {
 
   // Consider zError.
   double zErrorShift   = (parity > 0 ? zError : - zError);
@@ -155,7 +155,7 @@ double Disk::computeNextRho(const int parity, const double zError, const double 
 
   // If relevant, consider rSafetyMargin.
   if (oneBeforeLastRho > 1.) {
-    double nextRhoSafe = oneBeforeLastRho - rSafetyMargin();
+    double nextRhoSafe = oneBeforeLastRho - rSafetyMargin;
     nextRho = MIN(nextRho, nextRhoSafe);
   }
 
@@ -195,7 +195,8 @@ void Disk::buildTopDown(const ScanEndcapInfo& extremaDisksInfo) {
       
       // 2) CALCULATES RING (i) RADIUSHIGH USING RING (i+1)
       double zError = ring->zError();
-      double nextRho = computeNextRho(parity, zError, lastZ, newZ, lastRho, oneBeforeLastRho);
+      double rSafetyMargin = ring->rSafetyMargin();
+      double nextRho = computeNextRho(parity, zError, rSafetyMargin, lastZ, newZ, lastRho, oneBeforeLastRho);
 
       // 3) NOW, CAN ASSIGN THE CALCULATED RADIUS TO RING (i) ! 
       ring->buildStartRadius(nextRho);

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -154,10 +154,11 @@ double Disk::computeNextRho(int parity, double lastZ, double newZ, double lastRh
   double nextRhoWithZError   = lastRho / (lastZ - zErrorShift) * (newZ - zErrorShift);
 
   // Case B : Consider rOverlap
-  double nextRhoWithROverlap  = (lastRho + rOverlap()) / lastZ * newZ;
+  //double nextRhoWithROverlap  = (lastRho + rOverlap()) / lastZ * newZ;
       
   // Takes the most stringent of cases A and B
-  double nextRho = MAX(nextRhoWithZError, nextRhoWithROverlap);
+  //double nextRho = MAX(nextRhoWithZError, nextRhoWithROverlap);
+  double nextRho = nextRhoWithZError;
 
   return nextRho;
 }


### PR DESCRIPTION
This completes the recent efforts.

It is now possible to use, for each given ring (i) in TEDD, a radius mode or an auto mode.

- Radius mode: set the radius of the ring (i) (radiusHigh).
Example: Ring 15 { ringOuterRadius 1100 }

- Auto mode: set the zError coverage between ring (i) and ring (i+1). Ring (i) will be automatically placed accordingly. 
It is also possible to add a given radial safety distance between ring (i) and ring (i+2), called rSafetyMargin. The automatic placement will take this margin into account, and never place ring (i) closer to ring (i+2) than this margin distance.
Example: Ring 9 { zError -285 rSafetyMargin 45.0 }

Additionally, the projective z coverage info which is achieved by a given design, is calculated and displayed at (endcaps: additional info). Negative zError are supported.
Results are perfectly matching the coverages expected by construction.

NB: If radius mode is used, the parameters zError and rSafetyMargin will not be taken into account.
The achieved coverage info will obviously still be displayed in (endcaps: additional info) though.