### PR TITLE
Outer Tracker Services channels: MFBs and Power cables routing + Added TEDD surfaces details for technicians + Adapted cabling map to Nick TEDD design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ CABLING+=CablingMap
 CABLING+=DTC
 CABLING+=ModulesToBundlesConnector
 CABLING+=PhiPosition
+CABLING+=ServicesChannel
 
 EXES+=tklayout
 EXES+=setup

--- a/geometries/CMS_Phase2/OT614_200_IT4025.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT4025.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_0_2_5.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V614_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V614_200.cfg
@@ -1,0 +1,29 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDDTop_V351.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD2_V366.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+  
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V612_200.cfg
+  @include TB2S_V360_200.cfg
+  @include TEDD1_V614_200.cfg
+  @include TEDD2_V614_200.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V613_200.cfg
@@ -58,7 +58,7 @@ Endcap TEDD_1 {
   // Ring 1 { ringOuterRadius 275.701 }  // TDR 
 
 
-  alignEdges false
+  alignEdges true
   moduleShape rectangular
   Ring 1-10 {
     smallDelta 7.42

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V614_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V614_200.cfg
@@ -8,8 +8,8 @@ Endcap TEDD_1 {
   numDisks 2
   bigParity 1
   smallParity 1
-  bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
-  smallDelta 7.42 // PS NICK 2017
+  bigDelta 15.075  // NICK 2017-11-07
+  smallDelta 7.375 // NICK 2017-11-07
   minZ 1311.80 // Stefano&Duccio 2017-03-17 reducing clearance from 20 mm to 5 mm
   maxZ 1550.00
   
@@ -58,10 +58,10 @@ Endcap TEDD_1 {
   // Ring 1 { ringOuterRadius 275.701 }  // TDR 
 
 
-  alignEdges false
+  alignEdges true
   moduleShape rectangular
   Ring 1-10 {
-    smallDelta 7.42
+    smallDelta 7.375
     dsDistance 4.0
     @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
     @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V613_200.cfg
@@ -57,7 +57,7 @@ Endcap TEDD_2 {
   // Ring 2 { removeModule true }
   // Ring 1 { removeModule true }  
 
-  alignEdges false
+  alignEdges true
   moduleShape rectangular
   Ring 1-10 {
     smallDelta 7.42

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V614_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V614_200.cfg
@@ -7,8 +7,8 @@ Endcap TEDD_2 {
   numDisks 3
   bigParity 1
   smallParity 1  
-  bigDelta 14.85 // NICK 2017-03-27 ring 10 position only affects half of the DoubleDisk
-  smallDelta 7.42 // PS NICK 2017  
+  bigDelta 15.075  // NICK 2017-11-07
+  smallDelta 7.375 // NICK 2017-11-07
   minZ 1853.400
   Disk 2 { placeZ 2216.190 }
   maxZ 2650.000
@@ -57,10 +57,10 @@ Endcap TEDD_2 {
   // Ring 2 { removeModule true }
   // Ring 1 { removeModule true }  
 
-  alignEdges false
+  alignEdges true
   moduleShape rectangular
   Ring 1-10 {
-    smallDelta 7.42
+    smallDelta 7.375
     dsDistance 4.0
     @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
     @includestd CMS_Phase2/OuterTracker/Materials/ptPS_200_40

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -198,6 +198,14 @@ OT613_200_IT4025.cfg	   Like 6.1.2 but fixing bigDelta according to Nick 2017-03
                         Any ring movement was instead *avoided* by constraining the ring radii to those of 6.1.2, so that the geometry in the
                         xy plane is exactly the same
                         
+OT614_200_IT4025.cfg	  OT 614: Like 6.1.3 but updates from Nick 2017-11-07 in TEDD.
+                        'Identical dees' design (simplify cooling design, huge saving :) ):
+                          - Rotate in Phi all modules in all disks in TEDD by + half a module.
+                        PS module design has been updated, hence:
+                          - Increase bigDelta, from 14.85 mm to 15.075 mm (Zd goes from 29.7 mm to 30.15 mm), in all disks in TEDD.
+                          - Decrease smallDelta, from 7.42 mm to 7.375 mm (ZmPS4.0 goes from 14.84mm to 14.75mm), in PS4.0 rings.
+        
+                        
 OT613_200_IT4125.cfg	  Like OT613_200_IT4025, but with 50x50 pixels instead of 25x100.
 
 OT613_200_IT404.cfg                  OT Version 6.1.3

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -57,12 +57,10 @@ public:
 
   const int plotColor() const { return plotColor_; }
 
-  const int powerServicesChannel() const { return powerChannel_->myid(); }
-  const ChannelSection& powerServicesChannelSection() const { return powerChannel_->section(); }
-  const int powerServicesChannelPlotColor() const { return powerChannel_->plotColor(); }
-
-  void setPowerServicesChannel(ServicesChannel* powerChannel) {
-    powerChannel_ = powerChannel;
+  const ChannelSection* opticalChannelSection() const;
+  const ChannelSection* powerChannelSection() const { return powerChannelSection_; }
+  void setPowerChannelSection(ChannelSection* powerChannelSection) {
+    powerChannelSection_ = powerChannelSection;
   }
 
 
@@ -85,7 +83,7 @@ private:
 
   int plotColor_;
 
-  ServicesChannel* powerChannel_ = nullptr;
+  ChannelSection* powerChannelSection_ = nullptr;
 };
 
 

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -85,7 +85,7 @@ private:
 
   int plotColor_;
 
-  ServicesChannel* powerChannel_;
+  ServicesChannel* powerChannel_ = nullptr;
 };
 
 

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -17,8 +17,12 @@ class Bundle : public PropertyObject, public Buildable, public Identifiable<int>
   typedef PtrVector<Module> Container; 
 
 public:
-  Bundle(const int id, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart);
+  Bundle(const int id, const int complementaryBundleId, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart);
   ~Bundle();
+
+  const int complementaryBundleId() const { return complementaryBundleId_; }
+  void setIsInLowerSemiPhiSectorStereo(const bool isLower) { isInLowerSemiPhiSectorStereo_ = isLower; }
+  const bool isInLowerSemiPhiSectorStereo() const { return isInLowerSemiPhiSectorStereo_; }
 
   // MODULES CONNECTED TO THE BUNDLE.
   const Container& modules() const { return modules_; }
@@ -47,6 +51,9 @@ public:
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
   const bool isTiltedPart() const { return isTiltedPart_; }
 
+  const bool isBarrel() const { return (subDetectorName_ == cabling_tbps || subDetectorName_ == cabling_tb2s); }
+  const bool isPSFlatPart() const { return (!isTiltedPart_ && type_ != Category::SS); }
+
   const int plotColor() const { return plotColor_; }
 
   const int powerServicesChannel() const { return powerServicesChannel_; }
@@ -63,6 +70,9 @@ public:
 private:
   const int computePlotColor(const int id, const bool isPositiveCablingSide) const;
   int computePowerServicesChannelPlotColor(std::pair<int, ChannelSection>& powerServicesChannel) const;
+
+  int complementaryBundleId_;
+  bool isInLowerSemiPhiSectorStereo_;
 
   Container modules_;
 

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -28,7 +28,10 @@ public:
   void addModule(Module* m) { modules_.push_back(m); }
 
   // CABLE THE BUNDLE IS CONNECTED TO.
-  const Cable* getCable() const { return cable_; }
+  const Cable* getCable() const {
+    if (!cable_) throw PathfulException("cable_ is nullptr");
+    return cable_;
+  }
   void setCable(Cable* cable) { cable_ = cable; }
 
   // GENERAL INFO ON THE BUNDLE
@@ -65,7 +68,10 @@ public:
   // Optical
   const ChannelSection* opticalChannelSection() const;
   // Power
-  const ChannelSection* powerChannelSection() const { return powerChannelSection_; }
+  const ChannelSection* powerChannelSection() const {
+    if (!powerChannelSection_) throw PathfulException("powerChannelSection_ is nullptr");
+    return powerChannelSection_; 
+  }
   void setPowerChannelSection(ChannelSection* powerChannelSection) {
     powerChannelSection_ = powerChannelSection;
   }

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -7,6 +7,7 @@
 #include "Property.hh"
 #include "Module.hh"
 #include "Cabling/PhiPosition.hh"
+#include "Cabling/ServicesChannel.hh"
 
 
 namespace insur { class Cable; }
@@ -56,20 +57,17 @@ public:
 
   const int plotColor() const { return plotColor_; }
 
-  const int powerServicesChannel() const { return powerServicesChannel_; }
-  const ChannelSection& powerServicesChannelSection() const { return powerServicesChannelSection_; }
-  const int powerServicesChannelPlotColor() const { return powerServicesChannelPlotColor_; }
+  const int powerServicesChannel() const { return powerChannel_->myid(); }
+  const ChannelSection& powerServicesChannelSection() const { return powerChannel_->section(); }
+  const int powerServicesChannelPlotColor() const { return powerChannel_->plotColor(); }
 
-  void setPowerServicesChannel(std::pair<int, ChannelSection>& powerServicesChannel) {
-    powerServicesChannel_ = powerServicesChannel.first;
-    powerServicesChannelSection_ = powerServicesChannel.second;
-    powerServicesChannelPlotColor_ = computePowerServicesChannelPlotColor(powerServicesChannel);
+  void setPowerServicesChannel(ServicesChannel* powerChannel) {
+    powerChannel_ = powerChannel;
   }
 
 
 private:
   const int computePlotColor(const int id, const bool isPositiveCablingSide) const;
-  int computePowerServicesChannelPlotColor(std::pair<int, ChannelSection>& powerServicesChannel) const;
 
   int complementaryBundleId_;
   bool isInLowerSemiPhiSectorStereo_;
@@ -87,9 +85,7 @@ private:
 
   int plotColor_;
 
-  int powerServicesChannel_;
-  ChannelSection powerServicesChannelSection_;
-  int powerServicesChannelPlotColor_;
+  ServicesChannel* powerChannel_;
 };
 
 

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -18,12 +18,8 @@ class Bundle : public PropertyObject, public Buildable, public Identifiable<int>
   typedef PtrVector<Module> Container; 
 
 public:
-  Bundle(const int id, const int complementaryBundleId, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart);
+  Bundle(const int id, const int stereoBundleId, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart);
   ~Bundle();
-
-  const int complementaryBundleId() const { return complementaryBundleId_; }
-  void setIsInLowerSemiPhiSectorStereo(const bool isLower) { isInLowerSemiPhiSectorStereo_ = isLower; }
-  const bool isInLowerSemiPhiSectorStereo() const { return isInLowerSemiPhiSectorStereo_; }
 
   // MODULES CONNECTED TO THE BUNDLE.
   const Container& modules() const { return modules_; }
@@ -35,6 +31,20 @@ public:
   const Cable* getCable() const { return cable_; }
   void setCable(Cable* cable) { cable_ = cable; }
 
+  // GENERAL INFO ON THE BUNDLE
+  const Category& type() const { return type_; }
+  const std::string subDetectorName() const { return subDetectorName_; }
+  const int layerDiskNumber() const { return layerDiskNumber_; }
+  const PhiPosition& phiPosition() const { return phiPosition_; }  
+  const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
+
+  const bool isTiltedPart() const { return isTiltedPart_; }
+  const bool isBarrel() const { return (subDetectorName_ == cabling_tbps || subDetectorName_ == cabling_tb2s); }
+  const bool isPSFlatPart() const { return (!isTiltedPart_ && type_ != Category::SS); }
+
+  const int plotColor() const { return plotColor_; }
+
+  // PHI INFORMATION FROM MODULES CONNECTED TO THE BUNDLE
   void moveMaxPhiModuleFromOtherBundle(Bundle* otherBundle);
   void moveMinPhiModuleFromOtherBundle(Bundle* otherBundle);
 
@@ -43,32 +53,31 @@ public:
   const double meanPhi() const;
 
   Module* minPhiModule() const;
-  Module* maxPhiModule() const;
+  Module* maxPhiModule() const; 
 
-  const Category& type() const { return type_; }
-  const std::string subDetectorName() const { return subDetectorName_; }
-  const int layerDiskNumber() const { return layerDiskNumber_; }
-  const PhiPosition& phiPosition() const { return phiPosition_; }  
-  const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
-  const bool isTiltedPart() const { return isTiltedPart_; }
+  // SERVICES CHANNELS INFORMATION
+  // VERY IMPORTANT: connection scheme from modules to optical bundles = connection scheme from modules to power cables.
+  // As a result, 1 single Bundle object is used for both schemes.
+  // Regarding the connections to services channels, each Bundle is then assigned:
+  // - 1 Optical Services Channel Section (considering the Bundle as an optical Bundle);
+  // - 1 Power Services Channels section (making as if the Bundle is a power cable);
 
-  const bool isBarrel() const { return (subDetectorName_ == cabling_tbps || subDetectorName_ == cabling_tb2s); }
-  const bool isPSFlatPart() const { return (!isTiltedPart_ && type_ != Category::SS); }
-
-  const int plotColor() const { return plotColor_; }
-
+  // Optical
   const ChannelSection* opticalChannelSection() const;
+  // Power
   const ChannelSection* powerChannelSection() const { return powerChannelSection_; }
   void setPowerChannelSection(ChannelSection* powerChannelSection) {
     powerChannelSection_ = powerChannelSection;
   }
-
+  // Used to compute the power channel section.
+  const int tiltedBundleId() const;
+  const int stereoBundleId() const; // Id of the bundle located on the other cabling side, by rotation of 180° around CMS_Y.
+  void setIsPowerRoutedToBarrelLowerSemiNonant(const bool isLower);
+  const bool isPowerRoutedToBarrelLowerSemiNonant() const;
+  
 
 private:
   const int computePlotColor(const int id, const bool isPositiveCablingSide) const;
-
-  int complementaryBundleId_;
-  bool isInLowerSemiPhiSectorStereo_;
 
   Container modules_;
 
@@ -84,6 +93,9 @@ private:
   int plotColor_;
 
   ChannelSection* powerChannelSection_ = nullptr;
+
+  int stereoBundleId_;
+  bool isPowerRoutedToBarrelLowerSemiNonant_;
 };
 
 

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -40,7 +40,7 @@ public:
 
   const bool isTiltedPart() const { return isTiltedPart_; }
   const bool isBarrel() const { return (subDetectorName_ == cabling_tbps || subDetectorName_ == cabling_tb2s); }
-  const bool isPSFlatPart() const { return (!isTiltedPart_ && type_ != Category::SS); }
+  const bool isBarrelPSFlatPart() const { return (isBarrel() && type_ != Category::SS && !isTiltedPart_); }
 
   const int plotColor() const { return plotColor_; }
 

--- a/include/Cabling/Bundle.hh
+++ b/include/Cabling/Bundle.hh
@@ -35,6 +35,7 @@ public:
 
   const double minPhi() const;
   const double maxPhi() const;
+  const double meanPhi() const;
 
   Module* minPhiModule() const;
   Module* maxPhiModule() const;
@@ -48,9 +49,20 @@ public:
 
   const int plotColor() const { return plotColor_; }
 
+  const int powerServicesChannel() const { return powerServicesChannel_; }
+  const ChannelSection& powerServicesChannelSection() const { return powerServicesChannelSection_; }
+  const int powerServicesChannelPlotColor() const { return powerServicesChannelPlotColor_; }
+
+  void setPowerServicesChannel(std::pair<int, ChannelSection>& powerServicesChannel) {
+    powerServicesChannel_ = powerServicesChannel.first;
+    powerServicesChannelSection_ = powerServicesChannel.second;
+    powerServicesChannelPlotColor_ = computePowerServicesChannelPlotColor(powerServicesChannel);
+  }
+
 
 private:
   const int computePlotColor(const int id, const bool isPositiveCablingSide) const;
+  int computePowerServicesChannelPlotColor(std::pair<int, ChannelSection>& powerServicesChannel) const;
 
   Container modules_;
 
@@ -64,6 +76,10 @@ private:
   bool isTiltedPart_;
 
   int plotColor_;
+
+  int powerServicesChannel_;
+  ChannelSection powerServicesChannelSection_;
+  int powerServicesChannelPlotColor_;
 };
 
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -34,14 +34,14 @@ public:
   const int phiSectorRef() const { return phiSectorRef_; }
   const int slot() const { return slot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
-  const int servicesChannel() const { return servicesChannel_; }
-  const ChannelSection& servicesChannelSection() const { return servicesChannelSection_; }
-  const int servicesChannelPlotColor() const { return servicesChannelPlotColor_; }
+  const int servicesChannel() const { return opticalServicesChannel_; }
+  const ChannelSection& servicesChannelSection() const { return opticalServicesChannelSection_; }
+  const int servicesChannelPlotColor() const { return opticalServicesChannelPlotColor_; }
 
 
 private:
-  const std::tuple<int, ChannelSection, int> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
-  const int computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const;
+  const std::tuple<int, ChannelSection, int> computeOpticalServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  const int computeOpticalServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const;
   std::pair<int, ChannelSection> computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
 
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
@@ -56,9 +56,9 @@ private:
   Category type_;
   int slot_;
   bool isPositiveCablingSide_;
-  int servicesChannel_;
-  ChannelSection servicesChannelSection_;
-  int servicesChannelPlotColor_;
+  int opticalServicesChannel_;
+  ChannelSection opticalServicesChannelSection_;
+  int opticalServicesChannelPlotColor_;
 };
 
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -24,8 +24,6 @@ public:
   void addBundle(Bundle* b) { bundles_.push_back(b); }
   int numBundles() const { return bundles_.size(); }
 
-  void assignPowerServicesChannels();
-
   // DTC THE CABLE IS CONNECTED TO.
   const DTC* getDTC() const { return myDTC_; }
 
@@ -35,10 +33,9 @@ public:
   const int slot() const { return slot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
 
-  const int servicesChannel() const { return opticalChannel_->myid(); }
-  const ChannelSection& servicesChannelSection() const { return opticalChannel_->section(); }
-  const int servicesChannelPlotColor() const { return opticalChannel_->plotColor(); }
-
+  // SERVICES CHANNELS INFORMATION
+  const ChannelSection* opticalChannelSection() const { return opticalChannelSection_; }
+  void assignPowerChannelSections();
 
 private:
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
@@ -53,7 +50,7 @@ private:
   Category type_;
   int slot_;
   bool isPositiveCablingSide_;
-  ServicesChannel* opticalChannel_ = nullptr;
+  ChannelSection* opticalChannelSection_ = nullptr;
 };
 
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -34,16 +34,13 @@ public:
   const int phiSectorRef() const { return phiSectorRef_; }
   const int slot() const { return slot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
-  const int servicesChannel() const { return opticalServicesChannel_; }
-  const ChannelSection& servicesChannelSection() const { return opticalServicesChannelSection_; }
-  const int servicesChannelPlotColor() const { return opticalServicesChannelPlotColor_; }
+
+  const int servicesChannel() const { return opticalChannel_->myid(); }
+  const ChannelSection& servicesChannelSection() const { return opticalChannel_->section(); }
+  const int servicesChannelPlotColor() const { return opticalChannel_->plotColor(); }
 
 
 private:
-  const std::tuple<int, ChannelSection, int> computeOpticalServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
-  const int computeOpticalServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const;
-  std::pair<int, ChannelSection> computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
-
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
   const std::string computeDTCName(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   
@@ -56,9 +53,7 @@ private:
   Category type_;
   int slot_;
   bool isPositiveCablingSide_;
-  int opticalServicesChannel_;
-  ChannelSection opticalServicesChannelSection_;
-  int opticalServicesChannelPlotColor_;
+  ServicesChannel* opticalChannel_;
 };
 
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -34,7 +34,9 @@ public:
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
 
   // SERVICES CHANNELS INFORMATION
+  // Optical
   const ChannelSection* opticalChannelSection() const { return opticalChannelSection_; }
+  // Power
   void assignPowerChannelSections();
 
 private:
@@ -50,6 +52,7 @@ private:
   Category type_;
   int slot_;
   bool isPositiveCablingSide_;
+
   ChannelSection* opticalChannelSection_ = nullptr;
 };
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -24,6 +24,8 @@ public:
   void addBundle(Bundle* b) { bundles_.push_back(b); }
   int numBundles() const { return bundles_.size(); }
 
+  void assignPowerServicesChannels();
+
   // DTC THE CABLE IS CONNECTED TO.
   const DTC* getDTC() const { return myDTC_; }
 
@@ -40,6 +42,8 @@ public:
 private:
   const std::tuple<int, ChannelSection, int> computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   const int computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const;
+  std::pair<int, ChannelSection> computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
+
   void buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
   const std::string computeDTCName(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -25,7 +25,10 @@ public:
   int numBundles() const { return bundles_.size(); }
 
   // DTC THE CABLE IS CONNECTED TO.
-  const DTC* getDTC() const { return myDTC_; }
+  const DTC* getDTC() const {
+    if (!myDTC_) throw PathfulException("myDTC_ is nullptr");
+    return myDTC_; 
+  }
 
   const Category& type() const { return type_; }
   const double phiSectorWidth() const { return phiSectorWidth_; }
@@ -35,7 +38,10 @@ public:
 
   // SERVICES CHANNELS INFORMATION
   // Optical
-  const ChannelSection* opticalChannelSection() const { return opticalChannelSection_; }
+  const ChannelSection* opticalChannelSection() const {
+    if (!opticalChannelSection_) throw PathfulException("opticalChannelSection_ is nullptr");
+    return opticalChannelSection_; 
+  }
   // Power
   void assignPowerChannelSections();
 

--- a/include/Cabling/Cable.hh
+++ b/include/Cabling/Cable.hh
@@ -53,7 +53,7 @@ private:
   Category type_;
   int slot_;
   bool isPositiveCablingSide_;
-  ServicesChannel* opticalChannel_;
+  ServicesChannel* opticalChannel_ = nullptr;
 };
 
 

--- a/include/Cabling/CablingMap.hh
+++ b/include/Cabling/CablingMap.hh
@@ -39,12 +39,12 @@ private:
   const int computeCableId(const int phiSectorRefCable, const int cableTypeIndex, const int slot, const bool isPositiveCablingSide) const;
   void createAndStoreCablesAndDTCs(Bundle* myBundle, std::map<int, Cable*>& cables, std::map<const std::string, const DTC*>& DTCs, const int cableId, const double phiSectorWidth, const int phiSectorRefCable, const Category& type, const int slot, const bool isPositiveCablingSide); 
   void connectOneBundleToOneCable(Bundle* bundle, Cable* cable) const;
-  void checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles);
   void checkBundlesToCablesCabling(std::map<int, Cable*>& cables);  // check bundles to cables connections
 
-  void assignBundlesStereoSemiBoundaries(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& complementaryBundles);
-
-  void computePowerServicesChannels(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables);
+  // COMPUTE SERVICES CHANNELS ASSIGNMENTS OF POWER CABLES
+  void computePowerServicesChannels();
+  void routeBarrelBundlesPoweringToSemiNonants(const bool isPositiveCablingSide);
+  void checkBundlesToPowerServicesChannels(const std::map<int, Bundle*>& bundles);
 
   // positive cabling side
   std::map<int, Bundle*> bundles_;

--- a/include/Cabling/CablingMap.hh
+++ b/include/Cabling/CablingMap.hh
@@ -31,8 +31,6 @@ private:
   // CONNECT MODULES TO BUNDLES
   void connectModulesToBundles(Tracker* tracker);
 
-  void computePowerServicesChannels(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables);
-
   // CONNECT BUNDLES TO CABLES
   void connectBundlesToCables(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables, std::map<const std::string, const DTC*>& DTCs);
   const Category computeCableType(const Category& bundleType) const;
@@ -43,6 +41,10 @@ private:
   void connectOneBundleToOneCable(Bundle* bundle, Cable* cable) const;
   void checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles);
   void checkBundlesToCablesCabling(std::map<int, Cable*>& cables);  // check bundles to cables connections
+
+  void assignBundlesStereoSemiBoundaries(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& complementaryBundles);
+
+  void computePowerServicesChannels(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables);
 
   // positive cabling side
   std::map<int, Bundle*> bundles_;

--- a/include/Cabling/CablingMap.hh
+++ b/include/Cabling/CablingMap.hh
@@ -31,8 +31,7 @@ private:
   // CONNECT MODULES TO BUNDLES
   void connectModulesToBundles(Tracker* tracker);
 
-  void connectBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles);
-  std::pair<int, ChannelSection> computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
+  void computePowerServicesChannels(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables);
 
   // CONNECT BUNDLES TO CABLES
   void connectBundlesToCables(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables, std::map<const std::string, const DTC*>& DTCs);

--- a/include/Cabling/CablingMap.hh
+++ b/include/Cabling/CablingMap.hh
@@ -31,6 +31,9 @@ private:
   // CONNECT MODULES TO BUNDLES
   void connectModulesToBundles(Tracker* tracker);
 
+  void connectBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles);
+  std::pair<int, ChannelSection> computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
+
   // CONNECT BUNDLES TO CABLES
   void connectBundlesToCables(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables, std::map<const std::string, const DTC*>& DTCs);
   const Category computeCableType(const Category& bundleType) const;
@@ -39,6 +42,7 @@ private:
   const int computeCableId(const int phiSectorRefCable, const int cableTypeIndex, const int slot, const bool isPositiveCablingSide) const;
   void createAndStoreCablesAndDTCs(Bundle* myBundle, std::map<int, Cable*>& cables, std::map<const std::string, const DTC*>& DTCs, const int cableId, const double phiSectorWidth, const int phiSectorRefCable, const Category& type, const int slot, const bool isPositiveCablingSide); 
   void connectOneBundleToOneCable(Bundle* bundle, Cable* cable) const;
+  void checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles);
   void checkBundlesToCablesCabling(std::map<int, Cable*>& cables);  // check bundles to cables connections
 
   // positive cabling side

--- a/include/Cabling/ModulesToBundlesConnector.hh
+++ b/include/Cabling/ModulesToBundlesConnector.hh
@@ -38,7 +38,8 @@ private:
   void buildBundle(DetectorModule& m, std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const Category& bundleType, const bool isBarrel, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const int totalNumFlatRings = 0, const bool isTiltedPart = false, const bool isExtraFlatPart = false);
   const int computeBundleTypeIndex(const bool isBarrel, const Category& bundleType, const int totalNumFlatRings = 0, const bool isTilted = false, const bool isExtraFlatPart = false) const;
   const int computeBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
-  Bundle* createAndStoreBundle(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const int bundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart = false);
+  const int computeComplementaryBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
+  Bundle* createAndStoreBundle(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const int bundleId, const int complementaryBundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart = false);
   void connectModuleToBundle(DetectorModule& m, Bundle* bundle) const;
 
   // STAGERRING

--- a/include/Cabling/ModulesToBundlesConnector.hh
+++ b/include/Cabling/ModulesToBundlesConnector.hh
@@ -38,8 +38,8 @@ private:
   void buildBundle(DetectorModule& m, std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const Category& bundleType, const bool isBarrel, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const int totalNumFlatRings = 0, const bool isTiltedPart = false, const bool isExtraFlatPart = false);
   const int computeBundleTypeIndex(const bool isBarrel, const Category& bundleType, const int totalNumFlatRings = 0, const bool isTilted = false, const bool isExtraFlatPart = false) const;
   const int computeBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
-  const int computeComplementaryBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
-  Bundle* createAndStoreBundle(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const int bundleId, const int complementaryBundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart = false);
+  const int computeStereoBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
+  Bundle* createAndStoreBundle(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const int bundleId, const int stereoBundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart = false);
   void connectModuleToBundle(DetectorModule& m, Bundle* bundle) const;
 
   // STAGERRING

--- a/include/Cabling/PhiPosition.hh
+++ b/include/Cabling/PhiPosition.hh
@@ -26,6 +26,10 @@ public:
   const double phiSegmentWidth() const { return phiSegmentWidth_; }
   const double phiSegmentStart() const { return phiSegmentStart_; }
   const int phiSegmentRef() const { return phiSegmentRef_; }
+
+  // COMPLEMENTARY PHI SEGMENT
+  const double complementaryPhiSegmentStart() const { return complementaryPhiSegmentStart_; }
+  const int complementaryPhiSegmentRef() const { return complementaryPhiSegmentRef_; }
   
   // PHI REGION
   const double phiRegionWidth() const { return phiRegionWidth_; }
@@ -42,6 +46,10 @@ private:
   double phiSegmentWidth_;
   double phiSegmentStart_;
   int phiSegmentRef_;
+
+  // COMPLEMETARY PHI SEGMENT
+  double complementaryPhiSegmentStart_;
+  int complementaryPhiSegmentRef_;
 
   // PHI REGION
   double phiRegionWidth_;

--- a/include/Cabling/PhiPosition.hh
+++ b/include/Cabling/PhiPosition.hh
@@ -20,7 +20,7 @@
 */
 class PhiPosition {
 public:
-  PhiPosition(const double phi, const int numPhiSegments, const bool isPositiveCablingSide, const bool isBarrel, const int layerDiskNumber, const std::string subDetectorName = "", const Category& bundleType = Category::UNDEFINED);
+  PhiPosition(const double phi, const int numPhiSegments, const bool isBarrel, const int layerDiskNumber, const std::string subDetectorName = "", const Category& bundleType = Category::UNDEFINED);
 
   // PHI SEGMENT
   const double phiSegmentWidth() const { return phiSegmentWidth_; }

--- a/include/Cabling/PhiPosition.hh
+++ b/include/Cabling/PhiPosition.hh
@@ -27,9 +27,9 @@ public:
   const double phiSegmentStart() const { return phiSegmentStart_; }
   const int phiSegmentRef() const { return phiSegmentRef_; }
 
-  // COMPLEMENTARY PHI SEGMENT
-  const double complementaryPhiSegmentStart() const { return complementaryPhiSegmentStart_; }
-  const int complementaryPhiSegmentRef() const { return complementaryPhiSegmentRef_; }
+  // STEREO PHI SEGMENT
+  const double stereoPhiSegmentStart() const { return stereoPhiSegmentStart_; }
+  const int stereoPhiSegmentRef() const { return stereoPhiSegmentRef_; }
   
   // PHI REGION
   const double phiRegionWidth() const { return phiRegionWidth_; }
@@ -47,9 +47,9 @@ private:
   double phiSegmentStart_;
   int phiSegmentRef_;
 
-  // COMPLEMETARY PHI SEGMENT
-  double complementaryPhiSegmentStart_;
-  int complementaryPhiSegmentRef_;
+  // STEREO PHI SEGMENT
+  double stereoPhiSegmentStart_;
+  int stereoPhiSegmentRef_;
 
   // PHI REGION
   double phiRegionWidth_;

--- a/include/Cabling/ServicesChannel.hh
+++ b/include/Cabling/ServicesChannel.hh
@@ -20,7 +20,6 @@
 // A map of all Tracker ServicesChannels could then be assigned to the CablingMap.
 
 
-
 /*class ServicesChannel : public PropertyObject, public Buildable, public Identifiable<int> {
   typedef PtrVector<ChannelSection> Container;
 public:
@@ -35,6 +34,14 @@ protected:
   };*/
 
 
+/* Section of a services channel.
+   As all cables exit the Tracker, they are routed through a services channel.
+ * A services channel is divided into 3 sections: A, B and C.
+ * The optical bundles are always routed in section B.
+ * The power cables are always routed in section A or C.
+ * The cooling pipes are always routed in section A or C.
+ * IMPORTANT NOTE: SECTION IN SERVICES CHANNEL = SECTION IN PP1 (Patch Panel 1).
+ */
 class ChannelSection : public PropertyObject, public Buildable {
   //typedef PtrVector<Bundle> Container;
 public:
@@ -55,7 +62,8 @@ protected:
 };
 
 
-
+/* Channel Section filled by optical bundles.
+ */
 class OpticalSection : public ChannelSection {
 public:
   OpticalSection(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
@@ -63,11 +71,12 @@ public:
 private:
   const int computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
   const int computeChannelPlotColor(const int number) const;
-
 };
 
 
-
+/* Channel Section filled by power cables. 
+ * NB: In the CablingMap, 1 Bundle = 1 Power cable.
+ */
 class PowerSection : public ChannelSection {
 public:
   PowerSection(const int semiPhiRegionRef, const bool isPositiveCablingSide);
@@ -75,12 +84,7 @@ public:
 private:
   std::pair<int, ChannelSlot> computeChannelNumberAndSlot(const int semiPhiRegionRef, const bool isPositiveCablingSide) const;
   const int computeChannelPlotColor(const int number, const ChannelSlot& channelSlot, const bool isPositiveCablingSide) const;
-
 };
-
-
-
-
 
 
 

--- a/include/Cabling/ServicesChannel.hh
+++ b/include/Cabling/ServicesChannel.hh
@@ -15,7 +15,7 @@ public:
   const int plotColor() const { return plotColor_; }
 
 protected:
-  void build(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor);
+  void build(const int id, const ChannelSection section, const bool isPositiveCablingSide, const int plotColor);
 
   ChannelSection section_ = ChannelSection::UNKNOWN;
   bool isPositiveCablingSide_;  

--- a/include/Cabling/ServicesChannel.hh
+++ b/include/Cabling/ServicesChannel.hh
@@ -10,14 +10,13 @@
 
 class ServicesChannel : public PropertyObject, public Buildable, public Identifiable<int> {
 public:
-  ServicesChannel(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor);
-
   const ChannelSection& section() const { return section_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
- 
   const int plotColor() const { return plotColor_; }
 
 protected:
+  void build(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor);
+
   ChannelSection section_ = ChannelSection::UNKNOWN;
   bool isPositiveCablingSide_;  
   int plotColor_;
@@ -30,8 +29,8 @@ public:
   OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
 
 private:
-  const int computeOpticalChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
-  int computeOpticalChannelPlotColor(const int number) const;
+  const int computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  int computeChannelPlotColor(const int number) const;
 
 };
 
@@ -42,8 +41,8 @@ public:
   PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
 
 private:
-  std::pair<int, ChannelSection> computePowerChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const;
-  int computePowerChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const;
+  std::pair<int, ChannelSection> computeChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const;
+  int computeChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const;
 
 };
 

--- a/include/Cabling/ServicesChannel.hh
+++ b/include/Cabling/ServicesChannel.hh
@@ -8,41 +8,43 @@
 #include "Cabling/cabling_constants.hh"
 
 
-class ServicesChannel : public PropertyObject, public Buildable, public Identifiable<int> {
+class ChannelSection : public PropertyObject, public Buildable {
 public:
-  const ChannelSection& section() const { return section_; }
+  const int channelNumber() const { return channelNumber_; }
+  const ChannelSlot& channelSlot() const { return channelSlot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
   const int plotColor() const { return plotColor_; }
 
 protected:
-  void build(const int id, const ChannelSection section, const bool isPositiveCablingSide, const int plotColor);
+  void build(const int channelNumber, const ChannelSlot& channelSlot, const bool isPositiveCablingSide, const int plotColor);
 
-  ChannelSection section_ = ChannelSection::UNKNOWN;
+  int channelNumber_;
+  ChannelSlot channelSlot_ = ChannelSlot::UNKNOWN;
   bool isPositiveCablingSide_;  
   int plotColor_;
 };
 
 
 
-class OpticalChannel : public ServicesChannel {
+class OpticalSection : public ChannelSection {
 public:
-  OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
+  OpticalSection(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
 
 private:
   const int computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
-  int computeChannelPlotColor(const int number) const;
+  const int computeChannelPlotColor(const int number) const;
 
 };
 
 
 
-class PowerChannel : public ServicesChannel {
+class PowerSection : public ChannelSection {
 public:
-  PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
+  PowerSection(const int semiPhiRegionRef, const bool isPositiveCablingSide);
 
 private:
-  std::pair<int, ChannelSection> computeChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const;
-  int computeChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const;
+  std::pair<int, ChannelSlot> computeChannelNumberAndSlot(const int semiPhiRegionRef, const bool isPositiveCablingSide) const;
+  const int computeChannelPlotColor(const int number, const ChannelSlot& channelSlot, const bool isPositiveCablingSide) const;
 
 };
 

--- a/include/Cabling/ServicesChannel.hh
+++ b/include/Cabling/ServicesChannel.hh
@@ -1,0 +1,56 @@
+#ifndef SERVICESCHANEL_HH
+#define SERVICESCHANEL_HH
+
+#include <vector>
+#include <string>
+
+#include "Property.hh"
+#include "Cabling/cabling_constants.hh"
+
+
+class ServicesChannel : public PropertyObject, public Buildable, public Identifiable<int> {
+public:
+  ServicesChannel(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor);
+
+  const ChannelSection& section() const { return section_; }
+  const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
+ 
+  const int plotColor() const { return plotColor_; }
+
+protected:
+  ChannelSection section_ = ChannelSection::UNKNOWN;
+  bool isPositiveCablingSide_;  
+  int plotColor_;
+};
+
+
+
+class OpticalChannel : public ServicesChannel {
+public:
+  OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide);
+
+private:
+  const int computeOpticalChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const;
+  int computeOpticalChannelPlotColor(const int number) const;
+
+};
+
+
+
+class PowerChannel : public ServicesChannel {
+public:
+  PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide);
+
+private:
+  std::pair<int, ChannelSection> computePowerChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const;
+  int computePowerChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const;
+
+};
+
+
+
+
+
+
+
+#endif

--- a/include/Cabling/ServicesChannel.hh
+++ b/include/Cabling/ServicesChannel.hh
@@ -8,12 +8,41 @@
 #include "Cabling/cabling_constants.hh"
 
 
+// !!! TO DO !!!
+// FOR THE MOMENT, ChannelSection info is only accessible directly from the Bundle class.
+// This is sufficient, but it would be good to also have a gathering of the info per ServicesChannel.
+// A map of all Tracker ServicesChannels could then be assigned to the CablingMap.
+// (as is the map of Bundles and the map of Cables).
+
+// As a result, what needs to be done is: Add ServicesChannel class, containing 3 ChannelSections.
+// Example: ServicesChannel with number 12, on (+Z) side, contains sections A, B, and C.
+// Then, each ChannelSection should contain pointeres to the bundles which it contains.
+// A map of all Tracker ServicesChannels could then be assigned to the CablingMap.
+
+
+
+/*class ServicesChannel : public PropertyObject, public Buildable, public Identifiable<int> {
+  typedef PtrVector<ChannelSection> Container;
+public:
+  const int getNumber() const { return channelNumber_; }
+  const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
+  const Container& getSections() const { return sections_; }
+
+protected:
+  int channelNumber_;
+  bool isPositiveCablingSide_; 
+  Container sections_;
+  };*/
+
+
 class ChannelSection : public PropertyObject, public Buildable {
+  //typedef PtrVector<Bundle> Container;
 public:
   const int channelNumber() const { return channelNumber_; }
   const ChannelSlot& channelSlot() const { return channelSlot_; }
   const bool isPositiveCablingSide() const { return isPositiveCablingSide_; }
   const int plotColor() const { return plotColor_; }
+  //const Container& getBundles() const { return bundles_; }
 
 protected:
   void build(const int channelNumber, const ChannelSlot& channelSlot, const bool isPositiveCablingSide, const int plotColor);
@@ -22,6 +51,7 @@ protected:
   ChannelSlot channelSlot_ = ChannelSlot::UNKNOWN;
   bool isPositiveCablingSide_;  
   int plotColor_;
+  //Container bundles_;
 };
 
 

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -60,7 +60,7 @@ enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 // As a result, the full optical cabling map can be used for power cables mapping.
 // The only difference is that power cables are assigned to section A or C in PP1.
 // This additional info is dealt with by ChannelSection.
-enum ChannelSection { UNKNOWN, A, B, C };
+enum ChannelSlot { UNKNOWN, A, B, C };
 
 // Number of outer tracker services channels (per cabling side)
 static const int cabling_numServicesChannels = 12;

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -53,7 +53,7 @@ static const std::string cabling_negativePrefix = "neg";
 enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 
 
-// SERVICES CHANNEL SECTION
+// SERVICES CHANNELS INFO
 // There are 3 sections for cables in PP1: A, B, and C.
 // The optical bundles are always placed in section B.
 // Though, the cabling map is also used for power cables. 1 optical bundle = 1 power cable. 
@@ -62,15 +62,16 @@ enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 // This additional info is dealt with by ChannelSlot.
 enum ChannelSlot { UNKNOWN, A, B, C };
 
+// Offsets used in TEDD to split power cables coming from the same Phi nonant.
+static const double cabling_powerChannelsTeddStripStripSemiNonantBoundaryShift = 5. * M_PI / 180.;
+static const double cabling_powerChannelsTeddPixelStripSemiNonantBoundaryShift = -5. * M_PI / 180.;
+
 // Number of outer tracker services channels (per cabling side)
 static const int cabling_numServicesChannels = 12;
 // Maximum number of power cables per channel (used for cross-checking)
 static const int cabling_maxNumPowerCablesPerChannel = 48;
 // Maximum number of optical fiber bundles per channel (used for cross-checking)
 static const int cabling_maxNumOpticalBundlesPerChannel = 72;
-
-static const double cabling_powerChannelsTeddStripStripSemiNonantBoundaryShift = 5. * M_PI / 180.;
-static const double cabling_powerChannelsTeddPixelStripSemiNonantBoundaryShift = -5. * M_PI / 180.;
 
 
 #endif  // CABLING_CONSTANTS_HH

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -60,7 +60,7 @@ enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 // As a result, the full optical cabling map can be used for power cables mapping.
 // The only difference is that power cables are assigned to section A or C in PP1.
 // This additional info is dealt with by ChannelSection.
-enum ChannelSection { UNKNOWN, A, C };
+enum ChannelSection { UNKNOWN, A, B, C };
 
 
 #endif  // CABLING_CONSTANTS_HH

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -21,8 +21,8 @@ static const double cabling_endcapStripStripPhiRegionWidth = 2. * M_PI / 27.;   
 
 // Offset are sometimes used to set the phi slices.
 // This has been tried to be reduced to the bare minimum: only 2 hardcoded constants :)
-static const double cabling_tedd1StripStripPhiRegionStart = 0.065 * M_PI / 180.;
-static const double cabling_tedd2StripStripPhiRegionStart = 0.;
+static const double cabling_tedd1StripStripPhiRegionStart = 0.065 * M_PI / 180.; // For OT613 (TDR): use -0.55 * M_PI / 180.
+static const double cabling_tedd2StripStripPhiRegionStart = 0.; // For OT613 (TDR): use -0.001 * M_PI / 180.
 
 
 // ROUNDING

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -21,8 +21,8 @@ static const double cabling_endcapStripStripPhiRegionWidth = 2. * M_PI / 27.;   
 
 // Offset are sometimes used to set the phi slices.
 // This has been tried to be reduced to the bare minimum: only 2 hardcoded constants :)
-static const double cabling_tedd1StripStripPhiRegionStart = 0.065 * M_PI / 180.; // For OT613 (TDR): use -0.55 * M_PI / 180.
-static const double cabling_tedd2StripStripPhiRegionStart = 0.; // For OT613 (TDR): use -0.001 * M_PI / 180.
+static const double cabling_tedd1StripStripPhiRegionStart = 0.065 * M_PI / 180.;   // For OT613 (TDR): use -0.55 * M_PI / 180.
+static const double cabling_tedd2StripStripPhiRegionStart = 0.;                    // For OT613 (TDR): use -0.001 * M_PI / 180.
 
 
 // ROUNDING
@@ -61,6 +61,16 @@ enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 // The only difference is that power cables are assigned to section A or C in PP1.
 // This additional info is dealt with by ChannelSection.
 enum ChannelSection { UNKNOWN, A, B, C };
+
+// Number of outer tracker services channels (per cabling side)
+static const int cabling_numServicesChannels = 12;
+// Maximum number of power cables per channel (used for cross-checking)
+static const int cabling_maxNumPowerCablesPerChannel = 48;
+// Maximum number of optical fiber bundles per channel (used for cross-checking)
+static const int cabling_maxNumOpticalBundlesPerChannel = 72;
+
+static const double cabling_powerChannelsTeddStripStripSemiNonantBoundaryShift = 5. * M_PI / 180.;
+static const double cabling_powerChannelsTeddPixelStripSemiNonantBoundaryShift = -5. * M_PI / 180.;
 
 
 #endif  // CABLING_CONSTANTS_HH

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -21,7 +21,7 @@ static const double cabling_endcapStripStripPhiRegionWidth = 2. * M_PI / 27.;   
 
 // Offset are sometimes used to set the phi slices.
 // This has been tried to be reduced to the bare minimum: only 2 hardcoded constants :)
-static const double cabling_tedd1StripStripPhiRegionStart = 0.07 * M_PI / 180.;
+static const double cabling_tedd1StripStripPhiRegionStart = 0.065 * M_PI / 180.;
 static const double cabling_tedd2StripStripPhiRegionStart = 0.;
 
 

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -21,8 +21,8 @@ static const double cabling_endcapStripStripPhiRegionWidth = 2. * M_PI / 27.;   
 
 // Offset are sometimes used to set the phi slices.
 // This has been tried to be reduced to the bare minimum: only 2 hardcoded constants :)
-static const double cabling_tedd1StripStripPhiRegionStart = -0.55 * M_PI / 180.;
-static const double cabling_tedd2StripStripPhiRegionStart = -0.001 * M_PI / 180.;
+static const double cabling_tedd1StripStripPhiRegionStart = 0.07 * M_PI / 180.;
+static const double cabling_tedd2StripStripPhiRegionStart = 0.;
 
 
 // ROUNDING

--- a/include/Cabling/cabling_constants.hh
+++ b/include/Cabling/cabling_constants.hh
@@ -59,7 +59,7 @@ enum Category { UNDEFINED, PS10G, PS10GA, PS10GB, PS5G, SS };
 // Though, the cabling map is also used for power cables. 1 optical bundle = 1 power cable. 
 // As a result, the full optical cabling map can be used for power cables mapping.
 // The only difference is that power cables are assigned to section A or C in PP1.
-// This additional info is dealt with by ChannelSection.
+// This additional info is dealt with by ChannelSlot.
 enum ChannelSlot { UNKNOWN, A, B, C };
 
 // Number of outer tracker services channels (per cabling side)

--- a/include/Cabling/cabling_functions.hh
+++ b/include/Cabling/cabling_functions.hh
@@ -6,9 +6,9 @@
 #include "Cabling/cabling_constants.hh"
 
 
-const double computePhiSegmentStart(const double phi, const double phiSegmentWidth, const bool isPositiveCablingSide);
-const int computePhiSegmentRef(const double phi, const double phiSegmentStart, const double phiSegmentWidth, const bool isPositiveCablingSide);
-const int computePhiSliceRef(const double phi, const double phiSliceStart, const double phiSliceWidth, const bool isPositiveCablingSide);
+const double computePhiSegmentStart(const double phi, const double phiSegmentWidth);
+const int computePhiSegmentRef(const double phi, const double phiSegmentStart, const double phiSegmentWidth);
+const int computePhiSliceRef(const double phi, const double phiSliceStart, const double phiSliceWidth);
 
 const int computeNextPhiSliceRef(const int phiSliceRef, const int numPhiSlices);
 const int computePreviousPhiSliceRef(const int phiSliceRef, const int numPhiSlices);

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -326,7 +326,7 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   std::string summaryFullType() const;
 
   void setBundle(Bundle* bundle) { bundle_ = bundle ; }
-  const Bundle* getBundle() const { return bundle_; }  
+  const Bundle* getBundle() const { return bundle_; }
   const int isPositiveCablingSide() const;
   const int bundlePlotColor() const; 
   const int opticalChannelSectionPlotColor() const;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -329,11 +329,11 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   const Bundle* getBundle() const { return bundle_; }  
   const int isPositiveCablingSide() const;
   const int bundlePlotColor() const; 
-  const int channelPlotColor() const;
-  const int powerChannelPlotColor() const; 
+  const int opticalChannelSectionPlotColor() const;
+  const int powerChannelSectionPlotColor() const; 
   const DTC* getDTC() const;
   const int dtcPlotColor() const;
-  const int dtcPhiSectorRef() const;  
+  const int dtcPhiSectorRef() const;
 };
 
 

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -329,7 +329,8 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   const Bundle* getBundle() const { return bundle_; }  
   const int isPositiveCablingSide() const;
   const int bundlePlotColor() const; 
-  const int channelPlotColor() const; 
+  const int channelPlotColor() const;
+  const int powerChannelPlotColor() const; 
   const DTC* getDTC() const;
   const int dtcPlotColor() const;
   const int dtcPhiSectorRef() const;  

--- a/include/GeometryFactory.hh
+++ b/include/GeometryFactory.hh
@@ -23,6 +23,8 @@ struct FactoryCloneAllocator {
 
 template<class T> using PtrVector = boost::ptr_vector<T, FactoryCloneAllocator>;
 
+//template<class T> using PtrSet = boost::ptr_set<T, FactoryCloneAllocator>;
+
 template<class K, class V> using PtrMap = boost::ptr_multimap<K, V, std::less<K>, FactoryCloneAllocator>;
 
 

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -253,6 +253,19 @@ struct XYNeg : public std::pair<int, int>, private Rounder {
   int y() const { return this->second; }
 };
 
+// Same as XY, but for (-Z) side.
+struct XYNegRotateY180 : public std::pair<int, int>, private Rounder {
+  const bool valid;
+  // XY coordinates of the centre of module m.
+ XYNegRotateY180(const Module& m) : std::pair<int, int>(round(-m.center().X()), round(m.center().Y())), valid(m.center().Z() <= 0) {}
+  // XY coordinates of vector v.
+ XYNegRotateY180(const XYZVector& v) : std::pair<int, int>(round(-v.X()), round(v.Y())), valid(v.Z() <= 0) {}
+  // XY coordinates of vector v, in the (XY) plane passing by the center of module m.
+ XYNegRotateY180(const XYZVector& v, const Module& m) : XYNegRotateY180(v) {}
+  int x() const { return this->first; }
+  int y() const { return this->second; }
+};
+
 struct YZ : public std::pair<int, int>, private Rounder {
   const bool valid;
   // RZ coordinates of the centre of module m, in the plane (RZ) defined by ((Z axis), moduleCenter).

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -135,7 +135,7 @@ struct TypeChannelColor { // Module-maintained channel color
 struct TypeChannelTransparentColor { // Module-maintained channel color
   double operator()(const Module& m) {
     bool isTransparentActivated = true;
-    return Palette::colorChannel(m.channelPlotColor(), isTransparentActivated);
+    return Palette::colorChannel(m.powerChannelPlotColor(), isTransparentActivated);
   }
 };
 

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -241,6 +241,19 @@ struct XY : public std::pair<int, int>, private Rounder {
 };
 
 // Same as XY, but for (-Z) side.
+struct XYRotateY180 : public std::pair<int, int>, private Rounder {
+  const bool valid;
+  // XY coordinates of the centre of module m.
+ XYRotateY180(const Module& m) : std::pair<int, int>(round(-m.center().X()), round(m.center().Y())), valid(m.center().Z() >= 0) {}
+  // XY coordinates of vector v.
+ XYRotateY180(const XYZVector& v) : std::pair<int, int>(round(-v.X()), round(v.Y())), valid(v.Z() >= 0) {}
+  // XY coordinates of vector v, in the (XY) plane passing by the center of module m.
+ XYRotateY180(const XYZVector& v, const Module& m) : XYRotateY180(v) {}
+  int x() const { return this->first; }
+  int y() const { return this->second; }
+};
+
+// Same as XY, but for (-Z) side.
 struct XYNeg : public std::pair<int, int>, private Rounder {
   const bool valid;
   // XY coordinates of the centre of module m.

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -126,16 +126,16 @@ struct TypeDTCTransparentColor { // Module-maintained DTC color
   }
 };
 
-struct TypeChannelColor { // Module-maintained channel color
+struct TypeOpticalChannelColor { // Module-maintained channel color
   double operator()(const Module& m) {
-    return Palette::colorChannel(m.channelPlotColor());
+    return Palette::colorChannel(m.opticalChannelSectionPlotColor());
   }
 };
 
-struct TypeChannelTransparentColor { // Module-maintained channel color
+struct TypePowerChannelColor { // Module-maintained channel color
   double operator()(const Module& m) {
     bool isTransparentActivated = true;
-    return Palette::colorChannel(m.powerChannelPlotColor(), isTransparentActivated);
+    return Palette::colorChannel(m.powerChannelSectionPlotColor(), isTransparentActivated);
   }
 };
 

--- a/include/RootWeb.hh
+++ b/include/RootWeb.hh
@@ -92,10 +92,13 @@ public:
   pair<int, int> addContent(double number, int precision);
   pair<int, int> newLine();
   bool isTable() {return true;};
+  const int maxRow() const { return maxRow_; }
+  const int maxCol() const { return maxCol_; }
 private:
   rootWTableContent tableContent_;
   rootWTableContentColor tableContentColor_;
   int serialRow_, serialCol_;
+  int maxRow_, maxCol_;
 };
 
 typedef string RootWImageSize;

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -172,6 +172,9 @@ namespace insur {
     RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    RootWTable* powerServicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    void analyzePowerServicesChannels(const CablingMap* myCablingMap, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    RootWTable* createPowerServicesChannelTable(const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
 
     enum {ViewSectionXY=3, ViewSectionYZ=1, ViewSectionXZ=2};
     void drawEtaTicks(double maxL, double maxR, double tickDistance, double tickLength, double textDistance, Style_t labelFont, Float_t labelSize,

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -176,12 +176,12 @@ namespace insur {
     void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
 						     TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 						     std::vector<TCanvas*> &XYCanvasesDisk, std::vector<TCanvas*> &XYNegCanvasesDisk);
-    RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
-    void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
-    RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
-    RootWTable* powerServicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const std::vector<ChannelSection>& sections);
-    void analyzePowerServicesChannels(const CablingMap* myCablingMap, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
-    void createPowerServicesChannelTable(RootWTable* channelsTable, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    RootWTable* opticalServicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
+    void analyzeOpticalServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
+    RootWTable* createOpticalServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
+    RootWTable* powerServicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const std::vector<ChannelSlot>& slots);
+    void analyzePowerServicesChannels(const CablingMap* myCablingMap, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
+    void createPowerServicesChannelTable(RootWTable* channelsTable, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
 
     enum {ViewSectionXY=3, ViewSectionYZ=1, ViewSectionXZ=2};
     void drawEtaTicks(double maxL, double maxR, double tickDistance, double tickLength, double textDistance, Style_t labelFont, Float_t labelSize,

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -168,7 +168,9 @@ namespace insur {
     void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
     void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
+						     TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
+						     std::vector<TCanvas*> &XYCanvasesDisk, std::vector<TCanvas*> &XYNegCanvasesDisk);
     RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -174,9 +174,9 @@ namespace insur {
     RootWTable* servicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     void analyzeServicesChannels(const CablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
     RootWTable* createServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
-    RootWTable* powerServicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    RootWTable* powerServicesChannels(const CablingMap* myCablingMap, const bool isPositiveCablingSide, const std::vector<ChannelSection>& sections);
     void analyzePowerServicesChannels(const CablingMap* myCablingMap, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
-    RootWTable* createPowerServicesChannelTable(const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
+    void createPowerServicesChannelTable(RootWTable* channelsTable, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSection requestedSection = ChannelSection::UNKNOWN);
 
     enum {ViewSectionXY=3, ViewSectionYZ=1, ViewSectionXZ=2};
     void drawEtaTicks(double maxL, double maxR, double tickDistance, double tickLength, double textDistance, Style_t labelFont, Float_t labelSize,

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -241,7 +241,7 @@ namespace insur {
     TCanvas* drawFullLayoutBarrelXY();
 
     void drawCircle(double radius, bool full, int color=kBlack);
-    void drawPhiSectorsBoundaries(const double phiSectorWidth);
+    void drawPhiSectorsBoundaries(const double phiSectorWidth, const bool isRotatedY180 = false);
     void computeServicesChannelsLegend(TLegend* legend, const CablingMap* myCablingMap, const bool isPositiveCablingSide, const bool isPowerCabling);
   };
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -165,9 +165,12 @@ namespace insur {
 
     void createSummaryCanvas(double maxZ, double maxRho, Analyzer& analyzer, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYCanvasEC);
     void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, std::vector<TCanvas*> &XYCanvasEC, std::vector<TCanvas*> &XYSurfacesDisk);
-    void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasCablingBundleNicer(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, 
+					       std::vector<TCanvas*> &XYPosBundlesDisks, std::vector<TCanvas*> &XYPosBundlesDiskSurfaces,
+					       std::vector<TCanvas*> &XYNegBundlesDisks, std::vector<TCanvas*> &XYNegBundlesDiskSurfaces);
+    void createSummaryCanvasCablingDTCNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, 
+					    TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
     void createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
 						     TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 						     std::vector<TCanvas*> &XYCanvasesDisk, std::vector<TCanvas*> &XYNegCanvasesDisk);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -29,6 +29,8 @@
 #include <TLatex.h>
 #include <TColor.h>
 #include <TLine.h>
+#include <TArrow.h>
+#include <TEllipse.h>
 #include <TView.h>
 #include <TLegend.h>
 #include <TGraph.h>
@@ -247,6 +249,7 @@ namespace insur {
 
     void drawCircle(double radius, bool full, int color=kBlack);
     void drawPhiSectorsBoundaries(const double phiSectorWidth, const bool isRotatedY180 = false);
+    void drawFrameOfReference(const bool isRotatedY180);
     void computeServicesChannelsLegend(TLegend* legend, const CablingMap* myCablingMap, const bool isPositiveCablingSide, const bool isPowerCabling);
   };
 

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -144,7 +144,7 @@ namespace insur {
    */
   // TODO: make sure the following constants are only used in
   // mainConfigHandler
-  static const std::string default_tdrLayoutName                         = "OT613_200_IT4025.cfg";
+  static const std::string default_cabledOTName                  = "OT614";
   static const std::string default_mattabdir                     = "config";
   static const std::string default_mattabfile                    = "mattab.list";
   static const std::string default_irradiationdir                = "config";

--- a/include/global_funcs.hh
+++ b/include/global_funcs.hh
@@ -122,7 +122,7 @@ inline ArgType femod(const ArgType& phi, const ArgType& base) {
 
 
 // Same as femod, but handles the case where the result is closed to 0.
-template<typename ArgType> 
+template<typename ArgType>
 inline ArgType femodRounded(const ArgType& phi, const ArgType& base) {
   static_assert(std::is_arithmetic<ArgType>::value, "Argument type must be numeric.");
   ArgType result = femod(phi, base);

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -516,10 +516,10 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
 	std::stringstream cableInfo;
 	cableInfo << myCable->myid() << ","
 		  << any2str(myCable->type()) << ",";
-	bundleInfo << myCable->servicesChannel() << " " 
-		   << any2str(myCable->servicesChannelSection()) << ","
-		   << myBundle->powerServicesChannel() << " " 
-		   << any2str(myBundle->powerServicesChannelSection()) << ",";
+	bundleInfo << myCable->opticalChannelSection()->channelNumber() << " " 
+		   << any2str(myCable->opticalChannelSection()->channelSlot()) << ","
+		   << myBundle->powerChannelSection()->channelNumber() << " " 
+		   << any2str(myBundle->powerChannelSection()->channelSlot()) << ",";
 	
 	const DTC* myDTC = myCable->getDTC();
 	if (myDTC != nullptr) {

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -477,7 +477,7 @@ ModulesToDTCsVisitor::ModulesToDTCsVisitor(bool isPositiveCablingSide) {
 }
 
 void ModulesToDTCsVisitor::preVisit() {
-  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Bundle #/I, PWR Services Channel/I, Cable #/I, Cable type/C, DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D" << std::endl;
+  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Bundle #/I, OPT Services Channel/I, PWR Services Channel/I, Cable #/I, Cable type/C, DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D" << std::endl;
 }
 
 void ModulesToDTCsVisitor::visit(const Barrel& b) {
@@ -517,7 +517,9 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
 	cableInfo << myCable->myid() << ","
 		  << any2str(myCable->type()) << ",";
 	bundleInfo << myCable->servicesChannel() << " " 
-		   << any2str(myCable->servicesChannelSection()) << ",";
+		   << any2str(myCable->servicesChannelSection()) << ","
+		   << myBundle->powerServicesChannel() << " " 
+		   << any2str(myBundle->powerServicesChannelSection()) << ",";
 	
 	const DTC* myDTC = myCable->getDTC();
 	if (myDTC != nullptr) {

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -2,8 +2,8 @@
 #include "Cabling/Cable.hh"
 
 
-Bundle::Bundle(const int id, const int complementaryBundleId, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart) :
-  complementaryBundleId_(complementaryBundleId),
+Bundle::Bundle(const int id, const int stereoBundleId, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart) :
+  stereoBundleId_(stereoBundleId),
   type_(type),
   subDetectorName_(subDetectorName),
   layerDiskNumber_(layerDiskNumber),
@@ -111,4 +111,34 @@ const ChannelSection* Bundle::opticalChannelSection() const {
   const ChannelSection* opticalSection = nullptr;
   if (cable_ != nullptr) opticalSection = cable_->opticalChannelSection();
   return opticalSection;
+}
+
+
+/* Untilted TBPS only: Id of the bundle located on the same Phi, but connected to the tilted modules.
+ */
+const int Bundle::tiltedBundleId() const {
+  if (!isBarrel() || !isPSFlatPart()) logERROR("Tried to access tiltedBundleId, but not in TBPS flat part.");
+  const int bundleId = myid();
+  const int tiltedBundleId = bundleId - femod(bundleId, 10);
+  return tiltedBundleId;
+}
+
+
+/* Id of the bundle located on the other cabling side, by rotation of 180° around CMS_Y.
+ */
+const int Bundle::stereoBundleId() const {
+  if (!isBarrel()) logERROR("Tried to access stereoBundleId in TEDD, where it is not implemented (only implemented for Barrel).");
+  return stereoBundleId_;
+}
+
+
+void Bundle::setIsPowerRoutedToBarrelLowerSemiNonant(const bool isLower) {
+  if (!isBarrel()) logERROR("Tried to set Barrel power routing on a Bundle located in TEDD.");
+  isPowerRoutedToBarrelLowerSemiNonant_ = isLower;
+}
+
+
+const bool Bundle::isPowerRoutedToBarrelLowerSemiNonant() const {
+  if (!isBarrel()) logERROR("Tried to access Barrel power routing from a Bundle located in TEDD.");
+  return isPowerRoutedToBarrelLowerSemiNonant_;
 }

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -56,7 +56,7 @@ const double Bundle::maxPhi() const {
   for (const auto& m : modules_) { max = MAX(max, femodRounded(m.center().Phi(), 2. * M_PI) ); } return max;
 }
 
-const double Bundle::meanPhi() const { 
+const double Bundle::meanPhi() const {
   std::vector<double> modPhis;
 
   for (const auto& m : modules_) { 

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -56,6 +56,23 @@ const double Bundle::maxPhi() const {
   for (const auto& m : modules_) { max = MAX(max, femodRounded(m.center().Phi(), 2. * M_PI) ); } return max;
 }
 
+const double Bundle::meanPhi() const { 
+  std::vector<double> modPhis;
+
+  for (const auto& m : modules_) { 
+    double phi = femodRounded(m.center().Phi(), 2. * M_PI);
+    if (modPhis.size() > 0 && (fabs(modPhis.back() - phi) > M_PI)) {
+      if (phi < modPhis.back()) phi += 2.*M_PI;
+      else phi -= 2.*M_PI;
+    }
+    modPhis.push_back(phi);
+  } 
+
+  double mean = 0.;
+  for (const auto& phi : modPhis) { mean += phi; }
+  mean /= numModules();
+  return mean;
+}
 
 Module* Bundle::minPhiModule() const {
   const Module* mod = &(*std::min_element(modules_.begin(), modules_.end(), [](const Module& a, const Module& b) {
@@ -82,5 +99,18 @@ const int Bundle::computePlotColor(const int id, const bool isPositiveCablingSid
   int dizaine = plotId / 10;
   int plotPhi = dizaine % 3;  // Barrel : Identifies phiSegmentRef. Endcap : Identifies phiRegionRef.
   plotColor = plotType * 3 + plotPhi;
+  return plotColor;
+}
+
+
+int Bundle::computePowerServicesChannelPlotColor(std::pair<int, ChannelSection>& powerServicesChannel) const {
+  int plotColor = 0;
+  const int channel = powerServicesChannel.first;
+  plotColor = fabs(channel);
+  if ( (channel > 0 && powerServicesChannel.second == ChannelSection::A)
+       || (channel < 0 && powerServicesChannel.second == ChannelSection::C)
+       ) {
+    plotColor += 12;
+  }
   return plotColor;
 }

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -2,7 +2,8 @@
 #include "Cabling/Cable.hh"
 
 
-Bundle::Bundle(const int id, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart) :
+Bundle::Bundle(const int id, const int complementaryBundleId, const Category& type, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& phiPosition, const bool isPositiveCablingSide, const bool isTiltedPart) :
+  complementaryBundleId_(complementaryBundleId),
   type_(type),
   subDetectorName_(subDetectorName),
   layerDiskNumber_(layerDiskNumber),
@@ -110,6 +111,7 @@ int Bundle::computePowerServicesChannelPlotColor(std::pair<int, ChannelSection>&
   if ( (channel > 0 && powerServicesChannel.second == ChannelSection::A)
        || (channel < 0 && powerServicesChannel.second == ChannelSection::C)
        ) {
+    //if (powerServicesChannel.second == ChannelSection::A) {
     plotColor += 12;
   }
   return plotColor;

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -19,6 +19,9 @@ Bundle::Bundle(const int id, const int complementaryBundleId, const Category& ty
 Bundle::~Bundle() {
   delete cable_;    // TO DO: switch to smart pointers and remove this!
   cable_ = nullptr; 
+
+  delete powerChannel_;
+  powerChannel_ = nullptr;
 }
 
 

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -117,7 +117,7 @@ const ChannelSection* Bundle::opticalChannelSection() const {
 /* Untilted TBPS only: Id of the bundle located on the same Phi, but connected to the tilted modules.
  */
 const int Bundle::tiltedBundleId() const {
-  if (!isBarrel() || !isPSFlatPart()) logERROR("Tried to access tiltedBundleId, but not in TBPS flat part.");
+  if (!isBarrelPSFlatPart()) logERROR("Tried to access tiltedBundleId, but not in TBPS flat part.");
   const int bundleId = myid();
   const int tiltedBundleId = bundleId - femod(bundleId, 10);
   return tiltedBundleId;

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -102,17 +102,3 @@ const int Bundle::computePlotColor(const int id, const bool isPositiveCablingSid
   plotColor = plotType * 3 + plotPhi;
   return plotColor;
 }
-
-
-int Bundle::computePowerServicesChannelPlotColor(std::pair<int, ChannelSection>& powerServicesChannel) const {
-  int plotColor = 0;
-  const int channel = powerServicesChannel.first;
-  plotColor = fabs(channel);
-  if ( (channel > 0 && powerServicesChannel.second == ChannelSection::A)
-       || (channel < 0 && powerServicesChannel.second == ChannelSection::C)
-       ) {
-    //if (powerServicesChannel.second == ChannelSection::A) {
-    plotColor += 12;
-  }
-  return plotColor;
-}

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -109,7 +109,8 @@ const int Bundle::computePlotColor(const int id, const bool isPositiveCablingSid
 
 const ChannelSection* Bundle::opticalChannelSection() const {
   const ChannelSection* opticalSection = nullptr;
-  if (cable_ != nullptr) opticalSection = cable_->opticalChannelSection();
+  if (cable_) opticalSection = cable_->opticalChannelSection();
+  if (!cable_ || !opticalSection) throw PathfulException("cable_ or opticalSection is nullptr");
   return opticalSection;
 }
 

--- a/src/Cabling/Bundle.cc
+++ b/src/Cabling/Bundle.cc
@@ -20,8 +20,8 @@ Bundle::~Bundle() {
   delete cable_;    // TO DO: switch to smart pointers and remove this!
   cable_ = nullptr; 
 
-  delete powerChannel_;
-  powerChannel_ = nullptr;
+  delete powerChannelSection_;
+  powerChannelSection_ = nullptr;
 }
 
 
@@ -104,4 +104,11 @@ const int Bundle::computePlotColor(const int id, const bool isPositiveCablingSid
   int plotPhi = dizaine % 3;  // Barrel : Identifies phiSegmentRef. Endcap : Identifies phiRegionRef.
   plotColor = plotType * 3 + plotPhi;
   return plotColor;
+}
+
+
+const ChannelSection* Bundle::opticalChannelSection() const {
+  const ChannelSection* opticalSection = nullptr;
+  if (cable_ != nullptr) opticalSection = cable_->opticalChannelSection();
+  return opticalSection;
 }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -21,6 +21,9 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 Cable::~Cable() {
   delete myDTC_;       // TO DO: switch to smart pointers and remove this!
   myDTC_ = nullptr;
+
+  delete opticalChannel_;
+  opticalChannel_ = nullptr;
 }
 
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -27,34 +27,6 @@ Cable::~Cable() {
 }
 
 
-void Cable::assignPowerChannelSections() {
-  for (auto& myBundle : bundles_) {
-
-    const double meanPhi = femod(myBundle.meanPhi(), 2.*M_PI);
-    const int cablePhiSectorRef = phiSectorRef_;
-
-    const bool isBarrel = myBundle.isBarrel();
-    const Category& type = type_;
-
-    bool isLower;
-    if (isBarrel) { isLower = myBundle.isInLowerSemiPhiSectorStereo(); }
-    else {
-      const double phiShift = ((type == Category::SS) ? 
-				cabling_powerChannelsTeddStripStripSemiNonantBoundaryShift 
-				: cabling_powerChannelsTeddPixelStripSemiNonantBoundaryShift);
-      const double semiNonantBoundary = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiShift;
-      isLower = moduloComp(meanPhi, semiNonantBoundary, 2.*M_PI);
-    }
-
-    const int semiPhiRegionIndex = (isLower ? 0 : 1);
-    const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
-
-    ChannelSection* powerChannelSection = GeometryFactory::make<PowerSection>(semiPhiRegionRef, isPositiveCablingSide_);
-    myBundle.setPowerChannelSection(powerChannelSection);
-  }
-}
-
-
 /* Build DTC asociated to the cable.
  */
 void Cable::buildDTC(const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) {
@@ -73,4 +45,55 @@ const std::string Cable::computeDTCName(const int phiSectorRef, const Category& 
   dtcNameStream << phiSectorRef << "_" << any2str(type) << "_" << slot;
   const std::string dtcName = dtcNameStream.str();
   return dtcName;
+}
+
+
+/* POWER SERVICES CHANNELS CONNECTIONS.
+ * One use the equivalence 1 Bundle = 1 Power cable.
+ * The power channel mapping is done so that all modules connected to the same DTC, 
+ * have their power cables routed through 2 consecutive channels sections at most.
+ */
+void Cable::assignPowerChannelSections() {
+  // Loop on all bundles connected to the same DTC.
+  for (auto& myBundle : bundles_) {
+    
+    const bool isBarrel = myBundle.isBarrel();
+    const int cablePhiSectorRef = phiSectorRef_;
+    
+    // COMPUTE ISLOWER
+    // THIS DECIDES WETHER THE BUNDLE (= POWER CABLE) IS ASSIGNED TO LOWER OR UPPER SEMI-NONANT.
+    // 'lower' and 'upper' are defined by 'smaller' or 'bigger' Phi, 
+    // in the trigonometric sense in the (XY) plane in CMS global frame of reference.
+    bool isLower;
+
+    // BARREL: Use complex boundary relying on rotation of 180° around CMS_Y.
+    if (isBarrel) { 
+      isLower = myBundle.isPowerRoutedToBarrelLowerSemiNonant(); 
+    }
+
+    // ENDCAP: Define a Phi Semi-Nonant boundary and split bundles accordingly.
+    else {
+      // Average Phi of all modules the Bundle is connected to.
+      const double meanPhi = femod(myBundle.meanPhi(), 2.*M_PI);
+
+      const Category& type = type_;
+
+      // Compute Phi Semi-Nonant boundary
+      const double phiShift = ((type == Category::SS) ? 
+				cabling_powerChannelsTeddStripStripSemiNonantBoundaryShift 
+				: cabling_powerChannelsTeddPixelStripSemiNonantBoundaryShift);
+      const double semiNonantBoundary = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiShift;
+      isLower = moduloComp(meanPhi, semiNonantBoundary, 2.*M_PI);
+    }
+
+    // COMPUTE AT WHICH SEMINONANT THE BUNDLE IS LOCATED.
+    const int semiPhiRegionIndex = (isLower ? 0 : 1);
+    const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
+
+    // COMPUTE THE POWER CHANEL SECTION CORRESPONDING TO THE PHI SEMINONANT.
+    ChannelSection* powerChannelSection = GeometryFactory::make<PowerSection>(semiPhiRegionRef, isPositiveCablingSide_);
+
+    // ASSIGN THE POWER CHANNEL SECTION TO THE BUNDLE (bundle = power cable)
+    myBundle.setPowerChannelSection(powerChannelSection);
+  }
 }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -160,37 +160,46 @@ const int Cable::computeServicesChannelPlotColor(const int servicesChannel, cons
 
 
 void Cable::assignPowerServicesChannels() {
-  std::vector<std::pair<int, double> > myBundlesPhis;
-  for (auto& myBundle : bundles_) {
+  /*std::vector<std::pair<int, double> > myBundlesPhis;
+    for (auto& myBundle : bundles_) {
     const int bundleId = myBundle.myid();
     const double bundlePhi = myBundle.meanPhi();
     myBundlesPhis.push_back(std::make_pair(bundleId, bundlePhi));
-  }
-  std::sort(myBundlesPhis.begin(), myBundlesPhis.end(), 
-	    [] (std::pair<int, double> a, std::pair<int, double> b) { 
-	      return (moduloComp(a.second, b.second, 2.*M_PI)); 
-	    } 
-	    );
+    }
+    std::sort(myBundlesPhis.begin(), myBundlesPhis.end(), 
+    [] (std::pair<int, double> a, std::pair<int, double> b) { 
+    return (moduloComp(a.second, b.second, 2.*M_PI)); 
+    } 
+    );*/
+
+
+  //for (auto& myBundle : bundles_) {
+  /*const int bundleId = myBundle.myid();
+    const int phiIndex = std::distance(myBundlesPhis.begin(), it);
+    const int semiPhiRegionIndex = (phiIndex <= 2 ? 0 : 1);
+    const int semiPhiRegionRef = 2 * phiSectorRef_ + semiPhiRegionIndex;
+    std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide_);
+    myBundle.setPowerServicesChannel(powerServicesChannel);
+    /*} 
+    else {
+    std::cout << "ERROR: bundle Id not found in my own bundles vector!" << std::endl;
+    }    */
+
 
 
   for (auto& myBundle : bundles_) {
-    const int bundleId = myBundle.myid();
-    auto it = std::find_if(myBundlesPhis.begin(), myBundlesPhis.end(), 
-			   [bundleId] (const std::pair<const int, const double> bundlePhi) { 
-			     return (bundlePhi.first == bundleId); 
-			   } 
-			   );
+    const double bundlePhi = myBundle.meanPhi();
 
-    if (it != myBundlesPhis.end()) {
-      const int phiIndex = std::distance(myBundlesPhis.begin(), it);
-      const int semiPhiRegionIndex = (phiIndex <= 2 ? 0 : 1);
-      const int semiPhiRegionRef = 2 * phiSectorRef_ + semiPhiRegionIndex;
-      std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide_);
-      myBundle.setPowerServicesChannel(powerServicesChannel);
-    } 
-    else {
+    const int phiIndex = 
+    const int semiPhiRegionIndex = (phiIndex <= 2 ? 0 : 1);
+
+    const int semiPhiRegionRef = 2 * phiSectorRef_ + semiPhiRegionIndex;
+    std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide_);
+    myBundle.setPowerServicesChannel(powerServicesChannel);
+    /*} 
+      else {
       std::cout << "ERROR: bundle Id not found in my own bundles vector!" << std::endl;
-    }    
+      }    */
   }
 }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,10 +11,10 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN A SERVICESCHANNEL TO THE CABLE
-  const std::tuple<int, ChannelSection, int>& servicesChannelInfo = computeServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
-  servicesChannel_ = std::get<0>(servicesChannelInfo);
-  servicesChannelSection_ = std::get<1>(servicesChannelInfo);
-  servicesChannelPlotColor_ = std::get<2>(servicesChannelInfo);
+  const std::tuple<int, ChannelSection, int>& servicesChannelInfo = computeOpticalServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
+  opticalServicesChannel_ = std::get<0>(servicesChannelInfo);
+  opticalServicesChannelSection_ = std::get<1>(servicesChannelInfo);
+  opticalServicesChannelPlotColor_ = std::get<2>(servicesChannelInfo);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -27,71 +27,71 @@ Cable::~Cable() {
 }
 
 
-/* Compute services channels.
+/* Compute optical services channels.
  * They are the channels where the optical cables are routed when they exit the tracker.
  * They are closely related to the phiSector ref.
  */
-const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+const std::tuple<int, ChannelSection, int> Cable::computeOpticalServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
   int servicesChannel = 0;
-  ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
+  ChannelSection servicesChannelSection = ChannelSection::B;
 
   if (type == Category::PS10G) {
-    if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }   
+    if (phiSectorRef == 0) { servicesChannel = 2;  }
+    else if (phiSectorRef == 1) { servicesChannel = 3; }
+    else if (phiSectorRef == 2) { servicesChannel = 5; }
+    else if (phiSectorRef == 3) { servicesChannel = 6; }
+    else if (phiSectorRef == 4) { servicesChannel = 7; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; }
+    else if (phiSectorRef == 6) { servicesChannel = 9; }
+    else if (phiSectorRef == 7) { servicesChannel = 11; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; }   
   }
 
   else if (type == Category::PS5G) {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
+    if (phiSectorRef == 0) { servicesChannel = 1; }
+    else if (phiSectorRef == 1) { servicesChannel = 2; }
+    else if (phiSectorRef == 2) { servicesChannel = 4; }
+    else if (phiSectorRef == 3) { servicesChannel = 5; }
+    else if (phiSectorRef == 4) { servicesChannel = 7; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; }
+    else if (phiSectorRef == 6) { servicesChannel = 10; }
+    else if (phiSectorRef == 7) { servicesChannel = 11; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; }
   }
 
   else if (type == Category::SS) {
     if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 8) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
+      if (phiSectorRef == 0) { servicesChannel = 1; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; }
+      else if (phiSectorRef == 8) { servicesChannel = 11; }
     }
     else if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 5) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
+      if (phiSectorRef == 0) { servicesChannel = 1; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; }
+      else if (phiSectorRef == 5) { servicesChannel = 7; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; }
     }
     else {
-      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 5) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
+      if (phiSectorRef == 0) { servicesChannel = 1; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; }
+      else if (phiSectorRef == 5) { servicesChannel = 7; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; }
     }
   }
 
@@ -100,7 +100,7 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   // COMPUTE SERVICES CHANNEL PLOT COLOR, FOR BOTH SIDES, BEFORE THE CHANNEL NUMBERING IS MIRRORED FOR (-Z) SIDE.
   // THIS IS BECAUSE A GIVEN SERVICE CHANNEL IS IDENTICAL ALL ALONG Z (going from (+Z) to (-Z) side).
   // HENCE, EVEN IF THE CHANNEL NUMBERING CAN BE DIFFERENT, WE DONT CARE, AND WE ACTUALLY WANT A GIVEN CHANNEL COLORED BY A UNIQUE COLOR!!
-  int servicesChannelPlotColor = computeServicesChannelPlotColor(servicesChannel, servicesChannelSection);
+  int servicesChannelPlotColor = computeOpticalServicesChannelPlotColor(servicesChannel, servicesChannelSection);
 
 
   // NEGATIVE CABLING SIDE.
@@ -138,7 +138,7 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
 /* Compute color associated to services channel.
  * If section A, +12 is added so that the same color is used as scetion C, but that color can be set as transparent if desired.
  */
-const int Cable::computeServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
+const int Cable::computeOpticalServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
   int plotColor = 0;
   plotColor = servicesChannel;
   if (servicesChannelSection == ChannelSection::A) plotColor += 12;
@@ -158,9 +158,11 @@ void Cable::assignPowerServicesChannels() {
     bool isLower;
     if (isBarrel) { isLower = myBundle.isInLowerSemiPhiSectorStereo(); }
     else {
-      const double phiMargin = ((type == Category::SS) ? 5. : -5.) * M_PI / 180.;
-      const double phiLimit = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiMargin;
-      isLower = moduloComp(meanPhi, phiLimit, 2.*M_PI);
+      const double phiShift = ((type == Category::SS) ? 
+				cabling_powerChannelsTeddStripStripSemiNonantBoundaryShift 
+				: cabling_powerChannelsTeddPixelStripSemiNonantBoundaryShift);
+      const double semiNonantBoundary = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiShift;
+      isLower = moduloComp(meanPhi, semiNonantBoundary, 2.*M_PI);
     }
 
     const int semiPhiRegionIndex = (isLower ? 0 : 1);
@@ -175,7 +177,7 @@ void Cable::assignPowerServicesChannels() {
 std::pair<int, ChannelSection> Cable::computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
 
   int servicesChannel = 0;
-  ChannelSection servicesChannelSection = ChannelSection::B;
+  ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
 
   if (isPositiveCablingSide) {
     if (semiPhiRegionRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
@@ -198,45 +200,6 @@ std::pair<int, ChannelSection> Cable::computePowerServicesChannel(const int semi
     else if (semiPhiRegionRef == 17) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
   }
-
-  // This is the following transformation:
-  // 1 -> 6
-  // 2 -> 5
-  // 3 -> 4
-  // 7 -> 12
-  // 8 -> 11
-  // 9 -> 10
-  // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
-  // The services channel is then set to negative on negative cabling side.
-  /*if (!isPositiveCablingSide) {
-    const double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
-    servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
-    servicesChannel *= -1;
-    servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
-    }*/
-
-  /*else {
-    if (semiPhiRegionRef == 1) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 2) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 3) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 4) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 5) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 6) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 7) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 8) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 9) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 10) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 11) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 12) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 13) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 14) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 15) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 16) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 17) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 0) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
-    else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
-    }*/
-
 
   else {
     if (semiPhiRegionRef == 0) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -186,20 +186,41 @@ void Cable::assignPowerServicesChannels() {
     }    */
 
 
-
   for (auto& myBundle : bundles_) {
-    const double bundlePhi = myBundle.meanPhi();
 
-    const int phiIndex = 
-    const int semiPhiRegionIndex = (phiIndex <= 2 ? 0 : 1);
+    const double meanPhiPositiveSide = femod(myBundle.meanPhi(), 2.*M_PI);
+    const double meanPhiNegativeSide = femod(M_PI - meanPhiPositiveSide + cabling_semiNonantWidth, 2.*M_PI);
+    double meanPhi = (isPositiveCablingSide_ ? meanPhiPositiveSide : meanPhiNegativeSide);
 
-    const int semiPhiRegionRef = 2 * phiSectorRef_ + semiPhiRegionIndex;
+    const int cablePhiSectorRefPositiveSide =  phiSectorRef_;
+    int cablePhiSectorRefNegativeSide = 0;
+    if (cablePhiSectorRefPositiveSide == 0) cablePhiSectorRefNegativeSide = 4;
+    else if (cablePhiSectorRefPositiveSide == 1) cablePhiSectorRefNegativeSide = 3;
+    else if (cablePhiSectorRefPositiveSide == 2) cablePhiSectorRefNegativeSide = 2;
+    else if (cablePhiSectorRefPositiveSide == 3) cablePhiSectorRefNegativeSide = 1;
+    else if (cablePhiSectorRefPositiveSide == 4) cablePhiSectorRefNegativeSide = 0;
+    else if (cablePhiSectorRefPositiveSide == 5) cablePhiSectorRefNegativeSide = 8;
+    else if (cablePhiSectorRefPositiveSide == 6) cablePhiSectorRefNegativeSide = 7;
+    else if (cablePhiSectorRefPositiveSide == 7) cablePhiSectorRefNegativeSide = 6;
+    else if (cablePhiSectorRefPositiveSide == 8) cablePhiSectorRefNegativeSide = 5;
+    const int cablePhiSectorRef = (isPositiveCablingSide_ ? cablePhiSectorRefPositiveSide : cablePhiSectorRefNegativeSide);
+
+    /*double semiPhiRegionStart = cablePhiSectorRef * cabling_nonantWidth;
+    if (fabs(meanPhi - semiPhiRegionStart) > M_PI) {
+      if (meanPhi < semiPhiRegionStart) meanPhi += 2.*M_PI;
+      else semiPhiRegionStart += 2.*M_PI;
+    }
+    const int semiPhiRegionIndex = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth, true);*/
+
+    const std::string subDetectorName = myBundle.subDetectorName();
+    const double phiMargin = ((subDetectorName == cabling_tedd1 || subDetectorName == cabling_tedd2) ? 5. : -1.) * M_PI / 180.;
+    const double phiLimit = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiMargin;
+    const bool isLower = moduloComp(meanPhi, phiLimit, 2.*M_PI);
+    const int semiPhiRegionIndex = (isLower ? 0 : 1);
+    const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
+
     std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide_);
     myBundle.setPowerServicesChannel(powerServicesChannel);
-    /*} 
-      else {
-      std::cout << "ERROR: bundle Id not found in my own bundles vector!" << std::endl;
-      }    */
   }
 }
 
@@ -248,24 +269,24 @@ std::pair<int, ChannelSection> Cable::computePowerServicesChannel(const int semi
     }*/
 
   else {
-    if (semiPhiRegionRef == 0) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 1) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 2) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 3) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 4) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 5) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 6) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 7) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 8) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 9) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 10) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 11) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 12) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 13) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 14) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 15) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 16) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 17) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
+    if (semiPhiRegionRef == 1) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 2) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 3) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 4) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 5) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 6) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 7) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 8) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 9) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 10) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 11) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 12) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 13) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 14) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 15) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 16) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 17) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 0) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
   }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -36,49 +36,75 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
 
   if (type == Category::PS10G) {
-    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }   
+    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }   
   }
+
   else if (type == Category::PS5G) {
-    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
-    else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
-    else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
-  }
-  else if (type == Category::SS) {
-    if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
+    if (slot == 3) {
+      if (phiSectorRef == 0) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 8) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
     }
     else {
-      if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
+    }
+  }
+
+  else if (type == Category::SS) {
+    if (slot == 1 || slot == 2) {
+      if (phiSectorRef == 0) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 8) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
+    }
+    else if (slot == 3) {
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
+    }
+    else {
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 5) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
     }
   }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,7 +11,7 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN AN OPTICAL SERVICESCHANNEL TO THE CABLE
