### PR TITLE
Updated services channels numbering + Added details services channels maps on website

### DIFF
--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -34,10 +34,12 @@ public:
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
   const int servicesChannel() const { return servicesChannel_; }
   const ChannelSection& servicesChannelSection() const { return servicesChannelSection_; }
+  const int servicesChannelPlotColor() const { return servicesChannelPlotColor_; }
 
 
 private:
   const std::pair<int, ChannelSection> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  const int computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const;
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
   const std::string computeDTCName(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   
@@ -52,6 +54,7 @@ private:
   bool isPositiveCablingSide_;
   int servicesChannel_;
   ChannelSection servicesChannelSection_;
+  int servicesChannelPlotColor_;
 };
 
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -38,7 +38,7 @@ public:
 
 
 private:
-  const std::pair<int, ChannelSection> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  const std::tuple<int, ChannelSection, int> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   const int computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const;
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
   const std::string computeDTCName(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -328,7 +328,8 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   void setBundle(Bundle* bundle) { bundle_ = bundle ; }
   const Bundle* getBundle() const { return bundle_; }  
   const int isPositiveCablingSide() const;
-  const int bundlePlotColor() const;  
+  const int bundlePlotColor() const; 
+  const int channelPlotColor() const; 
   const DTC* getDTC() const;
   const int dtcPlotColor() const;
   const int dtcPhiSectorRef() const;  

--- a/include/Palette.hh
+++ b/include/Palette.hh
@@ -14,7 +14,7 @@ class Palette {
   static Color_t color(const std::string& objectName);
   static Color_t color(const unsigned int& colorIndex, bool isTransparent = false);
   static Color_t colorDTC(const int& colorIndex, bool isTransparent = false);
-  static Color_t colorChannel(const int& colorIndex, bool isTransparent = false);
+  static Color_t colorChannel(const int& colorIndex, bool isTransparentActivated = false);
   static const Color_t color_invalid_module = kGray + 1;
  private:
   static std::map<std::string, int> colorPickMap;

--- a/include/Palette.hh
+++ b/include/Palette.hh
@@ -14,6 +14,7 @@ class Palette {
   static Color_t color(const std::string& objectName);
   static Color_t color(const unsigned int& colorIndex, bool isTransparent = false);
   static Color_t colorDTC(const int& colorIndex, bool isTransparent = false);
+  static Color_t colorChannel(const int& colorIndex, bool isTransparent = false);
   static const Color_t color_invalid_module = kGray + 1;
  private:
   static std::map<std::string, int> colorPickMap;

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -100,13 +100,13 @@ struct Type { // Module-maintained color
   }
 };
 
-struct TypeBundleColor { // Module-maintained DTC color
+struct TypeBundleColor { // Module-maintained Bundle color
   double operator()(const Module& m) {
     return Palette::color(m.bundlePlotColor());
   }
 };
 
-struct TypeBundleTransparentColor { // Module-maintained DTC color
+struct TypeBundleTransparentColor { // Module-maintained Bundle color
   double operator()(const Module& m) {
     bool isTransparent = (m.isPositiveCablingSide() < 0);
     return Palette::color(m.bundlePlotColor(), isTransparent);
@@ -123,6 +123,19 @@ struct TypeDTCTransparentColor { // Module-maintained DTC color
   double operator()(const Module& m) {
     bool isTransparent = (m.isPositiveCablingSide() < 0);
     return Palette::colorDTC(m.dtcPlotColor(), isTransparent);
+  }
+};
+
+struct TypeChannelColor { // Module-maintained channel color
+  double operator()(const Module& m) {
+    return Palette::colorDTC(m.channelPlotColor());
+  }
+};
+
+struct TypeChannelTransparentColor { // Module-maintained channel color
+  double operator()(const Module& m) {
+    bool isTransparent = (m.isPositiveCablingSide() < 0);
+    return Palette::colorDTC(m.channelPlotColor(), isTransparent);
   }
 };
 

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -134,7 +134,9 @@ struct TypeChannelColor { // Module-maintained channel color
 
 struct TypeChannelTransparentColor { // Module-maintained channel color
   double operator()(const Module& m) {
-    bool isTransparent = (m.isPositiveCablingSide() < 0);
+
+    int isTrans = (m.channelPlotColor() - 1) / 12.;
+    bool isTransparent = (isTrans > 0.9);
     return Palette::colorChannel(m.channelPlotColor(), isTransparent);
   }
 };

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -134,10 +134,8 @@ struct TypeChannelColor { // Module-maintained channel color
 
 struct TypeChannelTransparentColor { // Module-maintained channel color
   double operator()(const Module& m) {
-
-    int isTrans = (m.channelPlotColor() - 1) / 12.;
-    bool isTransparent = (isTrans > 0.9);
-    return Palette::colorChannel(m.channelPlotColor(), isTransparent);
+    bool isTransparentActivated = true;
+    return Palette::colorChannel(m.channelPlotColor(), isTransparentActivated);
   }
 };
 

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -128,14 +128,14 @@ struct TypeDTCTransparentColor { // Module-maintained DTC color
 
 struct TypeChannelColor { // Module-maintained channel color
   double operator()(const Module& m) {
-    return Palette::colorDTC(m.channelPlotColor());
+    return Palette::colorChannel(m.channelPlotColor());
   }
 };
 
 struct TypeChannelTransparentColor { // Module-maintained channel color
   double operator()(const Module& m) {
     bool isTransparent = (m.isPositiveCablingSide() < 0);
-    return Palette::colorDTC(m.channelPlotColor(), isTransparent);
+    return Palette::colorChannel(m.channelPlotColor(), isTransparent);
   }
 };
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -239,8 +239,7 @@ namespace insur {
 
     void drawCircle(double radius, bool full, int color=kBlack);
     void drawPhiSectorsBoundaries(const double phiSectorWidth);
-    void computeServicesChannelsLegend(TLegend* leg);
-    void computePowerServicesChannelsLegend(TLegend* leg);
+    void computeServicesChannelsLegend(TLegend* leg, const bool isTransparentActivated = false);
   };
 
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -239,8 +239,8 @@ namespace insur {
 
     void drawCircle(double radius, bool full, int color=kBlack);
     void drawPhiSectorsBoundaries(const double phiSectorWidth);
-    void drawServicesChannelsLegend();
-    void drawPowerServicesChannelsLegend();
+    void computeServicesChannelsLegend(TLegend* leg);
+    void computePowerServicesChannelsLegend(TLegend* leg);
   };
 
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -167,7 +167,8 @@ namespace insur {
     void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
     void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createSummaryCanvasCablingChannelNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
     RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
@@ -239,6 +240,7 @@ namespace insur {
     void drawCircle(double radius, bool full, int color=kBlack);
     void drawPhiSectorsBoundaries(const double phiSectorWidth);
     void drawServicesChannelsLegend();
+    void drawPowerServicesChannelsLegend();
   };
 
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -167,6 +167,7 @@ namespace insur {
     void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
     void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasCablingChannelNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
     RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -238,6 +238,7 @@ namespace insur {
 
     void drawCircle(double radius, bool full, int color=kBlack);
     void drawPhiSectorsBoundaries(const double phiSectorWidth);
+    void drawServicesChannelsLegend();
   };
 
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -167,8 +167,8 @@ namespace insur {
     void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
     void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
     RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
@@ -239,7 +239,7 @@ namespace insur {
 
     void drawCircle(double radius, bool full, int color=kBlack);
     void drawPhiSectorsBoundaries(const double phiSectorWidth);
-    void computeServicesChannelsLegend(TLegend* leg, const bool isTransparentActivated = false);
+    void computeServicesChannelsLegend(TLegend* legend, const CablingMap* myCablingMap, const bool isPositiveCablingSide, const bool isPowerCabling);
   };
 
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -139,7 +139,7 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
 const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
   int plotColor = 0;
   plotColor = servicesChannel;
-  //if (servicesChannelSection == ChannelSection::C) plotColor += 12 * 1;
+  if (servicesChannelSection == ChannelSection::A) plotColor += 12 * 1;
   return plotColor;
 }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -139,7 +139,7 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
 const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
   int plotColor = 0;
   plotColor = servicesChannel;
-  if (servicesChannelSection == ChannelSection::A) plotColor += 12 * 1;
+  if (servicesChannelSection == ChannelSection::A) plotColor += 12;
   return plotColor;
 }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -14,6 +14,7 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
   const std::pair<int, ChannelSection>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
   servicesChannel_ = servicesChannelInfo.first;
   servicesChannelSection_ = servicesChannelInfo.second;
+  servicesChannelPlotColor_ = computeServicesChannelPlotColor(servicesChannel_, servicesChannelSection_);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -123,6 +124,14 @@ const std::pair<int, ChannelSection> Cable::computeServicesChannel(const int phi
   }
 
   return std::make_pair(servicesChannel, servicesChannelSection);
+}
+
+
+const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
+  int plotColor = 0;
+  plotColor = servicesChannel_;
+  if (servicesChannelSection_ == ChannelSection::C) plotColor += 12 * 4;
+  return plotColor;
 }
 
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,10 +11,10 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN A SERVICESCHANNEL TO THE CABLE
-  const std::pair<int, ChannelSection>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
-  servicesChannel_ = servicesChannelInfo.first;
-  servicesChannelSection_ = servicesChannelInfo.second;
-  servicesChannelPlotColor_ = computeServicesChannelPlotColor(servicesChannel_, servicesChannelSection_);
+  const std::tuple<int, ChannelSection, int>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
+  servicesChannel_ = std::get<0>(servicesChannelInfo);
+  servicesChannelSection_ = std::get<1>(servicesChannelInfo);
+  servicesChannelPlotColor_ = std::get<2>(servicesChannelInfo);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -31,7 +31,7 @@ Cable::~Cable() {
  * They are the channels where the optical cables are routed when they exit the tracker.
  * They are closely related to the phiSector ref.
  */
-const std::pair<int, ChannelSection> Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
   int servicesChannel = 0;
   ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
 
@@ -106,6 +106,15 @@ const std::pair<int, ChannelSection> Cable::computeServicesChannel(const int phi
     }
   }
 
+
+  // VERY IMPORTANT!
+  // COMPUTE SERVICES CHANNEL PLOT COLOR, FOR BOTH SIDES, BEFORE THE CHANNEL NUMBERING IS MIRRORED FOR (-Z) SIDE.
+  // THIS IS BECAUSE A GIVEN SERVICE CHANNEL IS IDENTICAL ALL ALONG Z (going from (+z) to (-Z) side).
+  // HENCE, EVEN IF THE NUMBERING IS MIRRORED, WE DONT CARE, AND WE ACTUALLY WANT A GIVEN CHANNEL COLORED BY A UNIQUE COLOR!!
+  int servicesChannelPlotColor = computeServicesChannelPlotColor(servicesChannel, servicesChannelSection);
+  std::cout << "servicesChannelPlotColor = " << servicesChannelPlotColor << std::endl;
+
+
   // NEGATIVE CABLING SIDE.
   // This is the following transformation:
   // 1 -> 6
@@ -123,14 +132,14 @@ const std::pair<int, ChannelSection> Cable::computeServicesChannel(const int phi
     servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
   }
 
-  return std::make_pair(servicesChannel, servicesChannelSection);
+  return std::make_tuple(servicesChannel, servicesChannelSection, servicesChannelPlotColor);
 }
 
 
 const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
   int plotColor = 0;
-  plotColor = servicesChannel_;
-  if (servicesChannelSection_ == ChannelSection::C) plotColor += 12 * 4;
+  plotColor = servicesChannel;
+  //if (servicesChannelSection_ == ChannelSection::C) plotColor += 12 * 4;
   return plotColor;
 }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -109,13 +109,23 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
 
   // VERY IMPORTANT!
   // COMPUTE SERVICES CHANNEL PLOT COLOR, FOR BOTH SIDES, BEFORE THE CHANNEL NUMBERING IS MIRRORED FOR (-Z) SIDE.
-  // THIS IS BECAUSE A GIVEN SERVICE CHANNEL IS IDENTICAL ALL ALONG Z (going from (+z) to (-Z) side).
-  // HENCE, EVEN IF THE NUMBERING IS MIRRORED, WE DONT CARE, AND WE ACTUALLY WANT A GIVEN CHANNEL COLORED BY A UNIQUE COLOR!!
+  // THIS IS BECAUSE A GIVEN SERVICE CHANNEL IS IDENTICAL ALL ALONG Z (going from (+Z) to (-Z) side).
+  // HENCE, EVEN IF THE CHANNEL NUMBERING CAN BE DIFFERENT, WE DONT CARE, AND WE ACTUALLY WANT A GIVEN CHANNEL COLORED BY A UNIQUE COLOR!!
   int servicesChannelPlotColor = computeServicesChannelPlotColor(servicesChannel, servicesChannelSection);
-  //std::cout << "servicesChannelPlotColor = " << servicesChannelPlotColor << std::endl;
 
 
   // NEGATIVE CABLING SIDE.
+  // A given services channel is simplified as a straight line all along (Z).
+  // THIS DEFINES THE CHANNEL NUMBERING ON THE (-Z) SIDE.
+
+  // OPTION A: 
+  // Channel 1A on (+Z) side becomes -1A on the (-Z) side, 1C on (+Z) side becomes -1C on (-Z) side, and so on.
+  if (!isPositiveCablingSide) {
+    servicesChannel *= -1;
+  }
+
+  // OPTION B (NOT PRESENTLY RETAINED)
+  /*
   // This is the following transformation:
   // 1 -> 6
   // 2 -> 5
@@ -125,23 +135,20 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   // 9 -> 10
   // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
   // The services channel is then set to negative on negative cabling side.
-
   if (!isPositiveCablingSide) {
-    servicesChannel *= -1;
-  }
-
-
-  /*if (!isPositiveCablingSide) {
-    double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
-    servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
-    servicesChannel *= -1;
-    servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
-    }*/
+  double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
+  servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
+  servicesChannel *= -1;
+  servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
+  }*/
 
   return std::make_tuple(servicesChannel, servicesChannelSection, servicesChannelPlotColor);
 }
 
 
+/* Compute color associated to services channel.
+ * If section A, +12 is added so that the same color is used as scetion C, but that color can be set as transparent if desired.
+ */
 const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
   int plotColor = 0;
   plotColor = servicesChannel;

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -125,12 +125,12 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   // 9 -> 10
   // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
   // The services channel is then set to negative on negative cabling side.
-  if (!isPositiveCablingSide) {
+  /*if (!isPositiveCablingSide) {
     double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
     servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
     servicesChannel *= -1;
     servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
-  }
+    }*/
 
   return std::make_tuple(servicesChannel, servicesChannelSection, servicesChannelPlotColor);
 }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -112,7 +112,7 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   // THIS IS BECAUSE A GIVEN SERVICE CHANNEL IS IDENTICAL ALL ALONG Z (going from (+z) to (-Z) side).
   // HENCE, EVEN IF THE NUMBERING IS MIRRORED, WE DONT CARE, AND WE ACTUALLY WANT A GIVEN CHANNEL COLORED BY A UNIQUE COLOR!!
   int servicesChannelPlotColor = computeServicesChannelPlotColor(servicesChannel, servicesChannelSection);
-  std::cout << "servicesChannelPlotColor = " << servicesChannelPlotColor << std::endl;
+  //std::cout << "servicesChannelPlotColor = " << servicesChannelPlotColor << std::endl;
 
 
   // NEGATIVE CABLING SIDE.
@@ -139,7 +139,7 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
 const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
   int plotColor = 0;
   plotColor = servicesChannel;
-  //if (servicesChannelSection_ == ChannelSection::C) plotColor += 12 * 4;
+  //if (servicesChannelSection == ChannelSection::C) plotColor += 12 * 1;
   return plotColor;
 }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -125,6 +125,12 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   // 9 -> 10
   // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
   // The services channel is then set to negative on negative cabling side.
+
+  if (!isPositiveCablingSide) {
+    servicesChannel *= -1;
+  }
+
+
   /*if (!isPositiveCablingSide) {
     double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
     servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -481,6 +481,19 @@ const int DetectorModule::bundlePlotColor() const {
 }
 
 
+const int DetectorModule::channelPlotColor() const {
+  int channelPlotColor = 0;
+  const Bundle* myBundle = getBundle();
+  if (myBundle != nullptr) {
+    const Cable* myCable = myBundle->getCable();
+    if (myCable != nullptr) {   
+      channelPlotColor = myCable->servicesChannelPlotColor();
+    }
+  }
+  return channelPlotColor;
+}
+
+
 const DTC* DetectorModule::getDTC() const {
   const DTC* myDTC = nullptr;
   const Bundle* myBundle = getBundle();

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -162,7 +162,7 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
 }
 
 
-Color_t Palette::colorChannel(const int& colorIndex, bool isTransparent) {
+Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated) {
 
   short zone = femod(colorIndex % 12, 12);
   int shift = (colorIndex - 1) / 12;
@@ -220,6 +220,11 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparent) {
 
     paletteIndex -= shift - 2;*/
 
+  /*std::cout << "colorIndex = " << colorIndex << std::endl;
+    std::cout << "paletteIndex = " << paletteIndex << std::endl;
+    std::cout << "(colorIndex % 10) = " << (colorIndex % 10) << std::endl;
+    std::cout << "zone =" << zone << std::endl;
+    std::cout << "shift = " << shift << std::endl;*/
 
 
 
@@ -269,16 +274,12 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparent) {
 
     //paletteIndex -= shift;
 
+    if (isTransparentActivated) {
+      bool isTransparent = (shift > 0.9);
+      if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.1);
+    }
 
 
-    /*std::cout << "colorIndex = " << colorIndex << std::endl;
-    std::cout << "paletteIndex = " << paletteIndex << std::endl;
-    std::cout << "(colorIndex % 10) = " << (colorIndex % 10) << std::endl;
-    std::cout << "zone =" << zone << std::endl;
-    std::cout << "shift = " << shift << std::endl;*/
-
-
-    if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.1);
   }
  
   return paletteIndex;

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -278,7 +278,7 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparent) {
     std::cout << "shift = " << shift << std::endl;*/
 
 
-    if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.2);
+    if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.1);
   }
  
   return paletteIndex;

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -267,7 +267,7 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparent) {
       break;
     }
 
