### PR TITLE
New services channels assignment by Duccio: Avoid power cables crossings in 2S region.

### DIFF
--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -47,53 +47,18 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
     else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }   
   }
   else if (type == Category::PS5G) {
-    if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
-    }
-    else {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
-    }
+    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
+    else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
+    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
   }
   else if (type == Category::SS) {
     if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
-    }
-    else if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
-    }
-    else {
       if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
       else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
       else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
@@ -103,6 +68,17 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
       else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
       else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
       else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
+    }
+    else {
+      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
     }
   }
 


### PR DESCRIPTION
This is in the hypothesis optical and power cabling maps are identical (apart from channel assignment).

This is merged for having a point of reference.
Further studies have shown the need of separating optical and power cabling maps (to come in further PR).