-  opticalChannel_ = GeometryFactory::make<OpticalChannel>(phiSectorRef, type, slot, isPositiveCablingSide);
+  opticalChannelSection_ = GeometryFactory::make<OpticalSection>(phiSectorRef, type, slot, isPositiveCablingSide);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -22,12 +22,12 @@ Cable::~Cable() {
   delete myDTC_;       // TO DO: switch to smart pointers and remove this!
   myDTC_ = nullptr;
 
-  delete opticalChannel_;
-  opticalChannel_ = nullptr;
+  delete opticalChannelSection_;
+  opticalChannelSection_ = nullptr;
 }
 
 
-void Cable::assignPowerServicesChannels() {
+void Cable::assignPowerChannelSections() {
   for (auto& myBundle : bundles_) {
 
     const double meanPhi = femod(myBundle.meanPhi(), 2.*M_PI);
@@ -49,8 +49,8 @@ void Cable::assignPowerServicesChannels() {
     const int semiPhiRegionIndex = (isLower ? 0 : 1);
     const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
 
-    ServicesChannel* powerChannel = GeometryFactory::make<PowerChannel>(semiPhiRegionRef, isPositiveCablingSide_);
-    myBundle.setPowerServicesChannel(powerChannel);
+    ChannelSection* powerChannelSection = GeometryFactory::make<PowerSection>(semiPhiRegionRef, isPositiveCablingSide_);
+    myBundle.setPowerChannelSection(powerChannelSection);
   }
 }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,7 +11,7 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN AN OPTICAL SERVICESCHANNEL TO THE CABLE
-  ServicesChannel* opticalChannel_ = GeometryFactory::make<ServicesChannel>(phiSectorRef, type, slot, isPositiveCablingSide);
+  ServicesChannel* opticalChannel_ = GeometryFactory::make<OpticalChannel>(phiSectorRef, type, slot, isPositiveCablingSide);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -46,7 +46,7 @@ void Cable::assignPowerServicesChannels() {
     const int semiPhiRegionIndex = (isLower ? 0 : 1);
     const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
 
-    ServicesChannel* powerChannel = GeometryFactory::make<ServicesChannel>(semiPhiRegionRef, isPositiveCablingSide_);
+    ServicesChannel* powerChannel = GeometryFactory::make<PowerChannel>(semiPhiRegionRef, isPositiveCablingSide_);
     myBundle.setPowerServicesChannel(powerChannel);
   }
 }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -175,10 +175,16 @@ void Cable::assignPowerServicesChannels() {
     }
     const int semiPhiRegionIndex = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth, true);*/
 