-    paletteIndex -= shift;
+    //paletteIndex -= shift;
 
 
 

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -162,6 +162,129 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
 }
 
 
+Color_t Palette::colorChannel(const int& colorIndex, bool isTransparent) {
+
+  short zone = femod(colorIndex % 12, 12);
+  int shift = (colorIndex - 1) / 12;
+  
+  short paletteIndex;
+
+  if (colorIndex == 0) paletteIndex = 1;
+
+
+  /* These are the colors used by Palette::colorDTC !!
+    
+    else {
+    switch (zone) {
+    case 0 :
+      paletteIndex= kYellow - 2;
+      break;
+    case 1 :
+      paletteIndex= kOrange - 1;
+      break;
+    case 2 :
+      paletteIndex= kRed - 2;
+      break;
+    case 3 :
+      paletteIndex=kPink - 3;
+      break;
+    case 4 :
+      paletteIndex=kMagenta - 4;
+      break;
+    case 5 :
+      paletteIndex=kViolet - 5;
+      break;
+    case 6 :
+      paletteIndex=kBlue - 6;
+      break;
+    case 7 :
+      paletteIndex=kAzure - 7;
+      break;
+    case 8 :
+      paletteIndex=kCyan - 8;
+      break;
+    case 9 :
+      paletteIndex=kTeal - 9;
+      break;
+    case 10 :
+      paletteIndex=kGreen;
+      break;
+    case 11 :
+      paletteIndex=kSpring - 1;
+      break;
+    default :
+      std::cerr << "ERROR: modulo 12" << std::endl;
+      paletteIndex=kWhite;
+      break;
+    }
+
+    paletteIndex -= shift - 2;*/
+
+
+
+
+  else {
+    switch (zone) {
+    case 1 :
+      paletteIndex= kYellow;
+      break;
+    case 2 :
+      paletteIndex= kOrange - 3;
+      break;
+    case 3 :
+      paletteIndex= kOrange + 3;
+      break;
+    case 4 :
+      paletteIndex=kRed;
+      break;
+    case 5 :
+      paletteIndex=kGray + 1;
+      break;
+    case 6 :
+      paletteIndex=kMagenta - 7;
+      break;
+    case 7 :
+      paletteIndex=kViolet - 1;
+      break;
+    case 8 :
+      paletteIndex=kBlue;
+      break;
+    case 9 :
+      paletteIndex=kAzure + 1;
+      break;
+    case 10 :
+      paletteIndex=kCyan;
+      break;
+    case 11 :
+      paletteIndex=kGreen + 2;
+      break;
+    case 0 :
+      paletteIndex=kSpring;
+      break;
+    default :
+      std::cerr << "ERROR: modulo 12" << std::endl;
+      paletteIndex=kWhite;
+      break;
+    }
+
+    paletteIndex -= shift;
+
+
+
+    /*std::cout << "colorIndex = " << colorIndex << std::endl;
+    std::cout << "paletteIndex = " << paletteIndex << std::endl;
+    std::cout << "(colorIndex % 10) = " << (colorIndex % 10) << std::endl;
+    std::cout << "zone =" << zone << std::endl;
+    std::cout << "shift = " << shift << std::endl;*/
+
+
+    if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.2);
+  }
+ 
+  return paletteIndex;
+}
+
+
 // TO DO : Why the hell is TColor::GetColorTransparent not recognized as a method of TColor ?? 
 // Temporary : use this instead.  
 Int_t Palette::GetColorTransparent(Int_t colorIndex, Float_t ratio) {

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -107,8 +107,6 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
   
   short paletteIndex;
   if (colorIndex == 0) paletteIndex = 1;
-  //else paletteIndex = 300 + colorIndex * 5;
-  //else paletteIndex = 300 + zone * 50 + 5 * phiSector;
 
   else {
     switch (zone) {
@@ -156,6 +154,60 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
 
     paletteIndex -= phiSector;
     if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.2);
+
+    /* These are the colors used by Palette::colorDTC !!
+    
+       else {
+       switch (zone) {
+       case 0 :
+       paletteIndex= kYellow - 2;
+       break;
+       case 1 :
+       paletteIndex= kOrange - 1;
+       break;
+       case 2 :
+       paletteIndex= kRed - 2;
+       break;
+       case 3 :
+       paletteIndex=kPink - 3;
+       break;
+       case 4 :
+       paletteIndex=kMagenta - 4;
+       break;
+       case 5 :
+       paletteIndex=kViolet - 5;
+       break;
+       case 6 :
+       paletteIndex=kBlue - 6;
+       break;
+       case 7 :
+       paletteIndex=kAzure - 7;
+       break;
+       case 8 :
+       paletteIndex=kCyan - 8;
+       break;
+       case 9 :
+       paletteIndex=kTeal - 9;
+       break;
+       case 10 :
+       paletteIndex=kGreen;
+       break;
+       case 11 :
+       paletteIndex=kSpring - 1;
+       break;
+       default :
+       std::cerr << "ERROR: modulo 12" << std::endl;
+       paletteIndex=kWhite;
+       break;
+       }
+
+       paletteIndex -= shift - 2;*/
+
+    /*std::cout << "colorIndex = " << colorIndex << std::endl;
+      std::cout << "paletteIndex = " << paletteIndex << std::endl;
+      std::cout << "(colorIndex % 10) = " << (colorIndex % 10) << std::endl;
+      std::cout << "zone =" << zone << std::endl;
+      std::cout << "shift = " << shift << std::endl;*/
   }
  
   return paletteIndex;
@@ -164,69 +216,12 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
 
 Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated) {
 
-  short zone = femod(colorIndex % 12, 12);
-  int shift = (colorIndex - 1) / 12;
+  const short zone = femod(colorIndex % 12, 12);  // unit digit (in a numbering of base 12)
+  const int shift = (colorIndex - 1) / 12;  // dizain digit (in a numbering of base 12)
   
   short paletteIndex;
 
   if (colorIndex == 0) paletteIndex = 1;
-
-
-  /* These are the colors used by Palette::colorDTC !!
-    
-    else {
-    switch (zone) {
-    case 0 :
-      paletteIndex= kYellow - 2;
-      break;
-    case 1 :
-      paletteIndex= kOrange - 1;
-      break;
-    case 2 :
-      paletteIndex= kRed - 2;
-      break;
-    case 3 :
-      paletteIndex=kPink - 3;
-      break;
-    case 4 :
-      paletteIndex=kMagenta - 4;
-      break;
-    case 5 :
-      paletteIndex=kViolet - 5;
-      break;
-    case 6 :
-      paletteIndex=kBlue - 6;
-      break;
-    case 7 :
-      paletteIndex=kAzure - 7;
-      break;
-    case 8 :
-      paletteIndex=kCyan - 8;
-      break;
-    case 9 :
-      paletteIndex=kTeal - 9;
-      break;
-    case 10 :
-      paletteIndex=kGreen;
-      break;
-    case 11 :
-      paletteIndex=kSpring - 1;
-      break;
-    default :
-      std::cerr << "ERROR: modulo 12" << std::endl;
-      paletteIndex=kWhite;
-      break;
-    }
-
-    paletteIndex -= shift - 2;*/
-
-  /*std::cout << "colorIndex = " << colorIndex << std::endl;
-    std::cout << "paletteIndex = " << paletteIndex << std::endl;
-    std::cout << "(colorIndex % 10) = " << (colorIndex % 10) << std::endl;
-    std::cout << "zone =" << zone << std::endl;
-    std::cout << "shift = " << shift << std::endl;*/
-
-
 
   else {
     switch (zone) {
@@ -273,12 +268,10 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated
     }
 
     //paletteIndex -= shift;
-
     if (isTransparentActivated) {
-      bool isTransparent = (shift > 0.9);
+      const bool isTransparent = (shift > 0.9); // set transparent if 12 has been added, hence if shift >= 1
       if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.1);
     }
-
 
   }
  

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -98,12 +98,16 @@ Color_t Palette::color_int(const unsigned int& plotIndex, bool isTransparent) {
 }
 
 