-    const std::string subDetectorName = myBundle.subDetectorName();
-    const double phiMargin = ((subDetectorName == cabling_tedd1 || subDetectorName == cabling_tedd2) ? 5. : -1.) * M_PI / 180.;
-    const double phiLimit = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiMargin;
-    const bool isLower = moduloComp(meanPhi, phiLimit, 2.*M_PI);
+    const bool isBarrel = myBundle.isBarrel();
+
+    bool isLower;
+    if (isBarrel) { isLower = myBundle.isInLowerSemiPhiSectorStereo(); }
+    else {
+      const double phiMargin = ((!isBarrel) ? 5. : -1.) * M_PI / 180.;
+      const double phiLimit = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiMargin;
+      isLower = moduloComp(meanPhi, phiLimit, 2.*M_PI);
+    }
+
     const int semiPhiRegionIndex = (isLower ? 0 : 1);
     const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -10,11 +10,8 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
   isPositiveCablingSide_(isPositiveCablingSide)
 { 
   myid(id);
-  // ASSIGN A SERVICESCHANNEL TO THE CABLE
-  const std::tuple<int, ChannelSection, int>& servicesChannelInfo = computeOpticalServicesChannel(phiSectorRef, type, slot, isPositiveCablingSide);
-  opticalServicesChannel_ = std::get<0>(servicesChannelInfo);
-  opticalServicesChannelSection_ = std::get<1>(servicesChannelInfo);
-  opticalServicesChannelPlotColor_ = std::get<2>(servicesChannelInfo);
+  // ASSIGN AN OPTICAL SERVICESCHANNEL TO THE CABLE
+  ServicesChannel* opticalChannel_ = GeometryFactory::make<ServicesChannel>(phiSectorRef, type, slot, isPositiveCablingSide);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  
@@ -24,125 +21,6 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 Cable::~Cable() {
   delete myDTC_;       // TO DO: switch to smart pointers and remove this!
   myDTC_ = nullptr;
-}
-
-
-/* Compute optical services channels.
- * They are the channels where the optical cables are routed when they exit the tracker.
- * They are closely related to the phiSector ref.
- */
-const std::tuple<int, ChannelSection, int> Cable::computeOpticalServicesChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
-  int servicesChannel = 0;
-  ChannelSection servicesChannelSection = ChannelSection::B;
-
-  if (type == Category::PS10G) {
-    if (phiSectorRef == 0) { servicesChannel = 2;  }
-    else if (phiSectorRef == 1) { servicesChannel = 3; }
-    else if (phiSectorRef == 2) { servicesChannel = 5; }
-    else if (phiSectorRef == 3) { servicesChannel = 6; }
-    else if (phiSectorRef == 4) { servicesChannel = 7; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; }
-    else if (phiSectorRef == 6) { servicesChannel = 9; }
-    else if (phiSectorRef == 7) { servicesChannel = 11; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; }   
-  }
-
-  else if (type == Category::PS5G) {
-    if (phiSectorRef == 0) { servicesChannel = 1; }
-    else if (phiSectorRef == 1) { servicesChannel = 2; }
-    else if (phiSectorRef == 2) { servicesChannel = 4; }
-    else if (phiSectorRef == 3) { servicesChannel = 5; }
-    else if (phiSectorRef == 4) { servicesChannel = 7; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; }
-    else if (phiSectorRef == 6) { servicesChannel = 10; }
-    else if (phiSectorRef == 7) { servicesChannel = 11; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; }
-  }
-
-  else if (type == Category::SS) {
-    if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 1; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; }
-      else if (phiSectorRef == 8) { servicesChannel = 11; }
-    }
-    else if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 1; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; }
-      else if (phiSectorRef == 5) { servicesChannel = 7; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; }
-    }
-    else {
-      if (phiSectorRef == 0) { servicesChannel = 1; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; }
-      else if (phiSectorRef == 5) { servicesChannel = 7; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; }
-    }
-  }
-
-
-  // VERY IMPORTANT!
-  // COMPUTE SERVICES CHANNEL PLOT COLOR, FOR BOTH SIDES, BEFORE THE CHANNEL NUMBERING IS MIRRORED FOR (-Z) SIDE.
-  // THIS IS BECAUSE A GIVEN SERVICE CHANNEL IS IDENTICAL ALL ALONG Z (going from (+Z) to (-Z) side).
-  // HENCE, EVEN IF THE CHANNEL NUMBERING CAN BE DIFFERENT, WE DONT CARE, AND WE ACTUALLY WANT A GIVEN CHANNEL COLORED BY A UNIQUE COLOR!!
-  int servicesChannelPlotColor = computeOpticalServicesChannelPlotColor(servicesChannel, servicesChannelSection);
-
-
-  // NEGATIVE CABLING SIDE.
-  // A given services channel is simplified as a straight line all along (Z).
-  // THIS DEFINES THE CHANNEL NUMBERING ON THE (-Z) SIDE.
-
-  // OPTION A: 
-  // Channel 1A on (+Z) side becomes -1A on the (-Z) side, 1C on (+Z) side becomes -1C on (-Z) side, and so on.
-  if (!isPositiveCablingSide) {
-    servicesChannel *= -1;
-  }
-
-  // OPTION B (NOT PRESENTLY RETAINED)
-  /*
-  // This is the following transformation:
-  // 1 -> 6
-  // 2 -> 5
-  // 3 -> 4
-  // 7 -> 12
-  // 8 -> 11
-  // 9 -> 10
-  // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
-  // The services channel is then set to negative on negative cabling side.
-  if (!isPositiveCablingSide) {
-  double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
-  servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
-  servicesChannel *= -1;
-  servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
-  }*/
-
-  return std::make_tuple(servicesChannel, servicesChannelSection, servicesChannelPlotColor);
-}
-
-
-/* Compute color associated to services channel.
- * If section A, +12 is added so that the same color is used as scetion C, but that color can be set as transparent if desired.
- */
-const int Cable::computeOpticalServicesChannelPlotColor(const int servicesChannel, const ChannelSection& servicesChannelSection) const {
-  int plotColor = 0;
-  plotColor = servicesChannel;
-  if (servicesChannelSection == ChannelSection::A) plotColor += 12;
-  return plotColor;
 }
 
 
@@ -168,62 +46,9 @@ void Cable::assignPowerServicesChannels() {
     const int semiPhiRegionIndex = (isLower ? 0 : 1);
     const int semiPhiRegionRef = 2 * cablePhiSectorRef + semiPhiRegionIndex;
 
-    std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide_);
-    myBundle.setPowerServicesChannel(powerServicesChannel);
+    ServicesChannel* powerChannel = GeometryFactory::make<ServicesChannel>(semiPhiRegionRef, isPositiveCablingSide_);
+    myBundle.setPowerServicesChannel(powerChannel);
   }
-}
-
-
-std::pair<int, ChannelSection> Cable::computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
-
-  int servicesChannel = 0;
-  ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
-
-  if (isPositiveCablingSide) {
-    if (semiPhiRegionRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 2) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 3) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 4) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 5) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 6) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 7) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 8) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 9) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 10) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 11) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 12) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 13) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 14) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 15) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 16) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 17) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
-    else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
-  }
-
-  else {
-    if (semiPhiRegionRef == 0) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 1) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 2) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 3) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 4) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 5) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 6) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 7) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 8) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 9) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 10) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 11) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 12) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 13) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 14) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 15) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 16) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 17) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
-    else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
-  }
-
-  return std::make_pair(servicesChannel, servicesChannelSection);
 }
 
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -11,7 +11,7 @@ Cable::Cable(const int id, const double phiSectorWidth, const int phiSectorRef, 
 { 
   myid(id);
   // ASSIGN AN OPTICAL SERVICESCHANNEL TO THE CABLE
-  ServicesChannel* opticalChannel_ = GeometryFactory::make<OpticalChannel>(phiSectorRef, type, slot, isPositiveCablingSide);
+  opticalChannel_ = GeometryFactory::make<OpticalChannel>(phiSectorRef, type, slot, isPositiveCablingSide);
 
   // BUILD DTC ASOCIATED TO THE CABLE
   buildDTC(phiSectorWidth, phiSectorRef, type, slot, isPositiveCablingSide);  

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -160,40 +160,15 @@ const int Cable::computeServicesChannelPlotColor(const int servicesChannel, cons
 
 
 void Cable::assignPowerServicesChannels() {
-  /*std::vector<std::pair<int, double> > myBundlesPhis;
-    for (auto& myBundle : bundles_) {
-    const int bundleId = myBundle.myid();
-    const double bundlePhi = myBundle.meanPhi();
-    myBundlesPhis.push_back(std::make_pair(bundleId, bundlePhi));
-    }
-    std::sort(myBundlesPhis.begin(), myBundlesPhis.end(), 
-    [] (std::pair<int, double> a, std::pair<int, double> b) { 
-    return (moduloComp(a.second, b.second, 2.*M_PI)); 
-    } 
-    );*/
-
-
-  //for (auto& myBundle : bundles_) {
-  /*const int bundleId = myBundle.myid();
-    const int phiIndex = std::distance(myBundlesPhis.begin(), it);
-    const int semiPhiRegionIndex = (phiIndex <= 2 ? 0 : 1);
-    const int semiPhiRegionRef = 2 * phiSectorRef_ + semiPhiRegionIndex;
-    std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide_);
-    myBundle.setPowerServicesChannel(powerServicesChannel);
-    /*} 
-    else {
-    std::cout << "ERROR: bundle Id not found in my own bundles vector!" << std::endl;
-    }    */
-
-
   for (auto& myBundle : bundles_) {
 
     const double meanPhiPositiveSide = femod(myBundle.meanPhi(), 2.*M_PI);
-    const double meanPhiNegativeSide = femod(M_PI - meanPhiPositiveSide + cabling_semiNonantWidth, 2.*M_PI);
-    double meanPhi = (isPositiveCablingSide_ ? meanPhiPositiveSide : meanPhiNegativeSide);
+    //const double meanPhiNegativeSide = femod(M_PI - meanPhiPositiveSide + cabling_semiNonantWidth, 2.*M_PI);
+    //double meanPhi = (isPositiveCablingSide_ ? meanPhiPositiveSide : meanPhiNegativeSide);
+    double meanPhi = meanPhiPositiveSide;
 
     const int cablePhiSectorRefPositiveSide =  phiSectorRef_;
-    int cablePhiSectorRefNegativeSide = 0;
+    /*int cablePhiSectorRefNegativeSide = 0;
     if (cablePhiSectorRefPositiveSide == 0) cablePhiSectorRefNegativeSide = 4;
     else if (cablePhiSectorRefPositiveSide == 1) cablePhiSectorRefNegativeSide = 3;
     else if (cablePhiSectorRefPositiveSide == 2) cablePhiSectorRefNegativeSide = 2;
@@ -202,8 +177,9 @@ void Cable::assignPowerServicesChannels() {
     else if (cablePhiSectorRefPositiveSide == 5) cablePhiSectorRefNegativeSide = 8;
     else if (cablePhiSectorRefPositiveSide == 6) cablePhiSectorRefNegativeSide = 7;
     else if (cablePhiSectorRefPositiveSide == 7) cablePhiSectorRefNegativeSide = 6;
-    else if (cablePhiSectorRefPositiveSide == 8) cablePhiSectorRefNegativeSide = 5;
-    const int cablePhiSectorRef = (isPositiveCablingSide_ ? cablePhiSectorRefPositiveSide : cablePhiSectorRefNegativeSide);
+    else if (cablePhiSectorRefPositiveSide == 8) cablePhiSectorRefNegativeSide = 5;*/
+    //const int cablePhiSectorRef = (isPositiveCablingSide_ ? cablePhiSectorRefPositiveSide : cablePhiSectorRefNegativeSide);
+    const int cablePhiSectorRef = cablePhiSectorRefPositiveSide;
 
     /*double semiPhiRegionStart = cablePhiSectorRef * cabling_nonantWidth;
     if (fabs(meanPhi - semiPhiRegionStart) > M_PI) {
@@ -268,7 +244,7 @@ std::pair<int, ChannelSection> Cable::computePowerServicesChannel(const int semi
     servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
     }*/
 
-  else {
+  /*else {
     if (semiPhiRegionRef == 1) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
     else if (semiPhiRegionRef == 2) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
     else if (semiPhiRegionRef == 3) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
@@ -287,6 +263,29 @@ std::pair<int, ChannelSection> Cable::computePowerServicesChannel(const int semi
     else if (semiPhiRegionRef == 16) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
     else if (semiPhiRegionRef == 17) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
     else if (semiPhiRegionRef == 0) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
+    else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
+    }*/
+
+
+  else {
+    if (semiPhiRegionRef == 0) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 1) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 2) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 3) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 4) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 5) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 6) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 7) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 8) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 9) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 10) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 11) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 12) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 13) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 14) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 15) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 16) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 17) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
   }
 

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -149,38 +149,16 @@ const int Cable::computeServicesChannelPlotColor(const int servicesChannel, cons
 void Cable::assignPowerServicesChannels() {
   for (auto& myBundle : bundles_) {
 
-    const double meanPhiPositiveSide = femod(myBundle.meanPhi(), 2.*M_PI);
-    //const double meanPhiNegativeSide = femod(M_PI - meanPhiPositiveSide + cabling_semiNonantWidth, 2.*M_PI);
-    //double meanPhi = (isPositiveCablingSide_ ? meanPhiPositiveSide : meanPhiNegativeSide);
-    double meanPhi = meanPhiPositiveSide;
-
-    const int cablePhiSectorRefPositiveSide =  phiSectorRef_;
-    /*int cablePhiSectorRefNegativeSide = 0;
-    if (cablePhiSectorRefPositiveSide == 0) cablePhiSectorRefNegativeSide = 4;
-    else if (cablePhiSectorRefPositiveSide == 1) cablePhiSectorRefNegativeSide = 3;
-    else if (cablePhiSectorRefPositiveSide == 2) cablePhiSectorRefNegativeSide = 2;
-    else if (cablePhiSectorRefPositiveSide == 3) cablePhiSectorRefNegativeSide = 1;
-    else if (cablePhiSectorRefPositiveSide == 4) cablePhiSectorRefNegativeSide = 0;
-    else if (cablePhiSectorRefPositiveSide == 5) cablePhiSectorRefNegativeSide = 8;
-    else if (cablePhiSectorRefPositiveSide == 6) cablePhiSectorRefNegativeSide = 7;
-    else if (cablePhiSectorRefPositiveSide == 7) cablePhiSectorRefNegativeSide = 6;
-    else if (cablePhiSectorRefPositiveSide == 8) cablePhiSectorRefNegativeSide = 5;*/
-    //const int cablePhiSectorRef = (isPositiveCablingSide_ ? cablePhiSectorRefPositiveSide : cablePhiSectorRefNegativeSide);
-    const int cablePhiSectorRef = cablePhiSectorRefPositiveSide;
-
-    /*double semiPhiRegionStart = cablePhiSectorRef * cabling_nonantWidth;
-    if (fabs(meanPhi - semiPhiRegionStart) > M_PI) {
-      if (meanPhi < semiPhiRegionStart) meanPhi += 2.*M_PI;
-      else semiPhiRegionStart += 2.*M_PI;
-    }
-    const int semiPhiRegionIndex = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth, true);*/
+    const double meanPhi = femod(myBundle.meanPhi(), 2.*M_PI);
+    const int cablePhiSectorRef = phiSectorRef_;
 
     const bool isBarrel = myBundle.isBarrel();
+    const Category& type = type_;
 
     bool isLower;
     if (isBarrel) { isLower = myBundle.isInLowerSemiPhiSectorStereo(); }
     else {
-      const double phiMargin = ((!isBarrel) ? 5. : -1.) * M_PI / 180.;
+      const double phiMargin = ((type == Category::SS) ? 5. : -5.) * M_PI / 180.;
       const double phiLimit = cablePhiSectorRef * cabling_nonantWidth + cabling_semiNonantWidth + phiMargin;
       isLower = moduloComp(meanPhi, phiLimit, 2.*M_PI);
     }

--- a/src/Cabling/Cable.cc
+++ b/src/Cabling/Cable.cc
@@ -36,11 +36,11 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
 
   if (type == Category::PS10G) {
-    if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
-    else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+    if (phiSectorRef == 0) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
+    else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
     else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
     else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
     else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
@@ -48,18 +48,6 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
   }
 
   else if (type == Category::PS5G) {
-    if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 8) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
-    }
-    else {
       if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
@@ -69,16 +57,15 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
       else if (phiSectorRef == 6) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
-    }
   }
 
   else if (type == Category::SS) {
     if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 1) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 2) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 4) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
+      if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
@@ -88,11 +75,11 @@ const std::tuple<int, ChannelSection, int> Cable::computeServicesChannel(const i
       if (phiSectorRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 2) { servicesChannel = 3; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 4) { servicesChannel = 6; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 5) { servicesChannel = 7; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 6) { servicesChannel = 9; servicesChannelSection = ChannelSection::B; }
-      else if (phiSectorRef == 7) { servicesChannel = 11; servicesChannelSection = ChannelSection::B; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; servicesChannelSection = ChannelSection::B; }
       else if (phiSectorRef == 8) { servicesChannel = 12; servicesChannelSection = ChannelSection::B; }
     }
     else {

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -105,7 +105,7 @@ void CablingMap::computePowerServicesChannels(std::map<int, Bundle*>& bundles, s
     const double meanPhiOfficial = b.second->meanPhi();
     const double meanPhi = (isPositiveCablingSide ? meanPhiOfficial : (M_PI - meanPhiOfficial));
     const double semiPhiRegionStart = 0.;
-    const int semiPhiRegionRef = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth, true);
+    const int semiPhiRegionRef = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth);
 
     std::pair<int, ChannelSlot> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide);
     b.second->setPowerServicesChannel(powerServicesChannel);*/

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -97,7 +97,7 @@ void CablingMap::assignBundlesStereoSemiBoundaries(std::map<int, Bundle*>& bundl
 void CablingMap::computePowerServicesChannels(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables) {
 
   for (auto& c : cables) {
-    c.second->assignPowerServicesChannels();
+    c.second->assignPowerChannelSections();
 
     /*
     const bool isPositiveCablingSide = b.second->isPositiveCablingSide();
@@ -107,7 +107,7 @@ void CablingMap::computePowerServicesChannels(std::map<int, Bundle*>& bundles, s
     const double semiPhiRegionStart = 0.;
     const int semiPhiRegionRef = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth, true);
 
-    std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide);
+    std::pair<int, ChannelSlot> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide);
     b.second->setPowerServicesChannel(powerServicesChannel);*/
   }
 
@@ -373,14 +373,15 @@ void CablingMap::connectOneBundleToOneCable(Bundle* bundle, Cable* cable) const 
 
 
 void CablingMap::checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles) {
-  std::map<std::pair<const int, const ChannelSection >, int > channels;
+  std::map<std::pair<const int, const ChannelSlot >, int > channels;
   for (auto& b : bundles) {
-    const int servicesChannel = b.second->powerServicesChannel();
-    const ChannelSection servicesChannelSection = b.second->powerServicesChannelSection();
+    const ChannelSection* mySection = b.second->powerChannelSection();
+    const int myChannelNumber = mySection->channelNumber();
+    const ChannelSlot& myChannelSlot = mySection->channelSlot();
 
-    if (fabs(servicesChannel) == 0 || fabs(servicesChannel) > cabling_numServicesChannels) std::cout << "ERROR: power servicesChannel = " << servicesChannel << std::endl;
-    if (servicesChannelSection != ChannelSection::A && servicesChannelSection != ChannelSection::C) std::cout << "ERROR: power servicesChannelSection = " << servicesChannelSection << std::endl;
-    std::pair<const int, const ChannelSection > myChannel = std::make_pair(servicesChannel, servicesChannelSection);
+    if (fabs(myChannelNumber) == 0 || fabs(myChannelNumber) > cabling_numServicesChannels) std::cout << "ERROR: power myChannelNumber = " << myChannelNumber << std::endl;
+    if (myChannelSlot != ChannelSlot::A && myChannelSlot != ChannelSlot::C) std::cout << "ERROR: power myChannelSlot = " << myChannelSlot << std::endl;
+    std::pair<const int, const ChannelSlot > myChannel = std::make_pair(myChannelNumber, myChannelSlot);
     channels[myChannel] += 1;
   }
 

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -35,8 +35,8 @@ void CablingMap::connectModulesToBundles(Tracker* tracker) {
 
 
 void CablingMap::assignBundlesStereoSemiBoundaries(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& complementaryBundles) {
-  int phiSectorRefMarker = 0;
-  int complementaryPhiSectorRefMarker = 0;
+  int phiSectorRefMarker = -1;
+  int complementaryPhiSectorRefMarker = -1;
 
   for (auto& b : bundles) {
     Bundle* myBundle = b.second;

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -378,14 +378,14 @@ void CablingMap::checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bun
     const int servicesChannel = b.second->powerServicesChannel();
     const ChannelSection servicesChannelSection = b.second->powerServicesChannelSection();
 
-    if (fabs(servicesChannel) == 0 || fabs(servicesChannel) >= 13) std::cout << "ERROR: power servicesChannel = " << servicesChannel << std::endl;
+    if (fabs(servicesChannel) == 0 || fabs(servicesChannel) > cabling_numServicesChannels) std::cout << "ERROR: power servicesChannel = " << servicesChannel << std::endl;
     if (servicesChannelSection != ChannelSection::A && servicesChannelSection != ChannelSection::C) std::cout << "ERROR: power servicesChannelSection = " << servicesChannelSection << std::endl;
     std::pair<const int, const ChannelSection > myChannel = std::make_pair(servicesChannel, servicesChannelSection);
     channels[myChannel] += 1;
   }
 
   for (const auto& c : channels) { 
-    if (c.second > 48) std::cout << "Power services channel " << c.first.first << " section " << c.first.second << " has " << c.second << " bundles." << std::endl;
+    if (c.second > cabling_maxNumPowerCablesPerChannel) std::cout << "Power services channel " << c.first.first << " section " << c.first.second << " has " << c.second << " bundles." << std::endl;
   }
 }
 

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -385,7 +385,7 @@ void CablingMap::checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bun
   }
 
   for (const auto& c : channels) { 
-    if (c.second > 36) std::cout << "Power services channel " << c.first.first << " section " << c.first.second << " has " << c.second << " bundles." << std::endl;
+    if (c.second > 48) std::cout << "Power services channel " << c.first.first << " section " << c.first.second << " has " << c.second << " bundles." << std::endl;
   }
 }
 

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -317,8 +317,6 @@ void CablingMap::checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bun
     const int servicesChannel = b.second->powerServicesChannel();
     const ChannelSection servicesChannelSection = b.second->powerServicesChannelSection();
 
-    std::cout << "Power services channel " << servicesChannel   << " section " << servicesChannelSection << std::endl;
-
     if (fabs(servicesChannel) == 0 || fabs(servicesChannel) >= 13) std::cout << "ERROR: power servicesChannel = " << servicesChannel << std::endl;
     if (servicesChannelSection != ChannelSection::A && servicesChannelSection != ChannelSection::C) std::cout << "ERROR: power servicesChannelSection = " << servicesChannelSection << std::endl;
     std::pair<const int, const ChannelSection > myChannel = std::make_pair(servicesChannel, servicesChannelSection);

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -11,12 +11,8 @@ CablingMap::CablingMap(Tracker* tracker) {
     connectBundlesToCables(bundles_, cables_, DTCs_);
     connectBundlesToCables(negBundles_, negCables_, negDTCs_);
 
-    assignBundlesStereoSemiBoundaries(bundles_, negBundles_);
-    assignBundlesStereoSemiBoundaries(negBundles_, bundles_);
-
-    // COMPUTE POWER SERVICES CHANNELS
-    computePowerServicesChannels(bundles_, cables_);
-    computePowerServicesChannels(negBundles_, negCables_);
+    // COMPUTE SERVICES CHANNELS ASSIGNMENTS OF POWER CABLES
+    computePowerServicesChannels();
   }
 
   catch (PathfulException& pe) { pe.pushPath(fullid(*this)); throw; }
@@ -32,89 +28,6 @@ void CablingMap::connectModulesToBundles(Tracker* tracker) {
   bundles_ = bundlesBuilder.getBundles();
   negBundles_ = bundlesBuilder.getNegBundles();
 }
-
-
-void CablingMap::assignBundlesStereoSemiBoundaries(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& complementaryBundles) {
-  int phiSectorRefMarker = -1;
-  int complementaryPhiSectorRefMarker = -1;
-
-  for (auto& b : bundles) {
-    Bundle* myBundle = b.second;
-    const bool isBarrel = myBundle->isBarrel();
-    const bool isPSFlatPart = myBundle->isPSFlatPart();
-
-    if (isBarrel && !isPSFlatPart) {
-      bool isLower;
-
-      const int phiSectorRef = myBundle->getCable()->phiSectorRef();
-      if (phiSectorRef != phiSectorRefMarker) {
-	phiSectorRefMarker = phiSectorRef;
-	complementaryPhiSectorRefMarker = -1;
-	isLower = true;
-      }
-
-      const int complementaryBundleId = myBundle->complementaryBundleId();
-      auto found = complementaryBundles.find(complementaryBundleId);
-      if (found != complementaryBundles.end()) {
-	Bundle* myComplementaryBundle = found->second;
-	const int complementaryPhiSectorRef = myComplementaryBundle->getCable()->phiSectorRef();
-	
-	if (complementaryPhiSectorRefMarker != -1 && complementaryPhiSectorRefMarker != complementaryPhiSectorRef) isLower = false;
-	myBundle->setIsInLowerSemiPhiSectorStereo(isLower);
-	complementaryPhiSectorRefMarker = complementaryPhiSectorRef;
-      }
-      else { std::cout << "Coud not find complementary bundle id " << complementaryBundleId << std::endl; }
-    }
-  }
-
-
-  for (auto& b : bundles) {
-    Bundle* myBundle = b.second;
-    const bool isBarrel = myBundle->isBarrel();
-    const bool isPSFlatPart = myBundle->isPSFlatPart();
-
-    if (isBarrel && isPSFlatPart) {
-      const int bundleId = myBundle->myid();
-      const int tiltedBundleId = bundleId - femod(bundleId, 10);
- 
-      auto found = bundles.find(tiltedBundleId);
-      if (found != bundles.end()) {
-	Bundle* myTiltedBundle = found->second;
-	const bool isLower = myTiltedBundle->isInLowerSemiPhiSectorStereo();
-	myBundle->setIsInLowerSemiPhiSectorStereo(isLower);
-      }
-      else { std::cout << "Coud not find tilted bundle id " << tiltedBundleId << std::endl; }
-    }
-  }
-
-
-}
-
-
-
-/* BUNDLES TO POWER SERVICE CHANNELS CONNECTIONS.
- */
-void CablingMap::computePowerServicesChannels(std::map<int, Bundle*>& bundles, std::map<int, Cable*>& cables) {
-
-  for (auto& c : cables) {
-    c.second->assignPowerChannelSections();
-
-    /*
-    const bool isPositiveCablingSide = b.second->isPositiveCablingSide();
-
-    const double meanPhiOfficial = b.second->meanPhi();
-    const double meanPhi = (isPositiveCablingSide ? meanPhiOfficial : (M_PI - meanPhiOfficial));
-    const double semiPhiRegionStart = 0.;
-    const int semiPhiRegionRef = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth);
-
-    std::pair<int, ChannelSlot> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide);
-    b.second->setPowerServicesChannel(powerServicesChannel);*/
-  }
-
-  // CHECK POWER SERVICES CHANNELS
-  checkBundlesToPowerServicesChannels(bundles);
-}
-
 
 
 /* BUNDLES TO CABLES CONNECTIONS.
@@ -372,25 +285,6 @@ void CablingMap::connectOneBundleToOneCable(Bundle* bundle, Cable* cable) const 
 }
 
 
-void CablingMap::checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles) {
-  std::map<std::pair<const int, const ChannelSlot >, int > channels;
-  for (auto& b : bundles) {
-    const ChannelSection* mySection = b.second->powerChannelSection();
-    const int myChannelNumber = mySection->channelNumber();
-    const ChannelSlot& myChannelSlot = mySection->channelSlot();
-
-    if (fabs(myChannelNumber) == 0 || fabs(myChannelNumber) > cabling_numServicesChannels) std::cout << "ERROR: power myChannelNumber = " << myChannelNumber << std::endl;
-    if (myChannelSlot != ChannelSlot::A && myChannelSlot != ChannelSlot::C) std::cout << "ERROR: power myChannelSlot = " << myChannelSlot << std::endl;
-    std::pair<const int, const ChannelSlot > myChannel = std::make_pair(myChannelNumber, myChannelSlot);
-    channels[myChannel] += 1;
-  }
-
-  for (const auto& c : channels) { 
-    if (c.second > cabling_maxNumPowerCablesPerChannel) std::cout << "Power services channel " << c.first.first << " section " << c.first.second << " has " << c.second << " bundles." << std::endl;
-  }
-}
-
-
 /* Check bundles-cables connections.
  */
 void CablingMap::checkBundlesToCablesCabling(std::map<int, Cable*>& cables) {
@@ -415,6 +309,199 @@ void CablingMap::checkBundlesToCablesCabling(std::map<int, Cable*>& cables) {
 	       );
     }
 
+  }
+}
+
+
+/* BUNDLES TO POWER SERVICE CHANNELS CONNECTIONS.
+ * VERY IMPORTANT: connection scheme from modules to optical bundles = connection scheme from modules to power cables.
+ * As a result, 1 single Bundle object is used for both schemes.
+ * Regarding the connections to services channels, each Bundle is then assigned:
+ * - 1 Optical Services Channel Section (considering the Bundle as an optical Bundle);
+ * - 1 Power Services Channels section (making as if the Bundle is a power cable);
+ * 
+ * The optical channel mapping is done so that all bundles connected to the same DTC,
+ * are routed through the same channel.
+ *
+ * The assignments of power cables to services channels must be done after the bundles to DTCs connections are established.
+ * Indeed, the power channel mapping is done so that all modules connected to the same DTC, 
+ * have their power cables routed through 2 consecutive channels sections at most.
+ */
+void CablingMap::computePowerServicesChannels() {
+  for (bool isPositiveCablingSide : { true, false }) {
+
+    // BARREL ONLY: IN VIEW OF THE POWER CHANNEL ASSIGNMENT, SPLIT EACH NONANT INTO 2 SEMI-NONANTS
+    routeBarrelBundlesPoweringToSemiNonants(isPositiveCablingSide);
+ 
+    // ASSIGN POWER SERVICES CHANNELS
+    std::map<int, Cable*>& cables = (isPositiveCablingSide ? cables_ : negCables_);
+    for (auto& c : cables) {
+      c.second->assignPowerChannelSections();
+    }
+
+    // CHECK POWER SERVICES CHANNELS
+    const std::map<int, Bundle*>& bundles = (isPositiveCablingSide ? bundles_ : negBundles_);
+    checkBundlesToPowerServicesChannels(bundles);
+  }
+}
+
+
+/* Barrel only: in view of the power channel assignment, split each nonant into 2 semi-nonants.
+   The cooling pipes design should be invariant by rotation of 180° around CMS_Y, to avoid different cooling designs on both (Z) side.
+   The cooling pipes and power cables are assigned to similar channels slots (A or C).
+   As a result, the channel assignmennt of power cables need to follow the same symmetry as the cooling pipes.
+   Hence, the CHANNEL ASSIGNMENNT OF POWER CABLES NEED TO BE INVARIANT BY ROTATION OF 180DEG AROUND CMS_Y.
+   This is a priori not trivial, since the power cables scheme follow the bundles scheme, hence the optical map mirror symmetry.
+   This is only possible if, for each phi nonant, one define a semi-nonant Phi boundary in a certain way.
+   This is what is done here: the semi-nonant Phi boundaries are defined
+   so that ALL NONANTS AND SEMI-NONANTS PHI BOUNDARIES ARE INVARIANT BY ROTATION OF 180° AROUND CMS_Y.
+ */
+void CablingMap::routeBarrelBundlesPoweringToSemiNonants(const bool isPositiveCablingSide) {
+  std::map<int, Bundle*>& bundles = (isPositiveCablingSide ? bundles_ : negBundles_);
+  const std::map<int, Bundle*>& stereoBundles = (isPositiveCablingSide ? negBundles_ : bundles_);
+
+  // phiSectorRefMarker keeps track of the Phi nonant we are in.
+  int phiSectorRefMarker = -1;
+  // phiSectorRefMarker keeps track of the stereo Phi nonant we are in.
+  // 'stereo' means on the other cabling side, by a rotation of 180° around CMS_Y.
+  int stereoPhiSectorRefMarker = -1;
+
+  // TILTED PART OF TBPS + TB2S
+  // Loop on all bundles of a given cabling side (sorted by their BundleIds).
+  for (auto& b : bundles) {
+    Bundle* myBundle = b.second;
+    const bool isBarrel = myBundle->isBarrel();
+    const bool isPSFlatPart = myBundle->isPSFlatPart();
+
+    // Only for Barrel: tilted TBPS, or TB2S.
+    if (isBarrel && !isPSFlatPart) {
+      // Should the bundle be assigned to the lower or upper semi-nonant ?
+      // 'lower' and 'upper' are defined by 'smaller' or 'bigger' Phi, 
+      // in the trigonometric sense in the (XY) plane in CMS global frame of reference.
+      bool isLower; // what we want to compute!
+
+      // Identifier of the Phi nonant we are in.
+      const int phiSectorRef = myBundle->getCable()->phiSectorRef();
+      // In case of a switch to a different Phi nonant, initialize variables.
+      if (phiSectorRef != phiSectorRefMarker) {	
+	phiSectorRefMarker = phiSectorRef;
+	// Starts by assigning to bundle to the lower semi-nonant.
+	isLower = true;
+	stereoPhiSectorRefMarker = -1;	
+      }
+
+      // Get the bundle located on the other cabling side, by a rotation of 180° around CMS_Y.
+      const int stereoBundleId = myBundle->stereoBundleId();
+      auto found = stereoBundles.find(stereoBundleId);
+      if (found != stereoBundles.end()) {
+	const Bundle* myStereoBundle = found->second;
+	// Get the Phi nonant in which the stereoBundle is located.
+	const int stereoPhiSectorRef = myStereoBundle->getCable()->phiSectorRef();
+	
+	// Decisive point!! 
+	// As soon as a change in the identifier of the stereoBundle Phi nonant is detected,
+	// one assigns the bundle to the upper semi-nonant.
+	if (stereoPhiSectorRefMarker != -1 && stereoPhiSectorRefMarker != stereoPhiSectorRef) isLower = false;
+
+	// Lastly, assign the semi-nonant attribution decision to the bundle.
+	myBundle->setIsPowerRoutedToBarrelLowerSemiNonant(isLower);
+
+	// Keeps track of the Phi nonant in which the stereoBundle is located.
+	stereoPhiSectorRefMarker = stereoPhiSectorRef;
+      }
+      else {
+	logERROR(any2str("Could not find stereo bundle, id ") 
+		    + any2str(stereoBundleId)
+		    );
+      }
+    }
+
+    // NB: All this is possible because the bundles and stereoBundles are sorted by their Ids.
+    // One relies on 2 characteristics of the BundleId scheme:
+    // - all Bundles connected to the same DTC will have consecutive Ids.
+    // - the Id increment is in Phi, in the (XY) plane in CMS global frame of reference.
+  }
+
+
+  // FLAT PART OF TBPS
+  // For a given bundle, connected to untilted modules:
+  // Take the same semi-nonant assignment as the bundle located at the same Phi and connected to the tilted modules.
+
+  // Loop on all bundles of a given cabling side (sorted by their BundleIds).
+  for (auto& b : bundles) {
+    Bundle* myBundle = b.second;
+    const bool isBarrel = myBundle->isBarrel();
+    const bool isPSFlatPart = myBundle->isPSFlatPart();
+
+    // Only for Barrel: flat part of TBPS
+    if (isBarrel && isPSFlatPart) {
+      const int tiltedBundleId = myBundle->tiltedBundleId();
+ 
+      // Get the bundle located at the same Phi, but connected to the tilted modules.
+      auto found = bundles.find(tiltedBundleId);
+      if (found != bundles.end()) {
+	const Bundle* myTiltedBundle = found->second;
+
+	// Decisive point!!
+	// Get the semi-nonant attribution of the tiltedBundle.
+	const bool isLower = myTiltedBundle->isPowerRoutedToBarrelLowerSemiNonant();
+
+	// Lastly, assign the semi-nonant attribution decision to the bundle.
+	myBundle->setIsPowerRoutedToBarrelLowerSemiNonant(isLower);
+      }
+      else {
+	logERROR(any2str("Could not find bundle connected to tilted modules, id ") 
+		 + any2str(tiltedBundleId)
+		 );
+      }
+    }
+  }
+
+}
+
+
+/* Check services channels sections containing power cables.
+ */
+void CablingMap::checkBundlesToPowerServicesChannels(const std::map<int, Bundle*>& bundles) {
+  std::map<std::pair<const int, const ChannelSlot>, int > channels;
+
+  for (auto& b : bundles) {
+    const ChannelSection* mySection = b.second->powerChannelSection();
+    const int myChannelNumber = mySection->channelNumber();
+    const ChannelSlot& myChannelSlot = mySection->channelSlot();
+
+    // Check channel number.
+    if (fabs(myChannelNumber) == 0 || fabs(myChannelNumber) > cabling_numServicesChannels) {
+      logERROR(any2str("Invalid channel number = ")
+	       + any2str(myChannelNumber)
+	       + any2str(". Should not be 0 or have abs value > ")
+	       + any2str(cabling_numServicesChannels) + any2str(".")
+	       );
+    }
+    // Check channel slot.
+    if (myChannelSlot != ChannelSlot::A && myChannelSlot != ChannelSlot::C) {
+      logERROR(any2str("Power cable: Invalid channel slot = ") 
+	       + any2str(myChannelSlot)
+	       + any2str(". Should be ") + any2str(ChannelSlot::A)
+	       + any2str(" or ") + any2str(ChannelSlot::C) + any2str(".")
+	       );
+    }
+
+    // Compute number of power cables per channel section.
+    std::pair<const int, const ChannelSlot> myChannel = std::make_pair(myChannelNumber, myChannelSlot);
+    channels[myChannel] += 1;
+  }
+
+  // Check number of power cables per channel section.
+  for (const auto& c : channels) { 
+    if (c.second > cabling_maxNumPowerCablesPerChannel) {
+      logERROR(any2str("Services channel ") + any2str(c.first.first) 
+	       + any2str(" section ") + any2str(c.first.second) 
+	       + any2str(" has " ) + any2str(c.second) + any2str(" power cables.")
+	       + any2str(" Max number of power cables per channel section is ") 
+	       + any2str(cabling_maxNumPowerCablesPerChannel)
+	       );
+    }
   }
 }
 

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -7,6 +7,10 @@ CablingMap::CablingMap(Tracker* tracker) {
     // CONNECT MODULES TO BUNDLES
     connectModulesToBundles(tracker);
 
+    // ASSIGN POWER SERVICES CHANNELS
+    connectBundlesToPowerServicesChannels(bundles_);
+    connectBundlesToPowerServicesChannels(negBundles_);
+
     // CONNECT BUNDLES TO CABLES
     connectBundlesToCables(bundles_, cables_, DTCs_);
     connectBundlesToCables(negBundles_, negCables_, negDTCs_);
@@ -24,6 +28,72 @@ void CablingMap::connectModulesToBundles(Tracker* tracker) {
   bundlesBuilder.postVisit();
   bundles_ = bundlesBuilder.getBundles();
   negBundles_ = bundlesBuilder.getNegBundles();
+}
+
+
+/* BUNDLES TO POWER SERVICE CHANNELS CONNECTIONS.
+ */
+void CablingMap::connectBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles) {
+
+  for (auto& b : bundles) {
+    const bool isPositiveCablingSide = b.second->isPositiveCablingSide();
+
+    const double meanPhiOfficial = b.second->meanPhi();
+    const double meanPhi = (isPositiveCablingSide ? meanPhiOfficial : (M_PI - meanPhiOfficial));
+    const double semiPhiRegionStart = 0.;
+    const int semiPhiRegionRef = computePhiSliceRef(meanPhi, semiPhiRegionStart, cabling_semiNonantWidth, true);
+
+    std::pair<int, ChannelSection> powerServicesChannel = computePowerServicesChannel(semiPhiRegionRef, isPositiveCablingSide);
+    b.second->setPowerServicesChannel(powerServicesChannel);
+  }
+
+  // CHECK POWER SERVICES CHANNELS
+  checkBundlesToPowerServicesChannels(bundles);
+}
+
+
+std::pair<int, ChannelSection> CablingMap::computePowerServicesChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
+
+  int servicesChannel = 0;
+  ChannelSection servicesChannelSection = ChannelSection::B;
+
+  if (semiPhiRegionRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
+  else if (semiPhiRegionRef == 2) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 3) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 4) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
+  else if (semiPhiRegionRef == 5) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 6) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 7) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
+  else if (semiPhiRegionRef == 8) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 9) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 10) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
+  else if (semiPhiRegionRef == 11) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 12) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 13) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
+  else if (semiPhiRegionRef == 14) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 15) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
+  else if (semiPhiRegionRef == 16) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
+  else if (semiPhiRegionRef == 17) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
+  else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
+
+  // This is the following transformation:
+  // 1 -> 6
+  // 2 -> 5
+  // 3 -> 4
+  // 7 -> 12
+  // 8 -> 11
+  // 9 -> 10
+  // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
+  // The services channel is then set to negative on negative cabling side.
+  if (!isPositiveCablingSide) {
+    const double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
+    servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
+    servicesChannel *= -1;
+    servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
+  }
+
+  return std::make_pair(servicesChannel, servicesChannelSection);
 }
 
 