+/*
+  This allows to have one different color for each of the 12 DTC slots.
+  A shift in the color scheme is also done for each of the 9 possible phi sectors.
+ */
 Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
   //TColor::CreateColorWheel();
- //return gROOT->GetColor(paletteIndex);
+  //return gROOT->GetColor(paletteIndex);
 
-  short phiSector = colorIndex % 10;
-  short zone = femod(colorIndex % 12, 12);
+  const int zone = femod(colorIndex % 12, 12);  // unit digit (in a numbering of base 12)
+  const int phiSector = (colorIndex - 1) / 12;  // dizain digit (in a numbering of base 12)
   
   short paletteIndex;
   if (colorIndex == 0) paletteIndex = 1;
@@ -111,7 +115,7 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
   else {
     switch (zone) {
     case 0 :
-      paletteIndex= kYellow;
+      paletteIndex= kYellow ;
       break;
     case 1 :
       paletteIndex= kOrange;
@@ -152,72 +156,21 @@ Color_t Palette::colorDTC(const int& colorIndex, bool isTransparent) {
       break;
     }
 
-    paletteIndex -= phiSector;
+    paletteIndex -= (colorIndex % 10);  // should be -= phiSector, but decision was made to keep things like this, since color scheme cannot be perfectly unique anyway.
     if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.2);
-
-    /* These are the colors used by Palette::colorDTC !!
-    
-       else {
-       switch (zone) {
-       case 0 :
-       paletteIndex= kYellow - 2;
-       break;
-       case 1 :
-       paletteIndex= kOrange - 1;
-       break;
-       case 2 :
-       paletteIndex= kRed - 2;
-       break;
-       case 3 :
-       paletteIndex=kPink - 3;
-       break;
-       case 4 :
-       paletteIndex=kMagenta - 4;
-       break;
-       case 5 :
-       paletteIndex=kViolet - 5;
-       break;
-       case 6 :
-       paletteIndex=kBlue - 6;
-       break;
-       case 7 :
-       paletteIndex=kAzure - 7;
-       break;
-       case 8 :
-       paletteIndex=kCyan - 8;
-       break;
-       case 9 :
-       paletteIndex=kTeal - 9;
-       break;
-       case 10 :
-       paletteIndex=kGreen;
-       break;
-       case 11 :
-       paletteIndex=kSpring - 1;
-       break;
-       default :
-       std::cerr << "ERROR: modulo 12" << std::endl;
-       paletteIndex=kWhite;
-       break;
-       }
-
-       paletteIndex -= shift - 2;*/
-
-    /*std::cout << "colorIndex = " << colorIndex << std::endl;
-      std::cout << "paletteIndex = " << paletteIndex << std::endl;
-      std::cout << "(colorIndex % 10) = " << (colorIndex % 10) << std::endl;
-      std::cout << "zone =" << zone << std::endl;
-      std::cout << "shift = " << shift << std::endl;*/
   }
  
   return paletteIndex;
 }
 
 