@@ -282,6 +352,23 @@ void CablingMap::connectOneBundleToOneCable(Bundle* bundle, Cable* cable) const 
 }
 
 
+void CablingMap::checkBundlesToPowerServicesChannels(std::map<int, Bundle*>& bundles) {
+  std::map<std::pair<const int, const ChannelSection >, int > channels;
+  for (auto& b : bundles) {
+    const int& servicesChannel = b.second->powerServicesChannel();
+    const ChannelSection& servicesChannelSection = b.second->powerServicesChannelSection();
+    if (servicesChannel == 0 || servicesChannel >= 13) std::cout << "ERROR: power servicesChannel = " << servicesChannel << std::endl;
+    if (servicesChannelSection != ChannelSection::A && servicesChannelSection != ChannelSection::C) std::cout << "ERROR: power servicesChannelSection = " << servicesChannelSection << std::endl;
+    std::pair<const int, const ChannelSection > myChannel = std::make_pair(servicesChannel, servicesChannelSection);
+    channels[myChannel] += 1;
+  }
+
+  for (const auto& c : channels) { 
+    if (c.second > 36) std::cout << "Power services channel " << c.first.first << " section " << c.first.second << " has " << c.second << " bundles." << std::endl;
+  }
+}
+
+
 /* Check bundles-cables connections.
  */
 void CablingMap::checkBundlesToCablesCabling(std::map<int, Cable*>& cables) {
@@ -308,3 +395,4 @@ void CablingMap::checkBundlesToCablesCabling(std::map<int, Cable*>& cables) {
 
   }
 }
+

--- a/src/Cabling/CablingMap.cc
+++ b/src/Cabling/CablingMap.cc
@@ -371,10 +371,10 @@ void CablingMap::routeBarrelBundlesPoweringToSemiNonants(const bool isPositiveCa
   for (auto& b : bundles) {
     Bundle* myBundle = b.second;
     const bool isBarrel = myBundle->isBarrel();
-    const bool isPSFlatPart = myBundle->isPSFlatPart();
+    const bool isBarrelPSFlatPart = myBundle->isBarrelPSFlatPart();
 
     // Only for Barrel: tilted TBPS, or TB2S.
-    if (isBarrel && !isPSFlatPart) {
+    if (isBarrel && !isBarrelPSFlatPart) {
       // Should the bundle be assigned to the lower or upper semi-nonant ?
       // 'lower' and 'upper' are defined by 'smaller' or 'bigger' Phi, 
       // in the trigonometric sense in the (XY) plane in CMS global frame of reference.
@@ -430,11 +430,10 @@ void CablingMap::routeBarrelBundlesPoweringToSemiNonants(const bool isPositiveCa
   // Loop on all bundles of a given cabling side (sorted by their BundleIds).
   for (auto& b : bundles) {
     Bundle* myBundle = b.second;
-    const bool isBarrel = myBundle->isBarrel();
-    const bool isPSFlatPart = myBundle->isPSFlatPart();
+    const bool isBarrelPSFlatPart = myBundle->isBarrelPSFlatPart();
 
     // Only for Barrel: flat part of TBPS
-    if (isBarrel && isPSFlatPart) {
+    if (isBarrelPSFlatPart) {
       const int tiltedBundleId = myBundle->tiltedBundleId();
  
       // Get the bundle located at the same Phi, but connected to the tilted modules.

--- a/src/Cabling/ModulesToBundlesConnector.cc
+++ b/src/Cabling/ModulesToBundlesConnector.cc
@@ -65,7 +65,7 @@ void ModulesToBundlesConnector::visit(BarrelModule& m) {
   }
 
   // NOW THAT ALL INFORMATION HAS BEEN GATHERED, COMPUTE PHIPOSITION.
-  const PhiPosition& modulePhiPosition = PhiPosition(rodPhi_, numRods_, isPositiveCablingSide, isBarrel_, layerNumber_);
+  const PhiPosition& modulePhiPosition = PhiPosition(rodPhi_, numRods_, isBarrel_, layerNumber_);
 
   // BUILD BUNDLE IF NECESSARY, AND CONNECT MODULE TO BUNDLE
   buildBundle(m, bundles_, negBundles_, bundleType_, isBarrel_, barrelName_, layerNumber_, modulePhiPosition, isPositiveCablingSide, totalNumFlatRings_, isTilted, isExtraFlatPart);
@@ -98,7 +98,7 @@ void ModulesToBundlesConnector::visit(EndcapModule& m) {
   bool isPositiveCablingSide = side_;    // Alyways true in the Endcaps : cabling side and geometrical side are the same.
 
   // NOW THAT ALL INFORMATION HAS BEEN GATHERED, COMPUTE PHIPOSITION.
-  const PhiPosition& modulePhiPosition = PhiPosition(modPhi, numModulesInRing_, isPositiveCablingSide, isBarrel_, diskNumber_, endcapName_, bundleType_);
+  const PhiPosition& modulePhiPosition = PhiPosition(modPhi, numModulesInRing_, isBarrel_, diskNumber_, endcapName_, bundleType_);
 
   // BUILD BUNDLE IF NECESSARY, AND CONNECT MODULE TO BUNDLE
   buildBundle(m, bundles_, negBundles_, bundleType_, isBarrel_, endcapName_, diskNumber_, modulePhiPosition, isPositiveCablingSide);
@@ -123,8 +123,8 @@ void ModulesToBundlesConnector::postVisit() {
 */
 const bool ModulesToBundlesConnector::computeBarrelFlatPartRodCablingSide(const double rodPhi, const double phiSegmentWidth) const {
   // Compute the phi position of the rod (in one cabling side frame of reference).
-  const double phiSegmentStartOneCablingSide = computePhiSegmentStart(rodPhi, phiSegmentWidth, true);
-  const int phiSegmentRefOneCablingSide = computePhiSegmentRef(rodPhi, phiSegmentStartOneCablingSide, phiSegmentWidth, true);
+  const double phiSegmentStartOneCablingSide = computePhiSegmentStart(rodPhi, phiSegmentWidth);
+  const int phiSegmentRefOneCablingSide = computePhiSegmentRef(rodPhi, phiSegmentStartOneCablingSide, phiSegmentWidth);
   // Assign the full rod to the positive cabling side or the negative cabling side alternatively.
   const bool isPositiveCablingSide = ((phiSegmentRefOneCablingSide % 2) == 1);
   return isPositiveCablingSide;

--- a/src/Cabling/ModulesToBundlesConnector.cc
+++ b/src/Cabling/ModulesToBundlesConnector.cc
@@ -185,6 +185,9 @@ void ModulesToBundlesConnector::buildBundle(DetectorModule& m, std::map<int, Bun
   const int phiSliceRef = (isBarrel ? modulePhiPosition.phiSegmentRef() : modulePhiPosition.phiRegionRef());
   const int bundleId = computeBundleId(isBarrel, isPositiveCablingSide, layerDiskNumber, phiSliceRef, bundleTypeIndex);
 
+  const int complemetaryPhiSliceRef = (isBarrel ? modulePhiPosition.complementaryPhiSegmentRef() : 0); //modulePhiPosition.complementaryPhiRegionRef());
+  const int complementaryBundleId = computeComplementaryBundleId(isBarrel, isPositiveCablingSide, layerDiskNumber, complemetaryPhiSliceRef, bundleTypeIndex);
+
   // bundles map
   const std::map<int, Bundle*>& stereoBundles = (isPositiveCablingSide ? bundles : negBundles);
 
@@ -192,7 +195,7 @@ void ModulesToBundlesConnector::buildBundle(DetectorModule& m, std::map<int, Bun
   Bundle* bundle = nullptr;
   auto found = stereoBundles.find(bundleId);
   if (found == stereoBundles.end()) {
-    bundle = createAndStoreBundle(bundles, negBundles, bundleId, bundleType, subDetectorName, layerDiskNumber, modulePhiPosition, isPositiveCablingSide, isTiltedPart);
+    bundle = createAndStoreBundle(bundles, negBundles, bundleId, complementaryBundleId, bundleType, subDetectorName, layerDiskNumber, modulePhiPosition, isPositiveCablingSide, isTiltedPart);
   }
   else {
     bundle = found->second;
@@ -248,12 +251,22 @@ const int ModulesToBundlesConnector::computeBundleId(const bool isBarrel, const 
 }
 
 
+/* Compute the Id associated to each complementary bundle.
+ */
+const int ModulesToBundlesConnector::computeComplementaryBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int complementaryPhiRef, const int bundleTypeIndex) const {
+  const bool complementarySide = !isPositiveCablingSide;
+  const int complementaryBundleId = computeBundleId(isBarrel, complementarySide, layerDiskNumber, complementaryPhiRef, bundleTypeIndex);
+
+  return complementaryBundleId;
+}
+
+
 /* Create a bundle, if it does not exist yet.
  *  Store it in the bundles_ or negBundles_ containers.
  */
-Bundle* ModulesToBundlesConnector::createAndStoreBundle(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const int bundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart) {
+Bundle* ModulesToBundlesConnector::createAndStoreBundle(std::map<int, Bundle*>& bundles, std::map<int, Bundle*>& negBundles, const int bundleId, const int complementaryBundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart) {
 
-  Bundle* bundle = GeometryFactory::make<Bundle>(bundleId, bundleType, subDetectorName, layerDiskNumber, modulePhiPosition, isPositiveCablingSide, isTiltedPart);
+  Bundle* bundle = GeometryFactory::make<Bundle>(bundleId, complementaryBundleId, bundleType, subDetectorName, layerDiskNumber, modulePhiPosition, isPositiveCablingSide, isTiltedPart);
 
   if (isPositiveCablingSide) {
     bundles.insert(std::make_pair(bundleId, bundle));

--- a/src/Cabling/PhiPosition.cc
+++ b/src/Cabling/PhiPosition.cc
@@ -1,7 +1,7 @@
 #include "Cabling/PhiPosition.hh"
 
 
-PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool isPositiveCablingSide, const bool isBarrel, const int layerDiskNumber, const std::string subDetectorName, const Category& bundleType) {
+PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool isBarrel, const int layerDiskNumber, const std::string subDetectorName, const Category& bundleType) {
 
   // BARREL
   if (isBarrel) {
@@ -10,22 +10,22 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
 
     // PHI SEGMENT
     phiSegmentWidth_ = (2.*M_PI) / numRods;
-    phiSegmentStart_ = computePhiSegmentStart(rodPhi, phiSegmentWidth_, isPositiveCablingSide);
-    phiSegmentRef_ = computePhiSegmentRef(rodPhi, phiSegmentStart_, phiSegmentWidth_, isPositiveCablingSide);
+    phiSegmentStart_ = computePhiSegmentStart(rodPhi, phiSegmentWidth_);
+    phiSegmentRef_ = computePhiSegmentRef(rodPhi, phiSegmentStart_, phiSegmentWidth_);
 
-    complementaryPhiSegmentStart_ = computePhiSegmentStart(femod(M_PI - rodPhi, 2.*M_PI), phiSegmentWidth_, isPositiveCablingSide);
-    complementaryPhiSegmentRef_ = computePhiSegmentRef(femod(M_PI - rodPhi, 2.*M_PI), complementaryPhiSegmentStart_, phiSegmentWidth_, isPositiveCablingSide);
+    complementaryPhiSegmentStart_ = computePhiSegmentStart(femod(M_PI - rodPhi, 2.*M_PI), phiSegmentWidth_);
+    complementaryPhiSegmentRef_ = computePhiSegmentRef(femod(M_PI - rodPhi, 2.*M_PI), complementaryPhiSegmentStart_, phiSegmentWidth_);
 
     // PHI REGION
     // Depending on the layer number, different phiRegionWidth are assigned.
     // This is because for several layers, there can be too many modules per DTC, hence the phi width is defined smaller.	
     phiRegionWidth_ = ((layerDiskNumber == 1 || layerDiskNumber == 2 || layerDiskNumber == 4) ? cabling_nonantWidth : cabling_semiNonantWidth);
     phiRegionStart_ = 0.;
-    phiRegionRef_ = computePhiSliceRef(rodPhi, phiRegionStart_, phiRegionWidth_, isPositiveCablingSide);
+    phiRegionRef_ = computePhiSliceRef(rodPhi, phiRegionStart_, phiRegionWidth_);
 
     // PHI SECTOR
     phiSectorStart_ = 0.;
-    phiSectorRef_ = computePhiSliceRef(rodPhi, phiSectorStart_, phiSectorWidth_, isPositiveCablingSide);
+    phiSectorRef_ = computePhiSliceRef(rodPhi, phiSectorStart_, phiSectorWidth_);
   }
 
   // ENDCAPS
@@ -35,8 +35,8 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
 
     // PHI SEGMENT
     phiSegmentWidth_ = (2.*M_PI) / numModulesInRing;
-    phiSegmentStart_ = computePhiSegmentStart(modPhi, phiSegmentWidth_, isPositiveCablingSide);
-    phiSegmentRef_ = computePhiSegmentRef(modPhi, phiSegmentStart_, phiSegmentWidth_, isPositiveCablingSide);
+    phiSegmentStart_ = computePhiSegmentStart(modPhi, phiSegmentWidth_);
+    phiSegmentRef_ = computePhiSegmentRef(modPhi, phiSegmentStart_, phiSegmentWidth_);
 	
     // PHI REGION
     // Depending on the disk number and cabling type, different phiRegionWidth are assigned.
@@ -59,10 +59,10 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
       if (subDetectorName == cabling_tedd1) phiRegionStart_ = cabling_tedd1StripStripPhiRegionStart;
       else phiRegionStart_ = cabling_tedd2StripStripPhiRegionStart;
     }
-    phiRegionRef_ = computePhiSliceRef(modPhi, phiRegionStart_, phiRegionWidth_, isPositiveCablingSide);
+    phiRegionRef_ = computePhiSliceRef(modPhi, phiRegionStart_, phiRegionWidth_);
     
     // PHI SECTOR
     phiSectorStart_ = 0.;
-    phiSectorRef_ = computePhiSliceRef(modPhi, phiSectorStart_, phiSectorWidth_, isPositiveCablingSide);
+    phiSectorRef_ = computePhiSliceRef(modPhi, phiSectorStart_, phiSectorWidth_);
   }
 }

--- a/src/Cabling/PhiPosition.cc
+++ b/src/Cabling/PhiPosition.cc
@@ -13,6 +13,9 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
     phiSegmentStart_ = computePhiSegmentStart(rodPhi, phiSegmentWidth_, isPositiveCablingSide);
     phiSegmentRef_ = computePhiSegmentRef(rodPhi, phiSegmentStart_, phiSegmentWidth_, isPositiveCablingSide);
 
+    complementaryPhiSegmentStart_ = computePhiSegmentStart(femod(M_PI - rodPhi, 2.*M_PI), phiSegmentWidth_, isPositiveCablingSide);
+    complementaryPhiSegmentRef_ = computePhiSegmentRef(femod(M_PI - rodPhi, 2.*M_PI), complementaryPhiSegmentStart_, phiSegmentWidth_, isPositiveCablingSide);
+
     // PHI REGION
     // Depending on the layer number, different phiRegionWidth are assigned.
     // This is because for several layers, there can be too many modules per DTC, hence the phi width is defined smaller.	

--- a/src/Cabling/PhiPosition.cc
+++ b/src/Cabling/PhiPosition.cc
@@ -13,8 +13,10 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
     phiSegmentStart_ = computePhiSegmentStart(rodPhi, phiSegmentWidth_);
     phiSegmentRef_ = computePhiSegmentRef(rodPhi, phiSegmentStart_, phiSegmentWidth_);
 
-    complementaryPhiSegmentStart_ = computePhiSegmentStart(femod(M_PI - rodPhi, 2.*M_PI), phiSegmentWidth_);
-    complementaryPhiSegmentRef_ = computePhiSegmentRef(femod(M_PI - rodPhi, 2.*M_PI), complementaryPhiSegmentStart_, phiSegmentWidth_);
+    // STEREO PHI SEGMENT
+    double stereoRodPhi = femod(M_PI - rodPhi, 2.*M_PI);
+    stereoPhiSegmentStart_ = computePhiSegmentStart(stereoRodPhi, phiSegmentWidth_);
+    stereoPhiSegmentRef_ = computePhiSegmentRef(stereoRodPhi, stereoPhiSegmentStart_, phiSegmentWidth_);
 
     // PHI REGION
     // Depending on the layer number, different phiRegionWidth are assigned.
@@ -37,6 +39,11 @@ PhiPosition::PhiPosition(const double phi, const int numPhiSegments, const bool 
     phiSegmentWidth_ = (2.*M_PI) / numModulesInRing;
     phiSegmentStart_ = computePhiSegmentStart(modPhi, phiSegmentWidth_);
     phiSegmentRef_ = computePhiSegmentRef(modPhi, phiSegmentStart_, phiSegmentWidth_);
+
+    // STEREO PHI SEGMENT
+    double stereoModPhi =  femod(M_PI - modPhi, 2.*M_PI);
+    stereoPhiSegmentStart_ = computePhiSegmentStart(stereoModPhi, phiSegmentWidth_);
+    stereoPhiSegmentRef_ = computePhiSegmentRef(stereoModPhi, stereoPhiSegmentStart_, phiSegmentWidth_);
 	
     // PHI REGION
     // Depending on the disk number and cabling type, different phiRegionWidth are assigned.

--- a/src/Cabling/ServicesChannel.cc
+++ b/src/Cabling/ServicesChannel.cc
@@ -1,0 +1,206 @@
+#include "Cabling/ServicesChannel.hh"
+
+
+/*ServicesChannel(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor) :
+  section_(section),
+  isPositiveCablingSide_(isPositiveCablingSide),
+  plotColor_(plotColor) 
+{ 
+  myid(id); 
+  };*/
+
+
+OpticalChannel::OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) :
+  section_(ChannelSection::B),
+  isPositiveCablingSide_(isPositiveCablingSide)
+{
+  const int number = computeOpticalChannelNumber(phiSectorRef, type, slot, isPositiveCablingSide);
+  myid(number);
+  plotColor_ = computeOpticalChannelPlotColor(number);
+};
+
+
+/* Compute optical services channels.
+ * They are the channels where the optical cables are routed when they exit the tracker.
+ * They are closely related to the phiSector ref.
+ */
+const int OpticalChannel::computeOpticalChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+  int servicesChannel = 0;
+
+  if (type == Category::PS10G) {
+    if (phiSectorRef == 0) { servicesChannel = 2;  }
+    else if (phiSectorRef == 1) { servicesChannel = 3; }
+    else if (phiSectorRef == 2) { servicesChannel = 5; }
+    else if (phiSectorRef == 3) { servicesChannel = 6; }
+    else if (phiSectorRef == 4) { servicesChannel = 7; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; }
+    else if (phiSectorRef == 6) { servicesChannel = 9; }
+    else if (phiSectorRef == 7) { servicesChannel = 11; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; }   
+  }
+
+  else if (type == Category::PS5G) {
+    if (phiSectorRef == 0) { servicesChannel = 1; }
+    else if (phiSectorRef == 1) { servicesChannel = 2; }
+    else if (phiSectorRef == 2) { servicesChannel = 4; }
+    else if (phiSectorRef == 3) { servicesChannel = 5; }
+    else if (phiSectorRef == 4) { servicesChannel = 7; }
+    else if (phiSectorRef == 5) { servicesChannel = 8; }
+    else if (phiSectorRef == 6) { servicesChannel = 10; }
+    else if (phiSectorRef == 7) { servicesChannel = 11; }
+    else if (phiSectorRef == 8) { servicesChannel = 12; }
+  }
+
+  else if (type == Category::SS) {
+    if (slot == 1 || slot == 2) {
+      if (phiSectorRef == 0) { servicesChannel = 1; }
+      else if (phiSectorRef == 1) { servicesChannel = 3; }
+      else if (phiSectorRef == 2) { servicesChannel = 4; }
+      else if (phiSectorRef == 3) { servicesChannel = 5; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; }
+      else if (phiSectorRef == 5) { servicesChannel = 8; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; }
+      else if (phiSectorRef == 8) { servicesChannel = 11; }
+    }
+    else if (slot == 3) {
+      if (phiSectorRef == 0) { servicesChannel = 1; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; }
+      else if (phiSectorRef == 5) { servicesChannel = 7; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; }
+    }
+    else {
+      if (phiSectorRef == 0) { servicesChannel = 1; }
+      else if (phiSectorRef == 1) { servicesChannel = 2; }
+      else if (phiSectorRef == 2) { servicesChannel = 3; }
+      else if (phiSectorRef == 3) { servicesChannel = 4; }
+      else if (phiSectorRef == 4) { servicesChannel = 6; }
+      else if (phiSectorRef == 5) { servicesChannel = 7; }
+      else if (phiSectorRef == 6) { servicesChannel = 9; }
+      else if (phiSectorRef == 7) { servicesChannel = 10; }
+      else if (phiSectorRef == 8) { servicesChannel = 12; }
+    }
+  }
+
+
+  // NEGATIVE CABLING SIDE.
+  // A given services channel is simplified as a straight line all along (Z).
+  // THIS DEFINES THE CHANNEL NUMBERING ON THE (-Z) SIDE.
+
+  // OPTION A: 
+  // Channel 1A on (+Z) side becomes -1A on the (-Z) side, 1C on (+Z) side becomes -1C on (-Z) side, and so on.
+  if (!isPositiveCablingSide) {
+    servicesChannel *= -1;
+  }
+
+  // OPTION B (NOT PRESENTLY RETAINED)
+  /*
+  // This is the following transformation:
+  // 1 -> 6
+  // 2 -> 5
+  // 3 -> 4
+  // 7 -> 12
+  // 8 -> 11
+  // 9 -> 10
+  // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
+  // The services channel is then set to negative on negative cabling side.
+  if (!isPositiveCablingSide) {
+  double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
+  servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
+  servicesChannel *= -1;
+  servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
+  }
+  */
+
+  return servicesChannel;
+}
+
+
+/* Compute color associated to services channel.
+ */
+int OpticalChannel::computeOpticalChannelPlotColor(const int number) const {
+  int plotColor = fabs(number);
+  return plotColor;
+}
+
+
+PowerChannel::PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) //:
+//isPositiveCablingSide_(isPositiveCablingSide)
+{
+  isPositiveCablingSide_ = isPositiveCablingSide;
+  const std::pair<int, ChannelSection> numberAndSection = computePowerChannelNumberAndSection(semiPhiRegionRef, isPositiveCablingSide);
+  const int number = numberAndSection.first;
+  myid(number);
+  section_ = numberAndSection.second;
+  plotColor_ = computePowerChannelPlotColor(number, section_, isPositiveCablingSide);
+};
+
+
+std::pair<int, ChannelSection> PowerChannel::computePowerChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
+
+  int servicesChannel = 0;
+  ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
+
+  if (isPositiveCablingSide) {
+    if (semiPhiRegionRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 2) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 3) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 4) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 5) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 6) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 7) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 8) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 9) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 10) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 11) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 12) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 13) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 14) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 15) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 16) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 17) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
+    else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
+  }
+
+  else {
+    if (semiPhiRegionRef == 0) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 1) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 2) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 3) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 4) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 5) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 6) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 7) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 8) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 9) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 10) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 11) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 12) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 13) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 14) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 15) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
+    else if (semiPhiRegionRef == 16) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
+    else if (semiPhiRegionRef == 17) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
+    else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
+  }
+
+  return std::make_pair(servicesChannel, servicesChannelSection);
+}
+
+
+int PowerChannel::computePowerChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const {
+  int plotColor = fabs(number);
+  if ( (isPositiveCablingSide && section == ChannelSection::A)
+       || (!isPositiveCablingSide && section == ChannelSection::C)
+       ) {
+    //if (section == ChannelSection::A) {
+    plotColor += 12;
+  }
+  return plotColor;
+}

--- a/src/Cabling/ServicesChannel.cc
+++ b/src/Cabling/ServicesChannel.cc
@@ -9,8 +9,10 @@ void ChannelSection::build(const int channelNumber, const ChannelSlot& channelSl
 };
 
 
+/* Channel Section filled by optical bundles. 
+ */
 OpticalSection::OpticalSection(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) {
-  const ChannelSlot& channelSlot = ChannelSlot::B;
+  const ChannelSlot& channelSlot = ChannelSlot::B;  // The optical bundles are always routed in section B.
 
   const int channelNumber = computeChannelNumber(phiSectorRef, type, slot, isPositiveCablingSide);
   const int plotColor = computeChannelPlotColor(channelNumber);
@@ -19,9 +21,9 @@ OpticalSection::OpticalSection(const int phiSectorRef, const Category& type, con
 };
 
 
-/* Compute optical services channels.
- * They are the channels where the optical cables are routed when they exit the tracker.
- * They are closely related to the phiSector ref.
+/* Compute the number of the Channel, through which the optical bundles are routed when they exit the Tracker.
+ * This number is closely related to the phiSector ref.
+ * This is done in a way to avoid crossings between fiber bundles, as they exit the tracker.
  */
 const int OpticalSection::computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
   int channelNumber = 0;
@@ -86,7 +88,6 @@ const int OpticalSection::computeChannelNumber(const int phiSectorRef, const Cat
     }
   }
 
-
   // NEGATIVE CABLING SIDE.
   // A given services channel is simplified as a straight line all along (Z).
   // THIS DEFINES THE CHANNEL NUMBERING ON THE (-Z) SIDE.
@@ -120,7 +121,7 @@ const int OpticalSection::computeChannelNumber(const int phiSectorRef, const Cat
 }
 
 
-/* Compute color associated to services channel.
+/* Compute color associated to optical channel section.
  */
 const int OpticalSection::computeChannelPlotColor(const int channelNumber) const {
   int plotColor = fabs(channelNumber);
@@ -128,6 +129,9 @@ const int OpticalSection::computeChannelPlotColor(const int channelNumber) const
 }
 
 
+/* Channel Section filled by power cables. 
+ * NB: In the CablingMap, 1 Bundle = 1 Power cable.
+ */
 PowerSection::PowerSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
 
   const std::pair<int, ChannelSlot> channelNumberAndSlot = computeChannelNumberAndSlot(semiPhiRegionRef, isPositiveCablingSide);
@@ -139,6 +143,12 @@ PowerSection::PowerSection(const int semiPhiRegionRef, const bool isPositiveCabl
 };
 
 
+/* Compute the number of the Channel, through which the power cables are routed when they exit the Tracker.
+ * Also compute the channel slot on which the power cables are routed.
+ * This is done in a way that leaves space free for the cooling pipes routing.
+ * Positive cabling side: 1A, 3A, 5A, 7A, 9A, 11A used for cooling pipes.
+ * Negative cabling side: 2C, 4C, 6C, 8C, 10C, 12C used for cooling pipes.
+ */
 std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
 
   int channelNumber = 0;
@@ -192,13 +202,15 @@ std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int 
 }
 
 
+/* Compute color associated to power channel section.
+ */
 const int PowerSection::computeChannelPlotColor(const int channelNumber, const ChannelSlot& channelSlot, const bool isPositiveCablingSide) const {
   int plotColor = fabs(channelNumber);
   if ( (isPositiveCablingSide && channelSlot == ChannelSlot::A)
        || (!isPositiveCablingSide && channelSlot == ChannelSlot::C)
        ) {
     //if (channelSlot == ChannelSlot::A) {
-    plotColor += 12;
+    plotColor += 12;  // This is used to activate transparency.
   }
   return plotColor;
 }

--- a/src/Cabling/ServicesChannel.cc
+++ b/src/Cabling/ServicesChannel.cc
@@ -1,7 +1,7 @@
 #include "Cabling/ServicesChannel.hh"
 
 
-void ServicesChannel::build(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor) {
+void ServicesChannel::build(const int id, const ChannelSection section, const bool isPositiveCablingSide, const int plotColor) {
   section_ = section;
   isPositiveCablingSide_ = isPositiveCablingSide;
   plotColor_ = plotColor;

--- a/src/Cabling/ServicesChannel.cc
+++ b/src/Cabling/ServicesChannel.cc
@@ -1,22 +1,21 @@
 #include "Cabling/ServicesChannel.hh"
 
 
-/*ServicesChannel(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor) :
-  section_(section),
-  isPositiveCablingSide_(isPositiveCablingSide),
-  plotColor_(plotColor) 
-{ 
+void ServicesChannel::build(const int id, const ChannelSection& section, const bool isPositiveCablingSide, const int plotColor) {
+  section_ = section;
+  isPositiveCablingSide_ = isPositiveCablingSide;
+  plotColor_ = plotColor;
   myid(id); 
-  };*/
+};
 
 
-OpticalChannel::OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) :
-  section_(ChannelSection::B),
-  isPositiveCablingSide_(isPositiveCablingSide)
-{
-  const int number = computeOpticalChannelNumber(phiSectorRef, type, slot, isPositiveCablingSide);
-  myid(number);
-  plotColor_ = computeOpticalChannelPlotColor(number);
+OpticalChannel::OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) {
+  const ChannelSection& section = ChannelSection::B;
+
+  const int number = computeChannelNumber(phiSectorRef, type, slot, isPositiveCablingSide);
+  const int plotColor = computeChannelPlotColor(number);
+
+  build(number, section, isPositiveCablingSide, plotColor);
 };
 
 