+/* This allows to have one color for each of the 12 services channels.
+   If 12 is added, the color is set to transparent (if transparent colors allowed by isTransparentActivated).
+ */
 Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated) {
 
-  const short zone = femod(colorIndex % 12, 12);  // unit digit (in a numbering of base 12)
-  const int shift = (colorIndex - 1) / 12;  // dizain digit (in a numbering of base 12)
+  const int zone = femod(colorIndex % 12, 12);  // unit digit (in a numbering of base 12)
+  const int shift = (colorIndex - 1) / 12;      // dizain digit (in a numbering of base 12)
   
   short paletteIndex;
 
@@ -267,12 +220,10 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated
       break;
     }
 
-    //paletteIndex -= shift;
     if (isTransparentActivated) {
-      const bool isTransparent = (shift > 0.9); // set transparent if 12 has been added, hence if shift >= 1
+      const bool isTransparent = (shift >= 1); // set transparent if 12 has been added
       if (isTransparent) paletteIndex = Palette::GetColorTransparent(paletteIndex, 0.1);
     }
-
   }
  
   return paletteIndex;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1378,7 +1378,7 @@ namespace insur {
       TCanvas *XYChannelFlatCanvas = nullptr; 
       std::vector<TCanvas*> XYChannelCanvasesDisk;
        
-      myContent = new RootWContent("Modules to Channels");
+      myContent = new RootWContent("Modules to Services Channels");
       myPage->addContent(myContent);
 
       createSummaryCanvasCablingChannelNicer(tracker, RZChannelCanvas, XYChannelNegCanvas, XYChannelNegFlatCanvas, XYChannelCanvas, XYChannelFlatCanvas, XYChannelCanvasesDisk);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1369,50 +1369,99 @@ namespace insur {
       }
 
 
-      // Modules to Services Channels
-      TCanvas *summaryChannelCanvas = nullptr;
-      TCanvas *RZChannelCanvas = nullptr;
-      TCanvas *XYChannelNegCanvas = nullptr;
-      TCanvas *XYChannelNegFlatCanvas = nullptr;
-      TCanvas *XYChannelCanvas = nullptr; 
-      TCanvas *XYChannelFlatCanvas = nullptr; 
-      std::vector<TCanvas*> XYChannelCanvasesDisk;
+      // Modules to Services Channels (optical)
+      TCanvas *summaryChannelOpticalCanvas = nullptr;
+      TCanvas *RZChannelOpticalCanvas = nullptr;
+      TCanvas *XYChannelOpticalNegCanvas = nullptr;
+      TCanvas *XYChannelOpticalNegFlatCanvas = nullptr;
+      TCanvas *XYChannelOpticalCanvas = nullptr; 
+      TCanvas *XYChannelOpticalFlatCanvas = nullptr; 
+      std::vector<TCanvas*> XYChannelOpticalCanvasesDisk;
        
-      myContent = new RootWContent("Modules to Services Channels");
+      myContent = new RootWContent("Modules to Services Channels (optical)");
       myPage->addContent(myContent);
 
-      createSummaryCanvasCablingChannelNicer(tracker, RZChannelCanvas, XYChannelNegCanvas, XYChannelNegFlatCanvas, XYChannelCanvas, XYChannelFlatCanvas, XYChannelCanvasesDisk);
+      createSummaryCanvasOpticalCablingChannelNicer(tracker, RZChannelOpticalCanvas, XYChannelOpticalNegCanvas, XYChannelOpticalNegFlatCanvas, XYChannelOpticalCanvas, XYChannelOpticalFlatCanvas, XYChannelOpticalCanvasesDisk);
 
-      /*if (RZChannelCanvas) {
-	myImage = new RootWImage(RZChannelCanvas, RZChannelCanvas->GetWindowWidth(), RZChannelCanvas->GetWindowHeight() );
+      /*if (RZChannelOpticalCanvas) {
+	myImage = new RootWImage(RZChannelOpticalCanvas, RZChannelOpticalCanvas->GetWindowWidth(), RZChannelOpticalCanvas->GetWindowHeight() );
 	myImage->setComment("(RZ) View : Tracker modules colored by their connections to Services Channels. 1 color = 1 Channel.");
 	myContent->addItem(myImage);
 	}*/
-      if (XYChannelNegCanvas) {
-	myImage = new RootWImage(XYChannelNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      if (XYChannelOpticalNegCanvas) {
+	myImage = new RootWImage(XYChannelOpticalNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      if (XYChannelNegFlatCanvas) {
-	myImage = new RootWImage(XYChannelNegFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      if (XYChannelOpticalNegFlatCanvas) {
+	myImage = new RootWImage(XYChannelOpticalNegFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      if (XYChannelCanvas) {
-	myImage = new RootWImage(XYChannelCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      if (XYChannelOpticalCanvas) {
+	myImage = new RootWImage(XYChannelOpticalCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      if (XYChannelFlatCanvas) {
-	myImage = new RootWImage(XYChannelFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      if (XYChannelOpticalFlatCanvas) {
+	myImage = new RootWImage(XYChannelOpticalFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYChannelCanvasDisk : XYChannelCanvasesDisk ) {
-	myImage = new RootWImage(XYChannelCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYChannelCanvasDisk->GetTitle());
+      for (const auto& XYChannelOpticalCanvasDisk : XYChannelOpticalCanvasesDisk ) {
+	myImage = new RootWImage(XYChannelOpticalCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(XYChannelOpticalCanvasDisk->GetTitle());
 	myContent->addItem(myImage);
       }
+
+
+      // Modules to Services Channels (powering)
+      TCanvas *summaryChannelPowerCanvas = nullptr;
+      TCanvas *RZChannelPowerCanvas = nullptr;
+      TCanvas *XYChannelPowerNegCanvas = nullptr;
+      TCanvas *XYChannelPowerNegFlatCanvas = nullptr;
+      TCanvas *XYChannelPowerCanvas = nullptr; 
+      TCanvas *XYChannelPowerFlatCanvas = nullptr; 
+      std::vector<TCanvas*> XYChannelPowerCanvasesDisk;
+       
+      myContent = new RootWContent("Modules to Services Channels (powering)");
+      myPage->addContent(myContent);
+
+      createSummaryCanvasPowerCablingChannelNicer(tracker, RZChannelPowerCanvas, XYChannelPowerNegCanvas, XYChannelPowerNegFlatCanvas, XYChannelPowerCanvas, XYChannelPowerFlatCanvas, XYChannelPowerCanvasesDisk);
+
+      /*if (RZChannelPowerCanvas) {
+	myImage = new RootWImage(RZChannelPowerCanvas, RZChannelPowerCanvas->GetWindowWidth(), RZChannelPowerCanvas->GetWindowHeight() );
+	myImage->setComment("(RZ) View : Tracker modules colored by their connections to Services ChannelPowers. 1 color = 1 ChannelPower.");
+	myContent->addItem(myImage);
+	}*/
+      if (XYChannelPowerNegCanvas) {
+	myImage = new RootWImage(XYChannelPowerNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards you)");
+	myContent->addItem(myImage);
+      }
+      if (XYChannelPowerNegFlatCanvas) {
+	myImage = new RootWImage(XYChannelPowerNegFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Negative cabling side. (CMS +Z points towards you)");
+	myContent->addItem(myImage);
+      }
+      if (XYChannelPowerCanvas) {
+	myImage = new RootWImage(XYChannelPowerCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment("(XY) Section : Tracker barrel. Positive cabling side. (CMS +Z points towards you)");
+	myContent->addItem(myImage);
+      }
+      if (XYChannelPowerFlatCanvas) {
+	myImage = new RootWImage(XYChannelPowerFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Positive cabling side. (CMS +Z points towards you)");
+	myContent->addItem(myImage);
+      }
+      for (const auto& XYChannelPowerCanvasDisk : XYChannelPowerCanvasesDisk ) {
+	myImage = new RootWImage(XYChannelPowerCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(XYChannelPowerCanvasDisk->GetTitle());
+	myContent->addItem(myImage);
+      }
+
+
+
 
       
       
@@ -6769,10 +6818,10 @@ namespace insur {
   }
 
 
-  void Vizard::createSummaryCanvasCablingChannelNicer(Tracker& tracker,
-						  TCanvas *&RZCanvas, 
-						  TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
-						  std::vector<TCanvas*> &XYCanvasesDisk) {
+  void Vizard::createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker,
+							   TCanvas *&RZCanvas, 
+							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
+							   std::vector<TCanvas*> &XYCanvasesDisk) {
 
     double scaleFactor = tracker.maxR()/600;
 
@@ -6782,7 +6831,7 @@ namespace insur {
     const std::set<Module*>& trackerModules = tracker.modules();
     RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", rzCanvasX, rzCanvasY );
     RZCanvas->cd();
-    PlotDrawer<YZFull, TypeChannelTransparentColor> yzDrawer;
+    PlotDrawer<YZFull, TypeChannelColor> yzDrawer;
     yzDrawer.addModules(trackerModules.begin(), trackerModules.end(), [] (const Module& m ) { 
 	return ( (m.isPositiveCablingSide() > 0 && m.dtcPhiSectorRef() == 1) || (m.isPositiveCablingSide() < 0 && m.dtcPhiSectorRef() == 2) ); 
       } );
@@ -6846,6 +6895,89 @@ namespace insur {
 	  XYCanvasesDisk.push_back(XYCanvasDisk);
 	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
 	  drawServicesChannelsLegend();
+	}
+      }
+    }
+  }
+
+
+  void Vizard::createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker,
+							   TCanvas *&RZCanvas, 
+							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
+							   std::vector<TCanvas*> &XYCanvasesDisk) {
+
+    double scaleFactor = tracker.maxR()/600;
+
+    int rzCanvasX = insur::vis_max_canvas_sizeX;//int(tracker.maxZ()/scaleFactor);
+    int rzCanvasY = insur::vis_min_canvas_sizeX;//int(tracker.maxR()/scaleFactor);
+
+    const std::set<Module*>& trackerModules = tracker.modules();
+    RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", rzCanvasX, rzCanvasY );
+    RZCanvas->cd();
+    PlotDrawer<YZFull, TypeChannelTransparentColor> yzDrawer;
+    yzDrawer.addModules(trackerModules.begin(), trackerModules.end(), [] (const Module& m ) { 
+	return ( (m.isPositiveCablingSide() > 0 && m.dtcPhiSectorRef() == 1) || (m.isPositiveCablingSide() < 0 && m.dtcPhiSectorRef() == 2) ); 
+      } );
+    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
+    yzDrawer.drawModules<ContourStyle>(*RZCanvas);
+
+    double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
+
+    // NEGATIVE CABLING SIDE. BARREL.
+    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas->cd();
+    PlotDrawer<XYNeg, TypeChannelTransparentColor> xyNegBarrelDrawer;
+    xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0)); } );
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawPowerServicesChannelsLegend();
+
+    // NEGATIVE CABLING SIDE. BARREL FLAT PART.
+    XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegFlatCanvas->cd();
+    PlotDrawer<XYNeg, TypeChannelTransparentColor> xyNegFlatBarrelDrawer;
+    xyNegFlatBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0) && !m.isTilted()); } );
+    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
+    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
+    drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawPowerServicesChannelsLegend();
+
+    // POSITIVE CABLING SIDE. BARREL.
+    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas->cd();
+    PlotDrawer<XY, TypeChannelTransparentColor> xyBarrelDrawer;
+    xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0)); } );
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawPowerServicesChannelsLegend();
+
+    // POSITIVE CABLING SIDE. BARREL FLAT PART.
+    XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYFlatCanvas->cd();
+    PlotDrawer<XY, TypeChannelTransparentColor> xyBarrelFlatDrawer;
+    xyBarrelFlatDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0) && !m.isTilted()); } );
+    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
+    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
+    drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawPowerServicesChannelsLegend();
+    
+    // ENDCAPS DISK.
+    for (auto& anEndcap : tracker.endcaps() ) {
+      for (auto& aDisk : anEndcap.disks() ) {
+	if (aDisk.side()) {
+	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYCanvasEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
+					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	  XYCanvasDisk->cd();
+	  PlotDrawer<XY, TypeChannelTransparentColor> xyDiskDrawer;
+	  xyDiskDrawer.addModules(aDisk);
+	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
+	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
+	  XYCanvasesDisk.push_back(XYCanvasDisk);
+	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+	  drawPowerServicesChannelsLegend();
 	}
       }
     }
@@ -7273,6 +7405,7 @@ namespace insur {
 
   void Vizard::drawServicesChannelsLegend() {
     TLegend* leg = new TLegend(0.905,0.3,1.0,0.8);
+    //leg->SetHeader("Channels (+Z side numbering)");
 
     for (int i = 1; i <= 12; i++) {
       Double_t x[5] = {0., 1.};
@@ -7285,6 +7418,44 @@ namespace insur {
       channelStream << "OT" << i << std::endl;
       std::string channel = channelStream.str();
       leg->AddEntry(line, channel.c_str(), "f"); 
+    }
+
+    leg->Draw("same");
+  }
+
+
+  void Vizard::drawPowerServicesChannelsLegend() {
+    TLegend* leg = new TLegend(0.905, 0., 1., 1.);
+    //leg->SetHeader("Channels (+Z side numbering)");
+
+    for (int i = 1; i <= 12; i++) {
+      Double_t x[5] = {0., 1.};
+      Double_t y[5] = {0., 0.};
+      TPolyLine* line = new TPolyLine(2, x, y);
+      line->SetLineColor(Palette::colorChannel(i));
+      line->SetFillColor(Palette::colorChannel(i));
+      
+      std::stringstream channelStream;
+      channelStream << "OT" << i << "C" << std::endl;
+      std::string channel = channelStream.str();
+      leg->AddEntry(line, channel.c_str(), "f"); 
+
+
+      if ((i % 2) == 0) {
+	bool isTransparent = true;
+	Double_t xTrans[5] = {0., 1.};
+	Double_t yTrans[5] = {0., 0.};
+	TPolyLine* lineTrans = new TPolyLine(2, xTrans, yTrans);
+	lineTrans->SetLineColor(Palette::colorChannel(i, isTransparent));
+	lineTrans->SetFillColor(Palette::colorChannel(i, isTransparent));
+      
+	std::stringstream channelStreamTrans;
+	channelStreamTrans << "OT" << i << "A" << std::endl;
+	std::string channelTrans = channelStreamTrans.str();
+	leg->AddEntry(lineTrans, channelTrans.c_str(), "f"); 
+      }
+
+    
     }
 
     leg->Draw("same");

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7431,8 +7431,13 @@ namespace insur {
       const int& myPlotColor = myCable.second->servicesChannelPlotColor();
 
       std::stringstream channelNameStream;
-      channelNameStream << "OT" << myNumber;
-      // If power cabling, one is also interedted in the section (A or C).
+      channelNameStream << "OT";
+      if (fabs(myNumber) <= 9) {
+	if (myNumber >= 0) channelNameStream << "0" << myNumber;  // add a 0 in front of single-digit numbers, so that the map is directly properly sorted.
+	else channelNameStream << "-0" << fabs(myNumber);
+      }
+      else channelNameStream << myNumber;
+      // If power cabling, one is also interested in the section (A or C).
       if (isPowerCabling) { 
 	const ChannelSection& mySection = myCable.second->servicesChannelSection();
 	channelNameStream << any2str(mySection); 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6927,7 +6927,8 @@ namespace insur {
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
 
     TLegend* channelsLegend = new TLegend(0.905, 0., 1., 1.);
-    computePowerServicesChannelsLegend(channelsLegend);
+    bool isTransparentActivated = true;
+    computeServicesChannelsLegend(channelsLegend, isTransparentActivated);
 
     // NEGATIVE CABLING SIDE. BARREL.
     XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -7409,54 +7410,39 @@ namespace insur {
   }
 
 
-  void Vizard::computeServicesChannelsLegend(TLegend* leg) {
+  void Vizard::computeServicesChannelsLegend(TLegend* leg, const bool isTransparentActivated) {
     //leg->SetHeader("Channels (+Z side numbering)");
 
     for (int i = 1; i <= 12; i++) {
-      Double_t x[5] = {0., 1.};
-      Double_t y[5] = {0., 0.};
-      TPolyLine* line = new TPolyLine(2, x, y);
+      Double_t x[1] = {0.};
+      Double_t y[1] = {0.};
+      TPolyLine* line = new TPolyLine(1, x, y);
       line->SetLineColor(Palette::colorChannel(i));
       line->SetFillColor(Palette::colorChannel(i));
       
       std::stringstream channelStream;
-      channelStream << "OT" << i << std::endl;
-      std::string channel = channelStream.str();
-      leg->AddEntry(line, channel.c_str(), "f"); 
-    }
-  }
+      channelStream << "OT" << i;
+      if (!isTransparentActivated) channelStream << std::endl;
+      else channelStream << "C" << std::endl;
 
-
-  void Vizard::computePowerServicesChannelsLegend(TLegend* leg) {   
-    //leg->SetHeader("Channels (+Z side numbering)");
-
-    for (int i = 1; i <= 12; i++) {
-      Double_t x[5] = {0., 1.};
-      Double_t y[5] = {0., 0.};
-      TPolyLine* line = new TPolyLine(2, x, y);
-      line->SetLineColor(Palette::colorChannel(i));
-      line->SetFillColor(Palette::colorChannel(i));
-      
-      std::stringstream channelStream;
-      channelStream << "OT" << i << "C" << std::endl;
       std::string channel = channelStream.str();
       leg->AddEntry(line, channel.c_str(), "f"); 
 
 
-      if ((i % 2) == 0) {
-	bool isTransparent = true;
-	Double_t xTrans[5] = {0., 1.};
-	Double_t yTrans[5] = {0., 0.};
-	TPolyLine* lineTrans = new TPolyLine(2, xTrans, yTrans);
-	lineTrans->SetLineColor(Palette::colorChannel(i, isTransparent));
-	lineTrans->SetFillColor(Palette::colorChannel(i, isTransparent));
+      if (isTransparentActivated && ((i % 2) == 0)) {
+	Double_t xTrans[1] = {0.};
+	Double_t yTrans[1] = {0.};
+	TPolyLine* lineTrans = new TPolyLine(1, xTrans, yTrans);
+	lineTrans->SetLineColor(Palette::colorChannel(i + 12, isTransparentActivated));
+	lineTrans->SetFillColor(Palette::colorChannel(i + 12, isTransparentActivated));
       
 	std::stringstream channelStreamTrans;
 	channelStreamTrans << "OT" << i << "A" << std::endl;
 	std::string channelTrans = channelStreamTrans.str();
 	leg->AddEntry(lineTrans, channelTrans.c_str(), "f"); 
       }
-  
+
+
     }
   }
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1383,11 +1383,11 @@ namespace insur {
 
       createSummaryCanvasCablingChannelNicer(tracker, RZChannelCanvas, XYChannelNegCanvas, XYChannelNegFlatCanvas, XYChannelCanvas, XYChannelFlatCanvas, XYChannelCanvasesDisk);
 
-      if (RZChannelCanvas) {
+      /*if (RZChannelCanvas) {
 	myImage = new RootWImage(RZChannelCanvas, RZChannelCanvas->GetWindowWidth(), RZChannelCanvas->GetWindowHeight() );
 	myImage->setComment("(RZ) View : Tracker modules colored by their connections to Services Channels. 1 color = 1 Channel.");
 	myContent->addItem(myImage);
-      }
+	}*/
       if (XYChannelNegCanvas) {
 	myImage = new RootWImage(XYChannelNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards you)");
@@ -6773,6 +6773,7 @@ namespace insur {
 						  TCanvas *&RZCanvas, 
 						  TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 						  std::vector<TCanvas*> &XYCanvasesDisk) {
+
     double scaleFactor = tracker.maxR()/600;
 
     int rzCanvasX = insur::vis_max_canvas_sizeX;//int(tracker.maxZ()/scaleFactor);
@@ -6798,6 +6799,7 @@ namespace insur {
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawServicesChannelsLegend();
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
     XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6807,6 +6809,7 @@ namespace insur {
     xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
     xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawServicesChannelsLegend();
 
     // POSITIVE CABLING SIDE. BARREL.
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6816,6 +6819,7 @@ namespace insur {
     xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawServicesChannelsLegend();
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
     XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6825,6 +6829,7 @@ namespace insur {
     xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
     xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawServicesChannelsLegend();
     
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
@@ -6840,6 +6845,7 @@ namespace insur {
 	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
 	  XYCanvasesDisk.push_back(XYCanvasDisk);
 	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+	  drawServicesChannelsLegend();
 	}
       }
     }
@@ -7260,8 +7266,28 @@ namespace insur {
     for (int i = 0; i < numPhiSectors; i++) {
       TLine* line = new TLine(0., 0., phiSectorBoundaryRadius * cos(i * phiSectorWidth), phiSectorBoundaryRadius * sin(i * phiSectorWidth)); 
       line->SetLineWidth(2); 
-      line->Draw("same");
+      line->Draw("same");     
     }
+  }
+
+
+  void Vizard::drawServicesChannelsLegend() {
+    TLegend* leg = new TLegend(0.905,0.3,1.0,0.8);
+
+    for (int i = 1; i <= 12; i++) {
+      Double_t x[5] = {0., 1.};
+      Double_t y[5] = {0., 0.};
+      TPolyLine* line = new TPolyLine(2, x, y);
+      line->SetLineColor(Palette::colorChannel(i));
+      line->SetFillColor(Palette::colorChannel(i));
+      
+      std::stringstream channelStream;
+      channelStream << "OT" << i << std::endl;
+      std::string channel = channelStream.str();
+      leg->AddEntry(line, channel.c_str(), "f"); 
+    }
+
+    leg->Draw("same");
   }
 
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1488,7 +1488,7 @@ namespace insur {
       myContent = new RootWContent("Modules to Services Channels (optical)");
       myPage->addContent(myContent);
 
-      createSummaryCanvasOpticalCablingChannelNicer(tracker, RZChannelOpticalCanvas, XYChannelOpticalNegCanvas, XYChannelOpticalNegFlatCanvas, XYChannelOpticalCanvas, XYChannelOpticalFlatCanvas, XYChannelOpticalCanvasesDisk);
+      createSummaryCanvasOpticalCablingChannelNicer(tracker, myCablingMap, RZChannelOpticalCanvas, XYChannelOpticalNegCanvas, XYChannelOpticalNegFlatCanvas, XYChannelOpticalCanvas, XYChannelOpticalFlatCanvas, XYChannelOpticalCanvasesDisk);
 
       /*if (RZChannelOpticalCanvas) {
 	myImage = new RootWImage(RZChannelOpticalCanvas, RZChannelOpticalCanvas->GetWindowWidth(), RZChannelOpticalCanvas->GetWindowHeight() );
@@ -1534,7 +1534,7 @@ namespace insur {
       myContent = new RootWContent("Modules to Services Channels (powering)");
       myPage->addContent(myContent);
 
-      createSummaryCanvasPowerCablingChannelNicer(tracker, RZChannelPowerCanvas, XYChannelPowerNegCanvas, XYChannelPowerNegFlatCanvas, XYChannelPowerCanvas, XYChannelPowerFlatCanvas, XYChannelPowerCanvasesDisk);
+      createSummaryCanvasPowerCablingChannelNicer(tracker, myCablingMap, RZChannelPowerCanvas, XYChannelPowerNegCanvas, XYChannelPowerNegFlatCanvas, XYChannelPowerCanvas, XYChannelPowerFlatCanvas, XYChannelPowerCanvasesDisk);
 
       /*if (RZChannelPowerCanvas) {
 	myImage = new RootWImage(RZChannelPowerCanvas, RZChannelPowerCanvas->GetWindowWidth(), RZChannelPowerCanvas->GetWindowHeight() );
@@ -6817,7 +6817,7 @@ namespace insur {
   }
 
 
-  void Vizard::createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker,
+  void Vizard::createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
 							   TCanvas *&RZCanvas, 
 							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 							   std::vector<TCanvas*> &XYCanvasesDisk) {
@@ -6839,8 +6839,13 @@ namespace insur {
 
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
 
-    TLegend* channelsLegend = new TLegend(0.905,0.3,1.0,0.8);
-    computeServicesChannelsLegend(channelsLegend);
+    bool isPowerCabling = false;
+    bool isPositiveCablingSide = true;
+    TLegend* channelsLegendPos = new TLegend(0.905,0.3,1.0,0.8);
+    computeServicesChannelsLegend(channelsLegendPos, myCablingMap, isPositiveCablingSide, isPowerCabling);
+    isPositiveCablingSide = false;
+    TLegend* channelsLegendNeg = new TLegend(0.905,0.3,1.0,0.8);
+    computeServicesChannelsLegend(channelsLegendNeg, myCablingMap, isPositiveCablingSide, isPowerCabling);
 
     // NEGATIVE CABLING SIDE. BARREL.
     XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6850,7 +6855,7 @@ namespace insur {
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendNeg->Draw("same");
     
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
@@ -6861,7 +6866,7 @@ namespace insur {
     xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
     xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendNeg->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6871,7 +6876,7 @@ namespace insur {
     xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendPos->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
     XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6881,7 +6886,7 @@ namespace insur {
     xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
     xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendPos->Draw("same");
     
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
@@ -6897,14 +6902,14 @@ namespace insur {
 	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
 	  XYCanvasesDisk.push_back(XYCanvasDisk);
 	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-	  channelsLegend->Draw("same");
+	  channelsLegendPos->Draw("same");
 	}
       }
     }
   }
 
 
-  void Vizard::createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker,
+  void Vizard::createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
 							   TCanvas *&RZCanvas, 
 							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 							   std::vector<TCanvas*> &XYCanvasesDisk) {
@@ -6926,9 +6931,13 @@ namespace insur {
 
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
 
-    TLegend* channelsLegend = new TLegend(0.905, 0., 1., 1.);
-    bool isTransparentActivated = true;
-    computeServicesChannelsLegend(channelsLegend, isTransparentActivated);
+    bool isPowerCabling = true;
+    bool isPositiveCablingSide = true;
+    TLegend* channelsLegendPos = new TLegend(0.905, 0., 1., 1.);
+    computeServicesChannelsLegend(channelsLegendPos, myCablingMap, isPositiveCablingSide, isPowerCabling);
+    isPositiveCablingSide = false;
+    TLegend* channelsLegendNeg = new TLegend(0.905, 0., 1., 1.);
+    computeServicesChannelsLegend(channelsLegendNeg, myCablingMap, isPositiveCablingSide, isPowerCabling);
 
     // NEGATIVE CABLING SIDE. BARREL.
     XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6938,7 +6947,7 @@ namespace insur {
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendNeg->Draw("same");
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
     XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6948,7 +6957,7 @@ namespace insur {
     xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
     xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendNeg->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6958,7 +6967,7 @@ namespace insur {
     xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendPos->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
     XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6968,7 +6977,7 @@ namespace insur {
     xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
     xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegend->Draw("same");
+    channelsLegendPos->Draw("same");
     
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
@@ -6984,7 +6993,7 @@ namespace insur {
 	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
 	  XYCanvasesDisk.push_back(XYCanvasDisk);
 	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-	  channelsLegend->Draw("same");
+	  channelsLegendPos->Draw("same");
 	}
       }
     }
@@ -7410,39 +7419,43 @@ namespace insur {
   }
 
 
-  void Vizard::computeServicesChannelsLegend(TLegend* leg, const bool isTransparentActivated) {
+  void Vizard::computeServicesChannelsLegend(TLegend* legend, const CablingMap* myCablingMap, const bool isPositiveCablingSide, const bool isPowerCabling) {
     //leg->SetHeader("Channels (+Z side numbering)");
+    std::map<std::string, int > channelsColors;
 
-    for (int i = 1; i <= 12; i++) {
+
+    const std::map<int, Cable*>& cables = (isPositiveCablingSide ? myCablingMap->getCables() : myCablingMap->getNegCables());
+
+    for (const auto& myCable : cables) {
+      const int& myNumber = myCable.second->servicesChannel();
+      const int& myPlotColor = myCable.second->servicesChannelPlotColor();
+
+      std::stringstream channelNameStream;
+      channelNameStream << "OT" << myNumber;
+      // If power cabling, one is also interedted in the section (A or C).
+      if (isPowerCabling) { 
+	const ChannelSection& mySection = myCable.second->servicesChannelSection();
+	channelNameStream << any2str(mySection); 
+      } 
+      channelNameStream << std::endl;
+      const std::string channelName = channelNameStream.str();
+
+      if (channelsColors.find(channelName) == channelsColors.end()) {
+	channelsColors[channelName] = myPlotColor;
+      }
+    }
+
+    for (const auto& it : channelsColors) {
+      const std::string channelName = it.first;
+      const int& myPlotColor = it.second;
+
       Double_t x[1] = {0.};
       Double_t y[1] = {0.};
       TPolyLine* line = new TPolyLine(1, x, y);
-      line->SetLineColor(Palette::colorChannel(i));
-      line->SetFillColor(Palette::colorChannel(i));
-      
-      std::stringstream channelStream;
-      channelStream << "OT" << i;
-      if (!isTransparentActivated) channelStream << std::endl;
-      else channelStream << "C" << std::endl;
-
-      std::string channel = channelStream.str();
-      leg->AddEntry(line, channel.c_str(), "f"); 
-
-
-      if (isTransparentActivated && ((i % 2) == 0)) {
-	Double_t xTrans[1] = {0.};
-	Double_t yTrans[1] = {0.};
-	TPolyLine* lineTrans = new TPolyLine(1, xTrans, yTrans);
-	lineTrans->SetLineColor(Palette::colorChannel(i + 12, isTransparentActivated));
-	lineTrans->SetFillColor(Palette::colorChannel(i + 12, isTransparentActivated));
-      
-	std::stringstream channelStreamTrans;
-	channelStreamTrans << "OT" << i << "A" << std::endl;
-	std::string channelTrans = channelStreamTrans.str();
-	leg->AddEntry(lineTrans, channelTrans.c_str(), "f"); 
-      }
-
-
+      const bool isTransparentActivated = isPowerCabling;
+      line->SetLineColor(Palette::colorChannel(myPlotColor, isTransparentActivated));
+      line->SetFillColor(Palette::colorChannel(myPlotColor, isTransparentActivated));
+      legend->AddEntry(line, channelName.c_str(), "f");
     }
   }
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6839,6 +6839,9 @@ namespace insur {
 
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
 
+    TLegend* channelsLegend = new TLegend(0.905,0.3,1.0,0.8);
+    computeServicesChannelsLegend(channelsLegend);
+
     // NEGATIVE CABLING SIDE. BARREL.
     XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
     XYNegCanvas->cd();
@@ -6847,7 +6850,8 @@ namespace insur {
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawServicesChannelsLegend();
+    channelsLegend->Draw("same");
+    
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
     XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6857,7 +6861,7 @@ namespace insur {
     xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
     xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawServicesChannelsLegend();
+    channelsLegend->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6867,7 +6871,7 @@ namespace insur {
     xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawServicesChannelsLegend();
+    channelsLegend->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
     XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6877,7 +6881,7 @@ namespace insur {
     xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
     xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawServicesChannelsLegend();
+    channelsLegend->Draw("same");
     
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
@@ -6893,7 +6897,7 @@ namespace insur {
 	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
 	  XYCanvasesDisk.push_back(XYCanvasDisk);
 	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-	  drawServicesChannelsLegend();
+	  channelsLegend->Draw("same");
 	}
       }
     }
@@ -6922,6 +6926,9 @@ namespace insur {
 
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
 
+    TLegend* channelsLegend = new TLegend(0.905, 0., 1., 1.);
+    computePowerServicesChannelsLegend(channelsLegend);
+
     // NEGATIVE CABLING SIDE. BARREL.
     XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
     XYNegCanvas->cd();
@@ -6930,7 +6937,7 @@ namespace insur {
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawPowerServicesChannelsLegend();
+    channelsLegend->Draw("same");
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
     XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6940,7 +6947,7 @@ namespace insur {
     xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
     xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawPowerServicesChannelsLegend();
+    channelsLegend->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6950,7 +6957,7 @@ namespace insur {
     xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawPowerServicesChannelsLegend();
+    channelsLegend->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
     XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -6960,7 +6967,7 @@ namespace insur {
     xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
     xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    drawPowerServicesChannelsLegend();
+    channelsLegend->Draw("same");
     
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
@@ -6976,7 +6983,7 @@ namespace insur {
 	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
 	  XYCanvasesDisk.push_back(XYCanvasDisk);
 	  drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-	  drawPowerServicesChannelsLegend();
+	  channelsLegend->Draw("same");
 	}
       }
     }
@@ -7402,8 +7409,7 @@ namespace insur {
   }
 
 
-  void Vizard::drawServicesChannelsLegend() {
-    TLegend* leg = new TLegend(0.905,0.3,1.0,0.8);
+  void Vizard::computeServicesChannelsLegend(TLegend* leg) {
     //leg->SetHeader("Channels (+Z side numbering)");
 
     for (int i = 1; i <= 12; i++) {
@@ -7418,13 +7424,10 @@ namespace insur {
       std::string channel = channelStream.str();
       leg->AddEntry(line, channel.c_str(), "f"); 
     }
-
-    leg->Draw("same");
   }
 
 
-  void Vizard::drawPowerServicesChannelsLegend() {
-    TLegend* leg = new TLegend(0.905, 0., 1., 1.);
+  void Vizard::computePowerServicesChannelsLegend(TLegend* leg) {   
     //leg->SetHeader("Channels (+Z side numbering)");
 
     for (int i = 1; i <= 12; i++) {
@@ -7453,11 +7456,8 @@ namespace insur {
 	std::string channelTrans = channelStreamTrans.str();
 	leg->AddEntry(lineTrans, channelTrans.c_str(), "f"); 
       }
-
-    
+  
     }
-
-    leg->Draw("same");
   }
 
 


### PR DESCRIPTION
- Updated services channels numbering to agreed convention: 
Channel 1A on (+Z) side becomes channel -1A on (-Z) side (when one walks along Z)
Channel 1C on (+Z) side becomes channel -1C on (-Z) side (when one walks along Z)
etc..

- Added details maps on website of routing of cables to services channels.
In all plots, +Z points towards you.
Selected examples:

Optical cabling:
Disk in TEDD:
![optical_disk](https://user-images.githubusercontent.com/11192654/31017991-bc972244-a52a-11e7-973b-b597881a64dd.png)

Barrel, (+Z) cabling side.
![optical_barrel_pos](https://user-images.githubusercontent.com/11192654/31018011-cff287c0-a52a-11e7-9270-fcc09854af9b.png)


Power cabling:
Disk in TEDD:
![power_disk](https://user-images.githubusercontent.com/11192654/31018046-e9623048-a52a-11e7-8c57-fec393db101e.png)

All detailed info is accessible at http://cms-tklayout.web.cern.ch/cms-tklayout/layouts/reference/OT613_200_IT4025/cablingOuter.html 
There is a dedicated table summarizing the channel assignments.

NB: Code related to services channels might be deeply reshaped, depending on future decisions on channels assignments designs.