@@ -24,7 +23,7 @@ OpticalChannel::OpticalChannel(const int phiSectorRef, const Category& type, con
  * They are the channels where the optical cables are routed when they exit the tracker.
  * They are closely related to the phiSector ref.
  */
-const int OpticalChannel::computeOpticalChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+const int OpticalChannel::computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
   int servicesChannel = 0;
 
   if (type == Category::PS10G) {
@@ -123,25 +122,24 @@ const int OpticalChannel::computeOpticalChannelNumber(const int phiSectorRef, co
 
 /* Compute color associated to services channel.
  */
-int OpticalChannel::computeOpticalChannelPlotColor(const int number) const {
+int OpticalChannel::computeChannelPlotColor(const int number) const {
   int plotColor = fabs(number);
   return plotColor;
 }
 
 
-PowerChannel::PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) //:
-//isPositiveCablingSide_(isPositiveCablingSide)
-{
-  isPositiveCablingSide_ = isPositiveCablingSide;
-  const std::pair<int, ChannelSection> numberAndSection = computePowerChannelNumberAndSection(semiPhiRegionRef, isPositiveCablingSide);
+PowerChannel::PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
+
+  const std::pair<int, ChannelSection> numberAndSection = computeChannelNumberAndSection(semiPhiRegionRef, isPositiveCablingSide);
   const int number = numberAndSection.first;
-  myid(number);
-  section_ = numberAndSection.second;
-  plotColor_ = computePowerChannelPlotColor(number, section_, isPositiveCablingSide);
+  const ChannelSection& section = numberAndSection.second;
+  const int plotColor = computeChannelPlotColor(number, section, isPositiveCablingSide);
+
+  build(number, section, isPositiveCablingSide, plotColor);
 };
 
 
-std::pair<int, ChannelSection> PowerChannel::computePowerChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
+std::pair<int, ChannelSection> PowerChannel::computeChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
 
   int servicesChannel = 0;
   ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
@@ -194,7 +192,7 @@ std::pair<int, ChannelSection> PowerChannel::computePowerChannelNumberAndSection
 }
 
 
-int PowerChannel::computePowerChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const {
+int PowerChannel::computeChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const {
   int plotColor = fabs(number);
   if ( (isPositiveCablingSide && section == ChannelSection::A)
        || (!isPositiveCablingSide && section == ChannelSection::C)

--- a/src/Cabling/ServicesChannel.cc
+++ b/src/Cabling/ServicesChannel.cc
@@ -1,21 +1,21 @@
 #include "Cabling/ServicesChannel.hh"
 
 
-void ServicesChannel::build(const int id, const ChannelSection section, const bool isPositiveCablingSide, const int plotColor) {
-  section_ = section;
+void ChannelSection::build(const int channelNumber, const ChannelSlot& channelSlot, const bool isPositiveCablingSide, const int plotColor) {
+  channelNumber_ = channelNumber;
+  channelSlot_ = channelSlot;
   isPositiveCablingSide_ = isPositiveCablingSide;
   plotColor_ = plotColor;
-  myid(id); 
 };
 
 
-OpticalChannel::OpticalChannel(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) {
-  const ChannelSection& section = ChannelSection::B;
+OpticalSection::OpticalSection(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) {
+  const ChannelSlot& channelSlot = ChannelSlot::B;
 
-  const int number = computeChannelNumber(phiSectorRef, type, slot, isPositiveCablingSide);
-  const int plotColor = computeChannelPlotColor(number);
+  const int channelNumber = computeChannelNumber(phiSectorRef, type, slot, isPositiveCablingSide);
+  const int plotColor = computeChannelPlotColor(channelNumber);
 
-  build(number, section, isPositiveCablingSide, plotColor);
+  build(channelNumber, channelSlot, isPositiveCablingSide, plotColor);
 };
 
 
@@ -23,66 +23,66 @@ OpticalChannel::OpticalChannel(const int phiSectorRef, const Category& type, con
  * They are the channels where the optical cables are routed when they exit the tracker.
  * They are closely related to the phiSector ref.
  */
-const int OpticalChannel::computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
-  int servicesChannel = 0;
+const int OpticalSection::computeChannelNumber(const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) const {
+  int channelNumber = 0;
 
   if (type == Category::PS10G) {
-    if (phiSectorRef == 0) { servicesChannel = 2;  }
-    else if (phiSectorRef == 1) { servicesChannel = 3; }
-    else if (phiSectorRef == 2) { servicesChannel = 5; }
-    else if (phiSectorRef == 3) { servicesChannel = 6; }
-    else if (phiSectorRef == 4) { servicesChannel = 7; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; }
-    else if (phiSectorRef == 6) { servicesChannel = 9; }
-    else if (phiSectorRef == 7) { servicesChannel = 11; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; }   
+    if (phiSectorRef == 0) { channelNumber = 2;  }
+    else if (phiSectorRef == 1) { channelNumber = 3; }
+    else if (phiSectorRef == 2) { channelNumber = 5; }
+    else if (phiSectorRef == 3) { channelNumber = 6; }
+    else if (phiSectorRef == 4) { channelNumber = 7; }
+    else if (phiSectorRef == 5) { channelNumber = 8; }
+    else if (phiSectorRef == 6) { channelNumber = 9; }
+    else if (phiSectorRef == 7) { channelNumber = 11; }
+    else if (phiSectorRef == 8) { channelNumber = 12; }   
   }
 
   else if (type == Category::PS5G) {
-    if (phiSectorRef == 0) { servicesChannel = 1; }
-    else if (phiSectorRef == 1) { servicesChannel = 2; }
-    else if (phiSectorRef == 2) { servicesChannel = 4; }
-    else if (phiSectorRef == 3) { servicesChannel = 5; }
-    else if (phiSectorRef == 4) { servicesChannel = 7; }
-    else if (phiSectorRef == 5) { servicesChannel = 8; }
-    else if (phiSectorRef == 6) { servicesChannel = 10; }
-    else if (phiSectorRef == 7) { servicesChannel = 11; }
-    else if (phiSectorRef == 8) { servicesChannel = 12; }
+    if (phiSectorRef == 0) { channelNumber = 1; }
+    else if (phiSectorRef == 1) { channelNumber = 2; }
+    else if (phiSectorRef == 2) { channelNumber = 4; }
+    else if (phiSectorRef == 3) { channelNumber = 5; }
+    else if (phiSectorRef == 4) { channelNumber = 7; }
+    else if (phiSectorRef == 5) { channelNumber = 8; }
+    else if (phiSectorRef == 6) { channelNumber = 10; }
+    else if (phiSectorRef == 7) { channelNumber = 11; }
+    else if (phiSectorRef == 8) { channelNumber = 12; }
   }
 
   else if (type == Category::SS) {
     if (slot == 1 || slot == 2) {
-      if (phiSectorRef == 0) { servicesChannel = 1; }
-      else if (phiSectorRef == 1) { servicesChannel = 3; }
-      else if (phiSectorRef == 2) { servicesChannel = 4; }
-      else if (phiSectorRef == 3) { servicesChannel = 5; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; }
-      else if (phiSectorRef == 5) { servicesChannel = 8; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; }
-      else if (phiSectorRef == 8) { servicesChannel = 11; }
+      if (phiSectorRef == 0) { channelNumber = 1; }
+      else if (phiSectorRef == 1) { channelNumber = 3; }
+      else if (phiSectorRef == 2) { channelNumber = 4; }
+      else if (phiSectorRef == 3) { channelNumber = 5; }
+      else if (phiSectorRef == 4) { channelNumber = 6; }
+      else if (phiSectorRef == 5) { channelNumber = 8; }
+      else if (phiSectorRef == 6) { channelNumber = 9; }
+      else if (phiSectorRef == 7) { channelNumber = 10; }
+      else if (phiSectorRef == 8) { channelNumber = 11; }
     }
     else if (slot == 3) {
-      if (phiSectorRef == 0) { servicesChannel = 1; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; }
-      else if (phiSectorRef == 5) { servicesChannel = 7; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; }
+      if (phiSectorRef == 0) { channelNumber = 1; }
+      else if (phiSectorRef == 1) { channelNumber = 2; }
+      else if (phiSectorRef == 2) { channelNumber = 3; }
+      else if (phiSectorRef == 3) { channelNumber = 4; }
+      else if (phiSectorRef == 4) { channelNumber = 6; }
+      else if (phiSectorRef == 5) { channelNumber = 7; }
+      else if (phiSectorRef == 6) { channelNumber = 9; }
+      else if (phiSectorRef == 7) { channelNumber = 10; }
+      else if (phiSectorRef == 8) { channelNumber = 12; }
     }
     else {
-      if (phiSectorRef == 0) { servicesChannel = 1; }
-      else if (phiSectorRef == 1) { servicesChannel = 2; }
-      else if (phiSectorRef == 2) { servicesChannel = 3; }
-      else if (phiSectorRef == 3) { servicesChannel = 4; }
-      else if (phiSectorRef == 4) { servicesChannel = 6; }
-      else if (phiSectorRef == 5) { servicesChannel = 7; }
-      else if (phiSectorRef == 6) { servicesChannel = 9; }
-      else if (phiSectorRef == 7) { servicesChannel = 10; }
-      else if (phiSectorRef == 8) { servicesChannel = 12; }
+      if (phiSectorRef == 0) { channelNumber = 1; }
+      else if (phiSectorRef == 1) { channelNumber = 2; }
+      else if (phiSectorRef == 2) { channelNumber = 3; }
+      else if (phiSectorRef == 3) { channelNumber = 4; }
+      else if (phiSectorRef == 4) { channelNumber = 6; }
+      else if (phiSectorRef == 5) { channelNumber = 7; }
+      else if (phiSectorRef == 6) { channelNumber = 9; }
+      else if (phiSectorRef == 7) { channelNumber = 10; }
+      else if (phiSectorRef == 8) { channelNumber = 12; }
     }
   }
 
@@ -94,7 +94,7 @@ const int OpticalChannel::computeChannelNumber(const int phiSectorRef, const Cat
   // OPTION A: 
   // Channel 1A on (+Z) side becomes -1A on the (-Z) side, 1C on (+Z) side becomes -1C on (-Z) side, and so on.
   if (!isPositiveCablingSide) {
-    servicesChannel *= -1;
+    channelNumber *= -1;
   }
 
   // OPTION B (NOT PRESENTLY RETAINED)
@@ -109,95 +109,95 @@ const int OpticalChannel::computeChannelNumber(const int phiSectorRef, const Cat
   // This is so that the numbering follows a rotation of 180 degrees around CMS_Y for the negative cabling side.
   // The services channel is then set to negative on negative cabling side.
   if (!isPositiveCablingSide) {
-  double pivot = (servicesChannel <= 6 ? 3.5 : 9.5);
-  servicesChannel = servicesChannel + round( 2. * (pivot - servicesChannel) );
-  servicesChannel *= -1;
-  servicesChannelSection = (servicesChannelSection == ChannelSection::A ? ChannelSection::C : ChannelSection::A);
+  double pivot = (channelNumber <= 6 ? 3.5 : 9.5);
+  channelNumber = channelNumber + round( 2. * (pivot - channelNumber) );
+  channelNumber *= -1;
+  servicesChannelSlot = (servicesChannelSlot == ChannelSlot::A ? ChannelSlot::C : ChannelSlot::A);
   }
   */
 
-  return servicesChannel;
+  return channelNumber;
 }
 
 
 /* Compute color associated to services channel.
  */
-int OpticalChannel::computeChannelPlotColor(const int number) const {
-  int plotColor = fabs(number);
+const int OpticalSection::computeChannelPlotColor(const int channelNumber) const {
+  int plotColor = fabs(channelNumber);
   return plotColor;
 }
 
 
-PowerChannel::PowerChannel(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
+PowerSection::PowerSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) {
 
-  const std::pair<int, ChannelSection> numberAndSection = computeChannelNumberAndSection(semiPhiRegionRef, isPositiveCablingSide);
-  const int number = numberAndSection.first;
-  const ChannelSection& section = numberAndSection.second;
-  const int plotColor = computeChannelPlotColor(number, section, isPositiveCablingSide);
+  const std::pair<int, ChannelSlot> channelNumberAndSlot = computeChannelNumberAndSlot(semiPhiRegionRef, isPositiveCablingSide);
+  const int channelNumber = channelNumberAndSlot.first;
+  const ChannelSlot& channelSlot = channelNumberAndSlot.second;
+  const int plotColor = computeChannelPlotColor(channelNumber, channelSlot, isPositiveCablingSide);
 
-  build(number, section, isPositiveCablingSide, plotColor);
+  build(channelNumber, channelSlot, isPositiveCablingSide, plotColor);
 };
 
 
-std::pair<int, ChannelSection> PowerChannel::computeChannelNumberAndSection(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
+std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
 
-  int servicesChannel = 0;
-  ChannelSection servicesChannelSection = ChannelSection::UNKNOWN;
+  int channelNumber = 0;
+  ChannelSlot channelSlot = ChannelSlot::UNKNOWN;
 
   if (isPositiveCablingSide) {
-    if (semiPhiRegionRef == 0) { servicesChannel = 1; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 1) { servicesChannel = 2; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 2) { servicesChannel = 2; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 3) { servicesChannel = 3; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 4) { servicesChannel = 4; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 5) { servicesChannel = 4; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 6) { servicesChannel = 5; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 7) { servicesChannel = 6; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 8) { servicesChannel = 6; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 9) { servicesChannel = 7; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 10) { servicesChannel = 8; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 11) { servicesChannel = 8; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 12) { servicesChannel = 9; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 13) { servicesChannel = 10; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 14) { servicesChannel = 10; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 15) { servicesChannel = 11; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 16) { servicesChannel = 12; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 17) { servicesChannel = 12; servicesChannelSection = ChannelSection::C; }
+    if (semiPhiRegionRef == 0) { channelNumber = 1; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 1) { channelNumber = 2; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 2) { channelNumber = 2; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 3) { channelNumber = 3; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 4) { channelNumber = 4; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 5) { channelNumber = 4; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 6) { channelNumber = 5; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 7) { channelNumber = 6; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 8) { channelNumber = 6; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 9) { channelNumber = 7; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 10) { channelNumber = 8; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 11) { channelNumber = 8; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 12) { channelNumber = 9; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 13) { channelNumber = 10; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 14) { channelNumber = 10; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 15) { channelNumber = 11; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 16) { channelNumber = 12; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 17) { channelNumber = 12; channelSlot = ChannelSlot::C; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
   }
 
   else {
-    if (semiPhiRegionRef == 0) { servicesChannel = -1; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 1) { servicesChannel = -1; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 2) { servicesChannel = -2; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 3) { servicesChannel = -3; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 4) { servicesChannel = -3; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 5) { servicesChannel = -4; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 6) { servicesChannel = -5; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 7) { servicesChannel = -5; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 8) { servicesChannel = -6; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 9) { servicesChannel = -7; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 10) { servicesChannel = -7; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 11) { servicesChannel = -8; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 12) { servicesChannel = -9; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 13) { servicesChannel = -9; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 14) { servicesChannel = -10; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 15) { servicesChannel = -11; servicesChannelSection = ChannelSection::A; }
-    else if (semiPhiRegionRef == 16) { servicesChannel = -11; servicesChannelSection = ChannelSection::C; }
-    else if (semiPhiRegionRef == 17) { servicesChannel = -12; servicesChannelSection = ChannelSection::A; }
+    if (semiPhiRegionRef == 0) { channelNumber = -1; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 1) { channelNumber = -1; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 2) { channelNumber = -2; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 3) { channelNumber = -3; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 4) { channelNumber = -3; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 5) { channelNumber = -4; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 6) { channelNumber = -5; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 7) { channelNumber = -5; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 8) { channelNumber = -6; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 9) { channelNumber = -7; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 10) { channelNumber = -7; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 11) { channelNumber = -8; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 12) { channelNumber = -9; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 13) { channelNumber = -9; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 14) { channelNumber = -10; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 15) { channelNumber = -11; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 16) { channelNumber = -11; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 17) { channelNumber = -12; channelSlot = ChannelSlot::A; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
   }
 
-  return std::make_pair(servicesChannel, servicesChannelSection);
+  return std::make_pair(channelNumber, channelSlot);
 }
 
 
-int PowerChannel::computeChannelPlotColor(const int number, const ChannelSection& section, const bool isPositiveCablingSide) const {
-  int plotColor = fabs(number);
-  if ( (isPositiveCablingSide && section == ChannelSection::A)
-       || (!isPositiveCablingSide && section == ChannelSection::C)
+const int PowerSection::computeChannelPlotColor(const int channelNumber, const ChannelSlot& channelSlot, const bool isPositiveCablingSide) const {
+  int plotColor = fabs(channelNumber);
+  if ( (isPositiveCablingSide && channelSlot == ChannelSlot::A)
+       || (!isPositiveCablingSide && channelSlot == ChannelSlot::C)
        ) {
-    //if (section == ChannelSection::A) {
+    //if (channelSlot == ChannelSlot::A) {
     plotColor += 12;
   }
   return plotColor;

--- a/src/Cabling/cabling_constants.cc
+++ b/src/Cabling/cabling_constants.cc
@@ -3,4 +3,4 @@
 
 define_enum_strings(Category) = { "Undefined", "PS10G", "PS10GA", "PS10GB", "PS5G", "2S" };
 
-define_enum_strings(ChannelSection) = { "Unknown", "A", "C" };
+define_enum_strings(ChannelSection) = { "Unknown", "A", "B", "C" };

--- a/src/Cabling/cabling_constants.cc
+++ b/src/Cabling/cabling_constants.cc
@@ -3,4 +3,4 @@
 
 define_enum_strings(Category) = { "Undefined", "PS10G", "PS10GA", "PS10GB", "PS5G", "2S" };
 
-define_enum_strings(ChannelSection) = { "Unknown", "A", "B", "C" };
+define_enum_strings(ChannelSlot) = { "Unknown", "A", "B", "C" };

--- a/src/Cabling/cabling_functions.cc
+++ b/src/Cabling/cabling_functions.cc
@@ -3,7 +3,7 @@
 
 /* Compute the offset in Phi with respect to Phi = 0.
  */
-const double computePhiSegmentStart(const double phi, const double phiSegmentWidth, const bool isPositiveCablingSide) {
+const double computePhiSegmentStart(const double phi, const double phiSegmentWidth) {
   double phiSegmentStart = femod(phi, phiSegmentWidth);
   return phiSegmentStart;
 }
@@ -11,7 +11,7 @@ const double computePhiSegmentStart(const double phi, const double phiSegmentWid
 
 /* Compute the int n for which we have: phi ~= (n * phiSegmentWidth + phiSegmentStart).
  */
-const int computePhiSegmentRef(const double phi, const double phiSegmentStart, const double phiSegmentWidth, const bool isPositiveCablingSide) {
+const int computePhiSegmentRef(const double phi, const double phiSegmentStart, const double phiSegmentWidth) {
   int phiSegmentRef = round(femod(phi - phiSegmentStart, 2.*M_PI) / phiSegmentWidth);
   return phiSegmentRef;
 }
@@ -19,7 +19,7 @@ const int computePhiSegmentRef(const double phi, const double phiSegmentStart, c
 
 /* Compute the int n for which we have: (phiSliceStart + n*phiSliceWidth) <= phi < (phiSliceStart + (n+1)*phiSliceWidth).
  */
-const int computePhiSliceRef(const double phi, const double phiSliceStart, const double phiSliceWidth, const bool isPositiveCablingSide) {
+const int computePhiSliceRef(const double phi, const double phiSliceStart, const double phiSliceWidth) {
   double phiSliceRefExact = femod(phi - phiSliceStart, 2.*M_PI) / phiSliceWidth;
   int phiSliceRef = 0;
   // In case phiSliceRefExact is an integer, round it to an int!

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -481,6 +481,16 @@ const int DetectorModule::bundlePlotColor() const {
 }
 
 
+const int DetectorModule::powerChannelPlotColor() const {
+  int powerChannelPlotColor = 0;
+  const Bundle* myBundle = getBundle();
+  if (myBundle != nullptr) {
+    powerChannelPlotColor = myBundle->powerServicesChannelPlotColor();
+  }
+  return powerChannelPlotColor;
+}
+
+
 const int DetectorModule::channelPlotColor() const {
   int channelPlotColor = 0;
   const Bundle* myBundle = getBundle();

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -464,7 +464,7 @@ std::string DetectorModule::summaryFullType() const  {
 const int DetectorModule::isPositiveCablingSide() const {
   int isPositiveCablingSide = 0;
   const Bundle* myBundle = getBundle();
-  if (myBundle != nullptr) {
+  if (myBundle) {
     isPositiveCablingSide = (myBundle->isPositiveCablingSide() ? 1 : -1);
   }
   return isPositiveCablingSide;
@@ -474,7 +474,7 @@ const int DetectorModule::isPositiveCablingSide() const {
 const int DetectorModule::bundlePlotColor() const {
   int bundlePlotColor = 0;
   const Bundle* myBundle = getBundle();
-  if (myBundle != nullptr) {
+  if (myBundle) {
     bundlePlotColor = myBundle->plotColor();
   }
   return bundlePlotColor;
@@ -484,9 +484,9 @@ const int DetectorModule::bundlePlotColor() const {
 const int DetectorModule::opticalChannelSectionPlotColor() const {
   int opticalChannelPlotColor = 0;
   const Bundle* myBundle = getBundle();
-  if (myBundle != nullptr) {
+  if (myBundle) {
     const ChannelSection* mySection = myBundle->opticalChannelSection();
-    if (mySection != nullptr) {
+    if (mySection) {
       opticalChannelPlotColor = mySection->plotColor();
     }
   }
@@ -497,9 +497,9 @@ const int DetectorModule::opticalChannelSectionPlotColor() const {
 const int DetectorModule::powerChannelSectionPlotColor() const {
   int powerChannelPlotColor = 0;
   const Bundle* myBundle = getBundle();
-  if (myBundle != nullptr) {
+  if (myBundle) {
     const ChannelSection* mySection = myBundle->powerChannelSection();
-    if (mySection != nullptr) {
+    if (mySection) {
       powerChannelPlotColor = mySection->plotColor();
     }
   }
@@ -510,9 +510,9 @@ const int DetectorModule::powerChannelSectionPlotColor() const {
 const DTC* DetectorModule::getDTC() const {
   const DTC* myDTC = nullptr;
   const Bundle* myBundle = getBundle();
-  if (myBundle != nullptr) {
+  if (myBundle) {
     const Cable* myCable = myBundle->getCable();
-    if (myCable != nullptr) {
+    if (myCable) {
       myDTC = myCable->getDTC();
     }
   }

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -481,26 +481,29 @@ const int DetectorModule::bundlePlotColor() const {
 }
 
 
-const int DetectorModule::powerChannelPlotColor() const {
-  int powerChannelPlotColor = 0;
+const int DetectorModule::opticalChannelSectionPlotColor() const {
+  int opticalChannelPlotColor = 0;
   const Bundle* myBundle = getBundle();
   if (myBundle != nullptr) {
-    powerChannelPlotColor = myBundle->powerServicesChannelPlotColor();
+    const ChannelSection* mySection = myBundle->opticalChannelSection();
+    if (mySection != nullptr) {
+      opticalChannelPlotColor = mySection->plotColor();
+    }
   }
-  return powerChannelPlotColor;
+  return opticalChannelPlotColor;
 }
 
 
-const int DetectorModule::channelPlotColor() const {
-  int channelPlotColor = 0;
+const int DetectorModule::powerChannelSectionPlotColor() const {
+  int powerChannelPlotColor = 0;
   const Bundle* myBundle = getBundle();
   if (myBundle != nullptr) {
-    const Cable* myCable = myBundle->getCable();
-    if (myCable != nullptr) {   
-      channelPlotColor = myCable->servicesChannelPlotColor();
+    const ChannelSection* mySection = myBundle->powerChannelSection();
+    if (mySection != nullptr) {
+      powerChannelPlotColor = mySection->plotColor();
     }
   }
-  return channelPlotColor;
+  return powerChannelPlotColor;
 }
 
 

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -194,13 +194,16 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated
       paletteIndex=kGray + 1;
       break;
     case 6 :
-      paletteIndex=kMagenta - 7;
+      //paletteIndex=kMagenta - 7;
+      paletteIndex=kMagenta;
       break;
     case 7 :
-      paletteIndex=kViolet - 1;
+      //paletteIndex=kViolet - 1;
+      paletteIndex=kViolet - 6;
       break;
     case 8 :
-      paletteIndex=kBlue;
+      //paletteIndex=kBlue;
+      paletteIndex=kBlue + 1;
       break;
     case 9 :
       paletteIndex=kAzure + 1;

--- a/src/Palette.cc
+++ b/src/Palette.cc
@@ -194,15 +194,12 @@ Color_t Palette::colorChannel(const int& colorIndex, bool isTransparentActivated
       paletteIndex=kGray + 1;
       break;
     case 6 :
-      //paletteIndex=kMagenta - 7;
       paletteIndex=kMagenta;
       break;
     case 7 :
-      //paletteIndex=kViolet - 1;
       paletteIndex=kViolet - 6;
       break;
     case 8 :
-      //paletteIndex=kBlue;
       paletteIndex=kBlue + 1;
       break;
     case 9 :

--- a/src/PlotDrawer.cc
+++ b/src/PlotDrawer.cc
@@ -32,8 +32,15 @@ int g
 ;
 
 template<> TH2C* FrameGetter<XY>::operator()(double viewportX, double viewportY) const {
-  std::string name = std::string("frameXY") + nextString();
+  std::string name = std::string("frameXYPos") + nextString();
   TH2C* frame = new TH2C(name.c_str(), ";x [mm];y [mm]", nBinsZoom, -viewportX, viewportX, nBinsZoom, -viewportY, viewportY);
+  frame->GetYaxis()->SetTitleOffset(1.3);
+  return frame;
+}
+
+template<> TH2C* FrameGetter<XYRotateY180>::operator()(double viewportX, double viewportY) const {
+  std::string name = std::string("frameXYPosRotateY180") + nextString();
+  TH2C* frame = new TH2C(name.c_str(), ";-x [mm];y [mm]", nBinsZoom, -viewportX, viewportX, nBinsZoom, -viewportY, viewportY);
   frame->GetYaxis()->SetTitleOffset(1.3);
   return frame;
 }
@@ -142,6 +149,10 @@ template<> void SummaryFrameStyle<YZFull>::operator()(TH2C& frame, TCanvas&, Dra
 }
 
 template<> void SummaryFrameStyle<XY>::operator()(TH2C& frame, TCanvas&, DrawerPalette&) const {
+  frame.Draw();    
+}
+
+template<> void SummaryFrameStyle<XYRotateY180>::operator()(TH2C& frame, TCanvas&, DrawerPalette&) const {
   frame.Draw();    
 }
 

--- a/src/PlotDrawer.cc
+++ b/src/PlotDrawer.cc
@@ -45,6 +45,13 @@ template<> TH2C* FrameGetter<XYNeg>::operator()(double viewportX, double viewpor
   return frame;
 }
 
+template<> TH2C* FrameGetter<XYNegRotateY180>::operator()(double viewportX, double viewportY) const {
+  std::string name = std::string("frameXYNegRotateY180") + nextString();
+  TH2C* frame = new TH2C(name.c_str(), ";x [mm];y [mm]", nBinsZoom, -viewportX, viewportX, nBinsZoom, -viewportY, viewportY);
+  frame->GetYaxis()->SetTitleOffset(1.3);
+  return frame;
+}
+
 TPolyLine* drawMod() {
   double x[] = { 131., 31., 31., 131., 131., 101. };
   double y[] = { 132., 132., 32., 32., 81., 81. };
@@ -139,6 +146,10 @@ template<> void SummaryFrameStyle<XY>::operator()(TH2C& frame, TCanvas&, DrawerP
 }
 
 template<> void SummaryFrameStyle<XYNeg>::operator()(TH2C& frame, TCanvas&, DrawerPalette&) const {
+  frame.Draw();    
+}
+
+template<> void SummaryFrameStyle<XYNegRotateY180>::operator()(TH2C& frame, TCanvas&, DrawerPalette&) const {
   frame.Draw();    
 }
 

--- a/src/PlotDrawer.cc
+++ b/src/PlotDrawer.cc
@@ -47,7 +47,7 @@ template<> TH2C* FrameGetter<XYNeg>::operator()(double viewportX, double viewpor
 
 template<> TH2C* FrameGetter<XYNegRotateY180>::operator()(double viewportX, double viewportY) const {
   std::string name = std::string("frameXYNegRotateY180") + nextString();
-  TH2C* frame = new TH2C(name.c_str(), ";x [mm];y [mm]", nBinsZoom, -viewportX, viewportX, nBinsZoom, -viewportY, viewportY);
+  TH2C* frame = new TH2C(name.c_str(), ";-x [mm];y [mm]", nBinsZoom, -viewportX, viewportX, nBinsZoom, -viewportY, viewportY);
   frame->GetYaxis()->SetTitleOffset(1.3);
   return frame;
 }

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -84,7 +84,7 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta) {
   for (int i = 0, parity = smallParity(); i < numMods; i++, parity *= -1) {
     EndcapModule* mod = GeometryFactory::clone(*templ);
     mod->myid(i+1);
-    mod->rotateZ(2*M_PI*(i+alignmentRotation)/numMods); // CUIDADO had a rotation offset of PI/2
+    mod->rotateZ(2.*M_PI*(i+alignmentRotation)/numMods); // CUIDADO had a rotation offset of PI/2
     mod->rotateZ(zRotation());
     mod->translateZ(parity*smallDelta);
     mod->flipped(parity != 1);

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -463,6 +463,7 @@ void RootWImage::saveSummaryLoop(TPad* basePad, std::string baseName, TFile* myT
 	       (myClass=="TLatex") ||
 	       (myClass=="TLegend") ||
 	       (myClass=="TLine") ||
+	       (myClass=="TArrow") ||
 	       (myClass=="TPaveText") ||
 	       (myClass=="TPolyLine") ||
 	       (myClass=="TText") ||

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -132,6 +132,8 @@ void RootWTable::setColor(int row, int column, int newColor) {
 void RootWTable::setContent(int row, int column, string content) {
   // std::cerr << "setContent("<<row<<", "<<column<<", "<<content<<")"<<endl; // debug
   tableContent_[make_pair(row, column)] = content;
+  maxRow_ = MAX(maxRow_, row);
+  maxCol_ = MAX(maxCol_, column);
 }
 
 void RootWTable::setContent(int row, int column, int number) {
@@ -140,6 +142,8 @@ void RootWTable::setContent(int row, int column, int number) {
   myNum_.clear();
   myNum_ << dec << number;
   tableContent_[make_pair(row, column)] = myNum_.str();
+  maxRow_ = MAX(maxRow_, row);
+  maxCol_ = MAX(maxCol_, column);
 }
 
 void RootWTable::setContent(int row, int column, double number, int precision) {
@@ -148,6 +152,8 @@ void RootWTable::setContent(int row, int column, double number, int precision) {
   myNum_.clear();
   myNum_ << dec << fixed << setprecision(precision) << number;
   tableContent_[make_pair(row, column)] = myNum_.str();
+  maxRow_ = MAX(maxRow_, row);
+  maxCol_ = MAX(maxCol_, column);
 }
 
 pair<int, int> RootWTable::addContent(string myContent) {

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -180,7 +180,7 @@ namespace insur {
    * Build an optical cabling map, which connects each module to a bundle, cable, DTC. 
    * Can actually be reused for power cables routing.
    * Please note that this is independant from any cable Materiabal Budget consideration, which is done indepedently.
-   * The underlying cabling was designed for TDR layout OT613_200_IT4025, and will not work for any other layout.
+   * The underlying cabling was designed for OT614, and will not work for any other layout.
    */
   bool Squid::buildCablingMap(const bool cablingOption) {
     startTaskClock("Building optical Cabling map.");
@@ -486,7 +486,7 @@ namespace insur {
    */
   bool Squid::reportCablingMapSite(const bool cablingOption, const std::string layoutName) {
     startTaskClock("Creating optical Cabling map report.");
-    if (layoutName != default_tdrLayoutName) logERROR("Cabling map is designed and implemented for TDR layout only.");
+    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT614 only.");
     if (tr) {
       // CREATE REPORT ON WEBSITE.
       v.cablingSummary(a, *tr, site);

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -185,10 +185,17 @@ namespace insur {
   bool Squid::buildCablingMap(const bool cablingOption) {
     startTaskClock("Building optical Cabling map.");
     if (tr) {
-      // BUILD CABLING MAP.	
-      std::unique_ptr<const CablingMap> map(new CablingMap(tr));
-      // std::unique_ptr<const CablingMap> map = std::make_unique<const CablingMap>(tr);  // Switch to C++14 :)
-      tr->setCablingMap(std::move(map));
+      try {
+	// BUILD CABLING MAP.	
+	std::unique_ptr<const CablingMap> map(new CablingMap(tr));
+	// std::unique_ptr<const CablingMap> map = std::make_unique<const CablingMap>(tr);  // Switch to C++14 :)
+	tr->setCablingMap(std::move(map));
+      }
+      catch (PathfulException& e) {
+	std::cerr << e.path() << " : " << e.what() << std::endl;  // should improve this!
+	stopTaskClock();
+	return false;
+	}
       stopTaskClock();
       return true;
     }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7618,7 +7618,7 @@ namespace insur {
   */
   void Vizard::drawPhiSectorsBoundaries(const double phiSectorWidth, const bool isRotatedY180) {
     int numPhiSectors = round(2. * M_PI / phiSectorWidth);
-    double phiSectorBoundaryRadius = 2 * vis_min_canvas_sizeX; 
+    double phiSectorBoundaryRadius = 2 * vis_min_canvas_sizeX;
 
     for (int i = 0; i < numPhiSectors; i++) {
       const double angle = i * phiSectorWidth;
@@ -7635,57 +7635,82 @@ namespace insur {
    *  Draw frame of reference reminder.
    */
   void Vizard::drawFrameOfReference(const bool isRotatedY180) {
+    const double arrowMin = 900;
+    const double arrowMax = 1100;
+    const double circleZRadius = 50;
+    const double arrowWidth = 0.02;
+    const double textSize = 0.025;
     
     // CMS reference frame of reference.
     if (!isRotatedY180) {
-      TArrow* arrowX = new TArrow(900, 900, 1100, 900, 0.02, "|>");
+      TArrow* arrowX = new TArrow(arrowMin, arrowMin, arrowMax, arrowMin, arrowWidth, "|>");
       arrowX->Draw();
-      TLatex* textX = new TLatex(1000, 820, "X");
-      textX->SetTextSize(0.025);
+      const double textXAbs = 1000;
+      const double textXOrd = 820;
+      TLatex* textX = new TLatex(textXAbs, textXOrd, "X");
+      textX->SetTextSize(textSize);
       textX->Draw("same");
 
-      TArrow* arrowY = new TArrow(900, 900, 900, 1100, 0.02, "|>");
+      TArrow* arrowY = new TArrow(arrowMin, arrowMin, arrowMin, arrowMax, arrowWidth, "|>");
       arrowY->Draw();
-      TLatex* textY = new TLatex(820, 1000, "Y");
-      textY->SetTextSize(0.025);
+      const double textYAbs = 820;
+      const double textYOrd = 1000;
+      TLatex* textY = new TLatex(textYAbs, textYOrd, "Y");
+      textY->SetTextSize(textSize);
       textY->Draw("same");
 
-      TEllipse* circleZ = new TEllipse(1050, 1050, 50, 50);
+      const double circleZCentre = 1050;
+      const double pointZRadius = 10;
+      TEllipse* circleZ = new TEllipse(circleZCentre, circleZCentre, circleZRadius, circleZRadius);
       circleZ->SetLineWidth(2);
       circleZ->Draw("same");
-      TEllipse* pointZ = new TEllipse(1050, 1050, 10, 10);
+      TEllipse* pointZ = new TEllipse(circleZCentre, circleZCentre, pointZRadius, pointZRadius);
       pointZ->SetFillColor(kBlack);
       pointZ->Draw("same");
-      TLatex* textZ = new TLatex(1030, 1110, "Z");
-      textZ->SetTextSize(0.025);
+      const double textZAbs = 1030;
+      const double textZOrd = 1110;
+      TLatex* textZ = new TLatex(textZAbs, textZOrd, "Z");
+      textZ->SetTextSize(textSize);
       textZ->Draw("same");
     }
 
     // CMS frame of reference rotated by 180 degrees around CMS_Y.
     else {
-      TArrow* arrowX = new TArrow(1100, 900, 900, 900, 0.02, "|>");
+      TArrow* arrowX = new TArrow(arrowMax, arrowMin, arrowMin, arrowMin, arrowWidth, "|>");
       arrowX->Draw();
-      TLatex* textX = new TLatex(950, 820, "X");
-      textX->SetTextSize(0.025);
+      const double textXAbs = 950;
+      const double textXOrd = 820;
+      TLatex* textX = new TLatex(textXAbs, textXOrd, "X");
+      textX->SetTextSize(textSize);
       textX->Draw("same");
 
-      TArrow* arrowY = new TArrow(1100, 900, 1100, 1100, 0.02, "|>");
+      TArrow* arrowY = new TArrow(arrowMax, arrowMin, arrowMax, arrowMax, arrowWidth, "|>");
       arrowY->Draw();
-      TLatex* textY = new TLatex(1020, 1000, "Y");
-      textY->SetTextSize(0.025);
+      const double textYAbs = 1020;
+      const double textYOrd = 1000;
+      TLatex* textY = new TLatex(textYAbs, textYOrd, "Y");
+      textY->SetTextSize(textSize);
       textY->Draw("same");
 
-      TEllipse* circleZ = new TEllipse(850, 1050, 50, 50);
+      const double circleZCentreAbs = 850;
+      const double circleZCentreOrd = 1050;
+      TEllipse* circleZ = new TEllipse(circleZCentreAbs, circleZCentreOrd, circleZRadius, circleZRadius);
       circleZ->SetLineWidth(2);
       circleZ->Draw("same");
-      TLine* lineU = new TLine(815, 1015, 885, 1085);
+      const double crossMinAbs = 815;
+      const double crossMaxAbs = 885;
+      const double crossMinOrd = 1015;
+      const double crossMaxOrd = 1085;
+      TLine* lineU = new TLine(crossMinAbs, crossMinOrd, crossMaxAbs, crossMaxOrd);
       lineU->SetLineWidth(2);
       lineU->Draw("same");
-      TLine* lineD = new TLine(815, 1085, 885, 1015);
+      TLine* lineD = new TLine(crossMinAbs, crossMaxOrd, crossMaxAbs, crossMinOrd);
       lineD->SetLineWidth(2);
       lineD->Draw("same");
-      TLatex* textZ = new TLatex(830, 1110, "Z");
-      textZ->SetTextSize(0.025);
+      const double textZAbs = 830;
+      const double textZOrd = 1110;
+      TLatex* textZ = new TLatex(textZAbs, textZOrd, "Z");
+      textZ->SetTextSize(textSize);
       textZ->Draw("same");
     }
   }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7256,7 +7256,7 @@ namespace insur {
   std::string Vizard::createDTCsToModulesCsv(const CablingMap* myCablingMap, const bool isPositiveCablingSide) {
 
     std::stringstream modulesToDTCsCsv;
-    modulesToDTCsCsv << "DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, Cable #/I, Cable type/C, Bundle #/I, PWR Services Channel/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
+    modulesToDTCsCsv << "DTC name/C, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, Cable #/I, Cable type/C, Bundle #/I, OPT Services Channel/I, PWR Services Channel/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
 
     const std::map<const std::string, const DTC*>& myDTCs = (isPositiveCablingSide ? myCablingMap->getDTCs() : myCablingMap->getNegDTCs());
     for (const auto& dtc : myDTCs) {
@@ -7282,7 +7282,9 @@ namespace insur {
 	    std::stringstream bundleInfo;
 	    bundleInfo << bundle.myid() << ","
 		       << servicesChannel << " " 
-		       << any2str(servicesChannelSection) << ",";
+		       << any2str(servicesChannelSection) << ","
+		       << bundle.powerServicesChannel() << " " 
+		       << any2str(bundle.powerServicesChannelSection());
 
 	    const PtrVector<Module>& myModules = bundle.modules();
 	    for (const auto& module : myModules) {

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1551,8 +1551,10 @@ namespace insur {
 	myContent->addItem(myImage);
       }
      
+      myContent = new RootWContent("");
+      myPage->addContent(myContent);
       // NEGATIVE CABLING SIDE
-      myContent->addItem(spacer);
+      //myContent->addItem(spacer);
       myContent->addItem(negativeSideName);
       if (XYChannelPowerNegCanvas) {
 	myImage = new RootWImage(XYChannelPowerNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7284,7 +7284,7 @@ namespace insur {
 		       << servicesChannel << " " 
 		       << any2str(servicesChannelSection) << ","
 		       << bundle.powerServicesChannel() << " " 
-		       << any2str(bundle.powerServicesChannelSection());
+		       << any2str(bundle.powerServicesChannelSection()) << ",";
 
 	    const PtrVector<Module>& myModules = bundle.modules();
 	    for (const auto& module : myModules) {

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1568,7 +1568,6 @@ namespace insur {
       myContent = new RootWContent("");
       myPage->addContent(myContent);
       // NEGATIVE CABLING SIDE
-      //myContent->addItem(spacer);
       myContent->addItem(negativeSideName);
       if (XYChannelPowerNegCanvas) {
 	myImage = new RootWImage(XYChannelPowerNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
@@ -1843,8 +1842,6 @@ namespace insur {
     channelsTable->setContent(13, startCol + 3, totalSsBundles);
     channelsTable->setContent(13, startCol + 4, totalBundles);
   }
-
-
 
 
   /**
@@ -6727,6 +6724,7 @@ namespace insur {
     //return summaryCanvas;
   }
 
+
   void Vizard::createSummaryCanvasNicer(Tracker& tracker,
                                         TCanvas *&RZCanvas, TCanvas *&RZCanvasBarrel, TCanvas *&XYCanvas,
                                         std::vector<TCanvas*> &XYCanvasesEC) {
@@ -7613,7 +7611,10 @@ namespace insur {
 
 
   /*
-  *  Draw spider net to delimit the Phi Sectors.
+  * Draw spider net to delimit the Phi Sectors.
+  * bool isRotatedY180 : 
+  - false: draws in CMS global frame of reference.
+  - true: draws in CMS global frame of reference rotated of 180° around CMS_Y.
   */
   void Vizard::drawPhiSectorsBoundaries(const double phiSectorWidth, const bool isRotatedY180) {
     int numPhiSectors = round(2. * M_PI / phiSectorWidth);
@@ -7635,7 +7636,7 @@ namespace insur {
    */
   void Vizard::drawFrameOfReference(const bool isRotatedY180) {
     
-    // CMS reference frame of reference
+    // CMS reference frame of reference.
     if (!isRotatedY180) {
       TArrow* arrowX = new TArrow(900, 900, 1100, 900, 0.02, "|>");
       arrowX->Draw();
@@ -7660,7 +7661,7 @@ namespace insur {
       textZ->Draw("same");
     }
 
-    // CMS frame of reference rotated by 180 degrees around CMS_Y
+    // CMS frame of reference rotated by 180 degrees around CMS_Y.
     else {
       TArrow* arrowX = new TArrow(1100, 900, 900, 900, 0.02, "|>");
       arrowX->Draw();

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1534,7 +1534,7 @@ namespace insur {
       createSummaryCanvasPowerCablingChannelNicer(tracker, myCablingMap, XYChannelPowerNegCanvas, XYChannelPowerNegFlatCanvas, XYChannelPowerCanvas, XYChannelPowerFlatCanvas, XYChannelPowerCanvasesDisk, XYNegChannelPowerCanvasesDisk);
 
       // POSITIVE CABLING SIDE
-      myContent->addItem(positiveSideName);  
+      myContent->addItem(positiveSideName);
       if (XYChannelPowerCanvas) {
 	myImage = new RootWImage(XYChannelPowerCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Positive cabling side. (CMS +Z points towards you)");
@@ -1574,16 +1574,24 @@ namespace insur {
 
 
       // SERVICES CHANNELS TABLES
-      RootWContent* channelsContent = new RootWContent("Services per channel", false);
+      RootWContent* channelsContent = new RootWContent("Services per channel and PP1", false);
       myPage->addContent(channelsContent);
+
+      RootWTable* opticalName = new RootWTable();
+      opticalName->setContent(0, 0, "Optical:");
+      RootWTable* poweringName = new RootWTable();
+      poweringName->setContent(0, 0, "Powering:");
+
       // POSITIVE CABLING SIDE
       isPositiveCablingSide = true;
       channelsContent->addItem(positiveSideName);
       // GENERAL
+      channelsContent->addItem(opticalName);
       ChannelSection requestedSection = ChannelSection::B;
       RootWTable* channelsTablePlus = servicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTablePlus);
       // SECTION A
+      channelsContent->addItem(poweringName);
       requestedSection = ChannelSection::A;
       RootWTable* channelsTablePlusA = powerServicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTablePlusA);
@@ -1595,12 +1603,15 @@ namespace insur {
       // NEGATIVE CABLING SIDE
       isPositiveCablingSide = false;
       channelsContent->addItem(spacer);
+      channelsContent->addItem(spacer);
       channelsContent->addItem(negativeSideName);
       // GENERAL
+      channelsContent->addItem(opticalName);
       requestedSection = ChannelSection::B;
       RootWTable* channelsTableMinus = servicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTableMinus);
       // SECTION A
+      channelsContent->addItem(poweringName);
       requestedSection = ChannelSection::A;
       RootWTable* channelsTableMinusA = powerServicesChannels(myCablingMap, isPositiveCablingSide, requestedSection);
       channelsContent->addItem(channelsTableMinusA);
@@ -1667,10 +1678,10 @@ namespace insur {
     RootWTable* channelsTable = new RootWTable();
 
     // Header table
-    channelsTable->setContent(0, 1, "# MFC");
-    channelsTable->setContent(0, 2, "# MFB PS");
-    channelsTable->setContent(0, 3, "# MFB 2S");
-    channelsTable->setContent(0, 4, "# MFB Total");
+    channelsTable->setContent(0, 2, "# MFC");
+    channelsTable->setContent(0, 3, "# MFB PS");
+    channelsTable->setContent(0, 4, "# MFB 2S");
+    channelsTable->setContent(0, 5, "# MFB Total");
 
     int totalCables = 0;
     int totalPsBundles = 0;
@@ -1685,27 +1696,35 @@ namespace insur {
       int numSsBundlesPerChannel = (ssBundlesPerChannel.count(channel) != 0 ? ssBundlesPerChannel.at(channel) : 0);
       int numBundlesPerChannel = numPsBundlesPerChannel + numSsBundlesPerChannel;
 
+      // PP1 name
+      const int pp1 = channel + (channel >= 0 ? (fabs(channel) <= 6 ? 2 : 5) : -(fabs(channel) <= 6 ? 2 : 5) );
+      std::stringstream pp1Name;
+      std::string sign = (pp1 >= 0 ? "+" : "");
+      pp1Name << "PP1" << sign << pp1;
+      if (requestedSection != ChannelSection::UNKNOWN) pp1Name << " " << any2str(requestedSection) << " ";
+      channelsTable->setContent(i, 0, pp1Name.str());
+
       // Channel name
       std::stringstream channelName;
       channelName << "OT" << channel;
-      if (requestedSection != ChannelSection::UNKNOWN) channelName << " " << any2str(requestedSection);
-      channelsTable->setContent(i, 0, channelName.str());
+      if (requestedSection != ChannelSection::UNKNOWN) channelName << " " << any2str(requestedSection) << " ";
+      channelsTable->setContent(i, 1, channelName.str());
 
-      channelsTable->setContent(i, 1, numCablesPerChannel);
-      channelsTable->setContent(i, 2, numPsBundlesPerChannel);
-      channelsTable->setContent(i, 3, numSsBundlesPerChannel);
-      channelsTable->setContent(i, 4, numBundlesPerChannel);
+      channelsTable->setContent(i, 2, numCablesPerChannel);
+      channelsTable->setContent(i, 3, numPsBundlesPerChannel);
+      channelsTable->setContent(i, 4, numSsBundlesPerChannel);
+      channelsTable->setContent(i, 5, numBundlesPerChannel);
 
       totalCables += numCablesPerChannel;
       totalPsBundles += numPsBundlesPerChannel;
       totalSsBundles += numSsBundlesPerChannel;
       totalBundles += numBundlesPerChannel;
     }
-    channelsTable->setContent(13, 0, "Total");
-    channelsTable->setContent(13, 1, totalCables);
-    channelsTable->setContent(13, 2, totalPsBundles);
-    channelsTable->setContent(13, 3, totalSsBundles);
-    channelsTable->setContent(13, 4, totalBundles);
+    channelsTable->setContent(13, 1, "Total");
+    channelsTable->setContent(13, 2, totalCables);
+    channelsTable->setContent(13, 3, totalPsBundles);
+    channelsTable->setContent(13, 4, totalSsBundles);
+    channelsTable->setContent(13, 5, totalBundles);
 
     return channelsTable;
   }
@@ -1760,9 +1779,9 @@ namespace insur {
     RootWTable* channelsTable = new RootWTable();
 
     // Header table
-    channelsTable->setContent(0, 1, "# PWR PS");
-    channelsTable->setContent(0, 2, "# PWR 2S");
-    channelsTable->setContent(0, 3, "# PWR Total");
+    channelsTable->setContent(0, 2, "# PWR PS");
+    channelsTable->setContent(0, 3, "# PWR 2S");
+    channelsTable->setContent(0, 4, "# PWR Total");
 
     int totalPsBundles = 0;
     int totalSsBundles = 0;
@@ -1775,24 +1794,32 @@ namespace insur {
       int numSsBundlesPerChannel = (ssBundlesPerChannel.count(channel) != 0 ? ssBundlesPerChannel.at(channel) : 0);
       int numBundlesPerChannel = numPsBundlesPerChannel + numSsBundlesPerChannel;
 
+      // PP1 name
+      const int pp1 = channel + (channel >= 0 ? (fabs(channel) <= 6 ? 2 : 5) : -(fabs(channel) <= 6 ? 2 : 5) );
+      std::stringstream pp1Name;
+      std::string sign = (pp1 >= 0 ? "+" : "");
+      pp1Name << "PP1" << sign << pp1;
+      if (requestedSection != ChannelSection::UNKNOWN) pp1Name << " " << any2str(requestedSection);
+      channelsTable->setContent(i, 0, pp1Name.str());
+
       // Channel name
       std::stringstream channelName;
       channelName << "OT" << channel;
       if (requestedSection != ChannelSection::UNKNOWN) channelName << " " << any2str(requestedSection);
-      channelsTable->setContent(i, 0, channelName.str());
+      channelsTable->setContent(i, 1, channelName.str());
 
-      channelsTable->setContent(i, 1, numPsBundlesPerChannel);
-      channelsTable->setContent(i, 2, numSsBundlesPerChannel);
-      channelsTable->setContent(i, 3, numBundlesPerChannel);
+      channelsTable->setContent(i, 2, numPsBundlesPerChannel);
+      channelsTable->setContent(i, 3, numSsBundlesPerChannel);
+      channelsTable->setContent(i, 4, numBundlesPerChannel);
 
       totalPsBundles += numPsBundlesPerChannel;
       totalSsBundles += numSsBundlesPerChannel;
       totalBundles += numBundlesPerChannel;
     }
-    channelsTable->setContent(13, 0, "Total");
-    channelsTable->setContent(13, 1, totalPsBundles);
-    channelsTable->setContent(13, 2, totalSsBundles);
-    channelsTable->setContent(13, 3, totalBundles);
+    channelsTable->setContent(13, 1, "Total");
+    channelsTable->setContent(13, 2, totalPsBundles);
+    channelsTable->setContent(13, 3, totalSsBundles);
+    channelsTable->setContent(13, 4, totalBundles);
 
     return channelsTable;
   }
@@ -7302,7 +7329,7 @@ namespace insur {
 			 << module.uniRef().subdetectorName << ", "
 			 << module.uniRef().layer << ", "
 			 << module.moduleRing() << ", "
-			 << module.center().Phi() * 180. / M_PI << ", ";
+			 << module.center().Phi() * 180. / M_PI;
 	      modulesToDTCsCsv << DTCInfo.str() << cableInfo.str() << bundleInfo.str() << moduleInfo.str() << std::endl;
 	    }
 	    if (myModules.size() == 0) modulesToDTCsCsv << DTCInfo.str() << cableInfo.str() << bundleInfo.str() << std::endl;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6994,7 +6994,9 @@ namespace insur {
   }
 
 
+  //template<class CoordType>
   void Vizard::createSummaryCanvasPowerCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
+							   //CoordType& XYNegType,
 							   TCanvas *&RZCanvas, 
 							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 							   std::vector<TCanvas*> &XYCanvasesDisk) {
@@ -7025,26 +7027,29 @@ namespace insur {
     computeServicesChannelsLegend(channelsLegendNeg, myCablingMap, isPositiveCablingSide, isPowerCabling);
 
     // NEGATIVE CABLING SIDE. BARREL.
+    bool isRotatedY180 = true;
     XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
     XYNegCanvas->cd();
-    PlotDrawer<XYNeg, TypeChannelTransparentColor> xyNegBarrelDrawer;
+    PlotDrawer<XYNegRotateY180, TypeChannelTransparentColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0)); } );
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
-    drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawPhiSectorsBoundaries(cabling_nonantWidth, isRotatedY180);  // Spider lines
     channelsLegendNeg->Draw("same");
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
+    isRotatedY180 = true;
     XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
     XYNegFlatCanvas->cd();
-    PlotDrawer<XYNeg, TypeChannelTransparentColor> xyNegFlatBarrelDrawer;
+    PlotDrawer<XYNegRotateY180, TypeChannelTransparentColor> xyNegFlatBarrelDrawer;
     xyNegFlatBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0) && !m.isTilted()); } );
     xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
     xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
-    drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+    drawPhiSectorsBoundaries(cabling_nonantWidth, isRotatedY180);  // Spider lines
     channelsLegendNeg->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
+    isRotatedY180 = false;
     XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
     XYCanvas->cd();
     PlotDrawer<XY, TypeChannelTransparentColor> xyBarrelDrawer;
@@ -7492,12 +7497,14 @@ namespace insur {
   /*
   *  Draw spider net to delimit the Phi Sectors.
   */
-  void Vizard::drawPhiSectorsBoundaries(const double phiSectorWidth) {
+  void Vizard::drawPhiSectorsBoundaries(const double phiSectorWidth, const bool isRotatedY180) {
     int numPhiSectors = round(2. * M_PI / phiSectorWidth);
     double phiSectorBoundaryRadius = 2 * vis_min_canvas_sizeX; 
 
     for (int i = 0; i < numPhiSectors; i++) {
-      TLine* line = new TLine(0., 0., phiSectorBoundaryRadius * cos(i * phiSectorWidth), phiSectorBoundaryRadius * sin(i * phiSectorWidth)); 
+      const double angle = i * phiSectorWidth;
+      const double rotatedAngle = (isRotatedY180 ?  M_PI - angle : angle);
+      TLine* line = new TLine(0., 0., phiSectorBoundaryRadius * cos(rotatedAngle), phiSectorBoundaryRadius * sin(rotatedAngle)); 
       line->SetLineWidth(2); 
       line->Draw("same");     
     }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6776,7 +6776,7 @@ namespace insur {
 	  if (found != allSurfaceModules.end()) {
 	    const std::vector<const Module*>& surfaceModules = found->second;
 	    TCanvas* XYCanvasEC = new TCanvas(Form("XYCanvasEC_%s_%d", anEndcap.myid().c_str(), surfaceIndex),
-					      Form("XY projection of Endcap %s -- surface %d", anEndcap.myid().c_str(), surfaceIndex),
+					      Form("XY section of Endcap %s -- surface %d", anEndcap.myid().c_str(), surfaceIndex),
 					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	    XYCanvasEC->cd();
 	    PlotDrawer<XY, Type> xyEndcapDrawer;
@@ -6862,7 +6862,7 @@ namespace insur {
 	    if ((surfaceIndex % 2) == 1) {
 	      const std::vector<const Module*>& surfaceModules = found->second;
 	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosRotateY180BundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
-						   Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards the depth of the screen)", anEndcap.myid().c_str(), surfaceIndex),
+						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
 						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	      XYSurfaceDisk->cd();
 	      PlotDrawer<XYRotateY180, TypeBundleColor> xyDiskDrawer;
@@ -6877,7 +6877,7 @@ namespace insur {
 	    else {
 	      const std::vector<const Module*>& surfaceModules = found->second;
 	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
-						   Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), surfaceIndex),
+						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
 						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	      XYSurfaceDisk->cd();
 	      PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
@@ -6925,7 +6925,7 @@ namespace insur {
 	    if ((surfaceIndex % 2) == 1) {
 	      const std::vector<const Module*>& surfaceModules = found->second;
 	      TCanvas* XYNegSurfaceDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
-						      Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards you)", 
+						      Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", 
 							   anEndcap.myid().c_str(), surfaceIndex),
 						      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	      XYNegSurfaceDisk->cd();
@@ -6940,7 +6940,7 @@ namespace insur {
 	    else {
 	      const std::vector<const Module*>& surfaceModules = found->second;
 	      TCanvas* XYNegSurfaceDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
-						      Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards the depth of the screen)", 
+						      Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", 
 							   anEndcap.myid().c_str(), surfaceIndex),
 						      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	      XYNegSurfaceDisk->cd();
@@ -7619,6 +7619,67 @@ namespace insur {
       TLine* line = new TLine(0., 0., phiSectorBoundaryRadius * cos(rotatedAngle), phiSectorBoundaryRadius * sin(rotatedAngle)); 
       line->SetLineWidth(2); 
       line->Draw("same");     
+    }
+    drawFrameOfReference(isRotatedY180);
+  }
+
+
+  /*
+   *  Draw frame of reference reminder.
+   */
+  void Vizard::drawFrameOfReference(const bool isRotatedY180) {
+    
+    // CMS reference frame of reference
+    if (!isRotatedY180) {
+      TArrow* arrowX = new TArrow(900, 900, 1100, 900, 0.02, "|>");
+      arrowX->Draw();
+      TLatex* textX = new TLatex(1000, 820, "X");
+      textX->SetTextSize(0.025);
+      textX->Draw("same");
+
+      TArrow* arrowY = new TArrow(900, 900, 900, 1100, 0.02, "|>");
+      arrowY->Draw();
+      TLatex* textY = new TLatex(820, 1000, "Y");
+      textY->SetTextSize(0.025);
+      textY->Draw("same");
+
+      TEllipse* circleZ = new TEllipse(1050, 1050, 50, 50);
+      circleZ->SetLineWidth(2);
+      circleZ->Draw("same");
+      TEllipse* pointZ = new TEllipse(1050, 1050, 10, 10);
+      pointZ->SetFillColor(kBlack);
+      pointZ->Draw("same");
+      TLatex* textZ = new TLatex(1030, 1110, "Z");
+      textZ->SetTextSize(0.025);
+      textZ->Draw("same");
+    }
+
+    // CMS frame of reference rotated by 180 degrees around CMS_Y
+    else {
+      TArrow* arrowX = new TArrow(1100, 900, 900, 900, 0.02, "|>");
+      arrowX->Draw();
+      TLatex* textX = new TLatex(950, 820, "X");
+      textX->SetTextSize(0.025);
+      textX->Draw("same");
+
+      TArrow* arrowY = new TArrow(1100, 900, 1100, 1100, 0.02, "|>");
+      arrowY->Draw();
+      TLatex* textY = new TLatex(1020, 1000, "Y");
+      textY->SetTextSize(0.025);
+      textY->Draw("same");
+
+      TEllipse* circleZ = new TEllipse(850, 1050, 50, 50);
+      circleZ->SetLineWidth(2);
+      circleZ->Draw("same");
+      TLine* lineU = new TLine(815, 1015, 885, 1085);
+      lineU->SetLineWidth(2);
+      lineU->Draw("same");
+      TLine* lineD = new TLine(815, 1085, 885, 1015);
+      lineD->SetLineWidth(2);
+      lineD->Draw("same");
+      TLatex* textZ = new TLatex(830, 1110, "Z");
+      textZ->SetTextSize(0.025);
+      textZ->Draw("same");
     }
   }
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1285,17 +1285,19 @@ namespace insur {
       RootWImage* myImage;
 
       // Modules to Bundles
-      TCanvas *summaryBundleCanvas = nullptr;
       TCanvas *RZBundleCanvas = nullptr;
       TCanvas *XYBundleNegCanvas = nullptr;
       TCanvas *XYBundleCanvas = nullptr;   
-      std::vector<TCanvas*> XYBundleCanvasesDisk;
-      std::vector<TCanvas*> XYSurfacesDisk;
+      std::vector<TCanvas*> XYPosBundlesDisks;
+      std::vector<TCanvas*> XYPosBundlesDiskSurfaces;
+      std::vector<TCanvas*> XYNegBundlesDisks;
+      std::vector<TCanvas*> XYNegBundlesDiskSurfaces;
    
       myContent = new RootWContent("Modules to Bundles");
       myPage->addContent(myContent);
 
-      createSummaryCanvasCablingBundleNicer(tracker, RZBundleCanvas, XYBundleCanvas, XYBundleNegCanvas, XYBundleCanvasesDisk, XYSurfacesDisk);
+      createSummaryCanvasCablingBundleNicer(tracker, RZBundleCanvas, XYBundleCanvas, XYBundleNegCanvas, 
+					    XYPosBundlesDisks, XYPosBundlesDiskSurfaces, XYNegBundlesDisks, XYNegBundlesDiskSurfaces);
 
       if (RZBundleCanvas) {
 	myImage = new RootWImage(RZBundleCanvas, RZBundleCanvas->GetWindowWidth(), RZBundleCanvas->GetWindowHeight() );
@@ -1312,14 +1314,36 @@ namespace insur {
 	myImage->setComment("(XY) Section : Tracker barrel, Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYBundleCanvasDisk : XYBundleCanvasesDisk ) {
-	  myImage = new RootWImage(XYBundleCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYBundleCanvasDisk->GetTitle());
+      // POSITIVE CABLING SIDE
+      myContent = new RootWContent("");
+      myPage->addContent(myContent);
+      RootWTable* positiveSideName = new RootWTable();
+      positiveSideName->setContent(0, 0, "Positive cabling side:");
+      myContent->addItem(positiveSideName);
+      for (const auto& XYPosDisk : XYPosBundlesDisks) {
+	  myImage = new RootWImage(XYPosDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	  myImage->setComment(XYPosDisk->GetTitle());
 	  myContent->addItem(myImage);
       }
-      for (const auto& XYSurface : XYSurfacesDisk ) {
-	  myImage = new RootWImage(XYSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYSurface->GetTitle());
+      for (const auto& XYPosSurface : XYPosBundlesDiskSurfaces) {
+	  myImage = new RootWImage(XYPosSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	  myImage->setComment(XYPosSurface->GetTitle());
+	  myContent->addItem(myImage);
+      }
+      // NEGATIVE CABLING SIDE
+      myContent = new RootWContent("");
+      myPage->addContent(myContent);
+      RootWTable* negativeSideName = new RootWTable();
+      negativeSideName->setContent(0, 0, "Negative cabling side:");
+      myContent->addItem(negativeSideName);
+      for (const auto& XYNegDisk : XYNegBundlesDisks) {
+	  myImage = new RootWImage(XYNegDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	  myImage->setComment(XYNegDisk->GetTitle());
+	  myContent->addItem(myImage);
+      }
+      for (const auto& XYNegSurface : XYNegBundlesDiskSurfaces) {
+	  myImage = new RootWImage(XYNegSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	  myImage->setComment(XYNegSurface->GetTitle());
 	  myContent->addItem(myImage);
       }
 
@@ -1379,8 +1403,6 @@ namespace insur {
       RootWInfo* myInfo = nullptr;
       // POSITIVE CABLING SIDE
       bool isPositiveCablingSide = true;
-      RootWTable* positiveSideName = new RootWTable();
-      positiveSideName->setContent(0, 0, "Positive cabling side:");
       filesContent->addItem(positiveSideName);
       // Modules to DTCs
       myTextFile = new RootWTextFile(Form("ModulesToDTCsPos%s.csv", name.c_str()), "Modules to DTCs");
@@ -1408,8 +1430,6 @@ namespace insur {
       spacer->setContent(1, 0, " ");
       spacer->setContent(2, 0, " ");
       filesContent->addItem(spacer);
-      RootWTable* negativeSideName = new RootWTable();
-      negativeSideName->setContent(0, 0, "Negative cabling side:");
       filesContent->addItem(negativeSideName);
       // Modules to DTCs
       myTextFile = new RootWTextFile(Form("ModulesToDTCsNeg%s.csv", name.c_str()), "Modules to DTCs");
@@ -1475,7 +1495,6 @@ namespace insur {
 
       // Modules to Services Channels (optical)
       TCanvas *summaryChannelOpticalCanvas = nullptr;
-      TCanvas *RZChannelOpticalCanvas = nullptr;
       TCanvas *XYChannelOpticalNegCanvas = nullptr;
       TCanvas *XYChannelOpticalNegFlatCanvas = nullptr;
       TCanvas *XYChannelOpticalCanvas = nullptr; 
@@ -1485,13 +1504,8 @@ namespace insur {
       myContent = new RootWContent("Modules to Services Channels (optical)");
       myPage->addContent(myContent);
 
-      createSummaryCanvasOpticalCablingChannelNicer(tracker, myCablingMap, RZChannelOpticalCanvas, XYChannelOpticalNegCanvas, XYChannelOpticalNegFlatCanvas, XYChannelOpticalCanvas, XYChannelOpticalFlatCanvas, XYChannelOpticalCanvasesDisk);
+      createSummaryCanvasOpticalCablingChannelNicer(tracker, myCablingMap, XYChannelOpticalNegCanvas, XYChannelOpticalNegFlatCanvas, XYChannelOpticalCanvas, XYChannelOpticalFlatCanvas, XYChannelOpticalCanvasesDisk);
 
-      /*if (RZChannelOpticalCanvas) {
-	myImage = new RootWImage(RZChannelOpticalCanvas, RZChannelOpticalCanvas->GetWindowWidth(), RZChannelOpticalCanvas->GetWindowHeight() );
-	myImage->setComment("(RZ) View : Tracker modules colored by their connections to Services Channels. 1 color = 1 Channel.");
-	myContent->addItem(myImage);
-	}*/
       if (XYChannelOpticalNegCanvas) {
 	myImage = new RootWImage(XYChannelOpticalNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards you)");
@@ -6782,9 +6796,10 @@ namespace insur {
 
 
   void Vizard::createSummaryCanvasCablingBundleNicer(const Tracker& tracker,
-					       TCanvas *&RZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas,
-						     std::vector<TCanvas*> &XYCanvasesDisk, std::vector<TCanvas*> &XYSurfacesDisk) {
-
+						     TCanvas *&RZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas,
+						     std::vector<TCanvas*> &XYPosBundlesDisks, std::vector<TCanvas*> &XYPosBundlesDiskSurfaces,
+						     std::vector<TCanvas*> &XYNegBundlesDisks, std::vector<TCanvas*> &XYNegBundlesDiskSurfaces) {
+    
     double scaleFactor = tracker.maxR()/600;
 
     int rzCanvasX = insur::vis_max_canvas_sizeX;//int(tracker.maxZ()/scaleFactor);
@@ -6817,11 +6832,12 @@ namespace insur {
     xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
 
+    // POSITIVE CABLING SIDE.
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
       if (anEndcap.disks().size() > 0) {
 	const Disk& lastDisk = anEndcap.disks().back();
-	TCanvas* XYCanvasDisk = new TCanvas(Form("XYCanvasEndcap_%sAnyDisk", anEndcap.myid().c_str()),
+	TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
 					    Form("(XY) Projection : Endcap %s, any Disk. (CMS +Z points towards you)", anEndcap.myid().c_str()),
 					    vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	XYCanvasDisk->cd();
@@ -6830,7 +6846,7 @@ namespace insur {
 	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
 	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
 	drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-	XYCanvasesDisk.push_back(XYCanvasDisk);
+	XYPosBundlesDisks.push_back(XYCanvasDisk);
       }
     }
 
@@ -6841,17 +6857,101 @@ namespace insur {
 	const std::map<int, std::vector<const Module*> >& allSurfaceModules = lastDisk.getSurfaceModules();
 	for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
 	  auto found = allSurfaceModules.find(surfaceIndex);
+	  if (found != allSurfaceModules.end()) {  
+	    // Surface seen rotated: (+Z) towards the depth of the screen
+	    if ((surfaceIndex % 2) == 1) {
+	      const std::vector<const Module*>& surfaceModules = found->second;
+	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosRotateY180BundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+						   Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards the depth of the screen)", anEndcap.myid().c_str(), surfaceIndex),
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	      XYSurfaceDisk->cd();
+	      PlotDrawer<XYRotateY180, TypeBundleColor> xyDiskDrawer;
+	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      const bool isRotatedY180 = true;
+	      drawPhiSectorsBoundaries(cabling_nonantWidth, isRotatedY180);  // Spider lines
+	      XYPosBundlesDiskSurfaces.push_back(XYSurfaceDisk);
+	    }
+	    // (+Z) towards you
+	    else {
+	      const std::vector<const Module*>& surfaceModules = found->second;
+	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+						   Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), surfaceIndex),
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	      XYSurfaceDisk->cd();
+	      PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
+	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+	      XYPosBundlesDiskSurfaces.push_back(XYSurfaceDisk);
+	    }
+	  }
+	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
+	}
+      }
+    }
+
+    // NEGATIVE CABLING SIDE.
+    // ENDCAPS DISK.
+    for (auto& anEndcap : tracker.endcaps() ) {
+      if (anEndcap.disks().size() > 0) {
+	const Disk& firstDisk = anEndcap.disks().front();
+	TCanvas* XYNegCanvasDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
+					       Form("(XY) Projection : Endcap %s, any Disk. (CMS +Z points towards the depth of the screen)", 
+						    anEndcap.myid().c_str()),
+					       vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	XYNegCanvasDisk->cd();
+	PlotDrawer<XYNegRotateY180, TypeBundleColor> xyDiskDrawer;
+	xyDiskDrawer.addModules(firstDisk);
+	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvasDisk);
+	xyDiskDrawer.drawModules<ContourStyle>(*XYNegCanvasDisk);
+	const bool isRotatedY180 = true;
+	drawPhiSectorsBoundaries(cabling_nonantWidth, isRotatedY180);  // Spider lines
+	XYNegBundlesDisks.push_back(XYNegCanvasDisk);
+      }
+    }
+
+    // ENDCAPS DISK SURFACE.
+    for (auto& anEndcap : tracker.endcaps() ) {
+      if (anEndcap.disks().size() > 0) {
+	const Disk& firstDisk = anEndcap.disks().front();	
+	const std::map<int, std::vector<const Module*> >& allSurfaceModules = firstDisk.getSurfaceModules();
+	for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
+	  auto found = allSurfaceModules.find(surfaceIndex);
 	  if (found != allSurfaceModules.end()) {
-	    const std::vector<const Module*>& surfaceModules = found->second;
-	    TCanvas* XYSurfaceDisk = new TCanvas(Form("XYSurfaceEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
-						 Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), surfaceIndex),
-						 vis_min_canvas_sizeX, vis_min_canvas_sizeY );
-	    XYSurfaceDisk->cd();
-	    PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
-	    xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	    xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	    xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
-	    XYSurfacesDisk.push_back(XYSurfaceDisk);
+	    // (+Z) towards you
+	    if ((surfaceIndex % 2) == 1) {
+	      const std::vector<const Module*>& surfaceModules = found->second;
+	      TCanvas* XYNegSurfaceDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+						      Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards you)", 
+							   anEndcap.myid().c_str(), surfaceIndex),
+						      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	      XYNegSurfaceDisk->cd();
+	      PlotDrawer<XYNeg, TypeBundleColor> xyDiskDrawer;
+	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk);
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk);
+	      drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
+	      XYNegBundlesDiskSurfaces.push_back(XYNegSurfaceDisk);
+	    }
+	    // Surface seen rotated: (+Z) towards the depth of the screen
+	    else {
+	      const std::vector<const Module*>& surfaceModules = found->second;
+	      TCanvas* XYNegSurfaceDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+						      Form("(XY) Projection : Endcap %s, any Disk, Surface %d. (CMS +Z points towards the depth of the screen)", 
+							   anEndcap.myid().c_str(), surfaceIndex),
+						      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+	      XYNegSurfaceDisk->cd();
+	      PlotDrawer<XYNegRotateY180, TypeBundleColor> xyDiskDrawer;
+	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk);
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk);
+	      const bool isRotatedY180 = true;
+	      drawPhiSectorsBoundaries(cabling_nonantWidth, isRotatedY180);  // Spider lines
+	      XYNegBundlesDiskSurfaces.push_back(XYNegSurfaceDisk);
+	    }
 	  }
 	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
 	}
@@ -6922,7 +7022,7 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       for (auto& aDisk : anEndcap.disks() ) {
 	if (aDisk.side()) {
-	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYCanvasEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosDTCEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
 					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	  XYCanvasDisk->cd();
@@ -6939,27 +7039,8 @@ namespace insur {
 
 
   void Vizard::createSummaryCanvasOpticalCablingChannelNicer(Tracker& tracker, const CablingMap* myCablingMap,
-							   TCanvas *&RZCanvas, 
 							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
 							   std::vector<TCanvas*> &XYCanvasesDisk) {
-
-    double scaleFactor = tracker.maxR()/600;
-
-    int rzCanvasX = insur::vis_max_canvas_sizeX;//int(tracker.maxZ()/scaleFactor);
-    int rzCanvasY = insur::vis_min_canvas_sizeX;//int(tracker.maxR()/scaleFactor);
-
-    const std::set<Module*>& trackerModules = tracker.modules();
-    RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", rzCanvasX, rzCanvasY );
-    RZCanvas->cd();
-    PlotDrawer<YZFull, TypeChannelColor> yzDrawer;
-    yzDrawer.addModules(trackerModules.begin(), trackerModules.end(), [] (const Module& m ) { 
-	return ( (m.isPositiveCablingSide() > 0 && m.dtcPhiSectorRef() == 1) || (m.isPositiveCablingSide() < 0 && m.dtcPhiSectorRef() == 2) ); 
-      } );
-    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
-    yzDrawer.drawModules<ContourStyle>(*RZCanvas);
-
-    double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
-
     bool isPowerCabling = false;
     bool isPositiveCablingSide = true;
     TLegend* channelsLegendPos = new TLegend(0.905,0.3,1.0,0.8);
@@ -6976,8 +7057,7 @@ namespace insur {
     xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
     xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
     drawPhiSectorsBoundaries(cabling_nonantWidth);  // Spider lines
-    channelsLegendNeg->Draw("same");
-    
+    channelsLegendNeg->Draw("same"); 
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
     XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
@@ -7013,7 +7093,7 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       for (auto& aDisk : anEndcap.disks() ) {
 	if (aDisk.side()) {
-	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYCanvasEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosOpticalChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
 					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	  XYCanvasDisk->cd();
@@ -7090,7 +7170,7 @@ namespace insur {
 	// POSITIVE CABLING SIDE. ENDCAPS DISK.
 	if (aDisk.side()) {
 	  isRotatedY180 = false;
-	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYCanvasEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosPowerChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
 					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	  XYCanvasDisk->cd();
@@ -7105,7 +7185,7 @@ namespace insur {
 	// NEGATIVE CABLING SIDE. ENDCAPS DISK.
 	else {
 	  isRotatedY180 = true;
-	  TCanvas* XYNegCanvasDisk = new TCanvas(Form("XYNegCanvasEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  TCanvas* XYNegCanvasDisk = new TCanvas(Form("XYNegPowerChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards the depth of the screen)", anEndcap.myid().c_str(), aDisk.myid()),
 					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
 	  XYNegCanvasDisk->cd();

--- a/src/tklayout.cc
+++ b/src/tklayout.cc
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     ("resolution,r", "Report resolution analysis.")
     ("debug-resolution,R", "Report extended resolution analysis : debug plots for modules parametrized spatial resolution.")
     ("pattern-reco,P", "Report pattern recognition analysis.")
-    ("cablingMap,c", "Build an optical cabling map, which connects each module to a bundle, cable, DTC + Build a power cabling map. Also provide info on routing of services into channels.")
+    ("cablingMap,c", "Build an optical cabling map, which connects each module to a bundle, cable, DTC + Build a power cabling map. Also provide info on routing of services through channels.")
     ("trigger,t", "Report base trigger analysis.")
     ("trigger-ext,T", "Report extended trigger analysis.\n\t(implies 't')")
     ("debug-services,d", "Service additional debug info")

--- a/src/tklayout.cc
+++ b/src/tklayout.cc
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     ("resolution,r", "Report resolution analysis.")
     ("debug-resolution,R", "Report extended resolution analysis : debug plots for modules parametrized spatial resolution.")
     ("pattern-reco,P", "Report pattern recognition analysis.")
-    ("cablingMap,c", "Build an optical cabling map, which connects each module to a bundle, cable, DTC. Can actually be reused for power cables.")
+    ("cablingMap,c", "Build an optical cabling map, which connects each module to a bundle, cable, DTC + Build a power cabling map. Also provide info on routing of services into channels.")
     ("trigger,t", "Report base trigger analysis.")
     ("trigger-ext,T", "Report extended trigger analysis.\n\t(implies 't')")
     ("debug-services,d", "Service additional debug info")
@@ -158,7 +158,11 @@ int main(int argc, char* argv[]) {
       }
     }
     
-    if (vm.count("cablingMap") && !squid.reportCablingMapSite(vm.count("cablingMap"), basename)) return EXIT_FAILURE;
+    // Cabling map: Only computed for a specific layout (for which the map is designed).
+    // It is also computed if ever the user forces computation by using 'cabling' option.
+    if (((vm.count("all") && basename.find(insur::default_cabledOTName) != std::string::npos) || vm.count("cablingMap")) 
+	&& !squid.reportCablingMapSite(vm.count("cablingMap"), basename)) return EXIT_FAILURE;
+
     if ((vm.count("all") || vm.count("trigger") || vm.count("trigger-ext")) &&
         ( !squid.analyzeTriggerEfficiency(mattracks, vm.count("trigger-ext")) || !squid.reportTriggerPerformanceSite(vm.count("trigger-ext"))) ) return EXIT_FAILURE;
    

--- a/src/tklayout.cc
+++ b/src/tklayout.cc
@@ -159,7 +159,7 @@ int main(int argc, char* argv[]) {
     }
     
     // Cabling map: Only computed for a specific layout (for which the map is designed).
-    // It is also computed if ever the user forces computation by using 'cabling' option.
+    // It is also computed if ever the user forces computation by using 'cablingMap' option.
     if (((vm.count("all") && basename.find(insur::default_cabledOTName) != std::string::npos) || vm.count("cablingMap")) 
 	&& !squid.reportCablingMapSite(vm.count("cablingMap"), basename)) return EXIT_FAILURE;
 


### PR DESCRIPTION
1) MFBs channels assignments:
- There should be less crossings of the MFBs than in the previous version :)
- There is the equivalent of 8 or 10 MFCs per channel.
- All double-disks within same TEDD block (TEDD_1 or TEDD_2) have same channels assignment scheme.
- There is the same channels assignment scheme on (+Z) and (-Z) sides 
('same' = invariant by push-through symmetry, mirror).

2) Power cables channels assignments:
It is now completely decoupled from MFBs channels assignments.
This scheme must follow a rotational symmetry of 180 degrees around CMS_Y.
- Barrel: There is the same cabling scheme on both (Z) sides (except for the flat ladders in TBPS).
('same' = invariant by rotation of 180 degrees around CMS_Y).
- Endcaps: 2 different cabling schemes, one per (Z) end.
All double-disks within same TEDD block (TEDD_1 or TEDD_2) have same channels assignment scheme.

3) Added detailed plots for technicians on website: which modules should be connected to which MFBs in TEDD?

4) Recomputed all cabling map for layout OT614 ('identical dees' design from Nick, resulting in a shift in Phi in TEDD).
OT614 is now set as the default layout for which the cabling map should be computed (will not work for any other layout!).


Results: 
All results accessible at http://ghugo.web.cern.ch/ghugo/layouts/channels/OT614_200_IT4025/cablingOuter.html 
