### PR TITLE
Important: Bug fixes affecting tracking resolution + Shape of luminous region for resolution studies

### DIFF
--- a/include/InactiveElement.hh
+++ b/include/InactiveElement.hh
@@ -53,8 +53,7 @@ namespace insur {
     virtual double getLength() const;
     double getVolume() const;
     std::pair<double, double> getEtaMinMax() const;
-    const bool checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir, Material& hitMaterial, XYZVector& hitPos, double& factor);
-    const bool checkTrackHits(const XYZVector& trackOrig, const double& trackEta) const;
+    const bool checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir, XYZVector& hitPos, Material& hitMaterial);
     int getFeederIndex();
     void setFeederIndex(int layer);
     InType getFeederType();

--- a/include/InactiveElement.hh
+++ b/include/InactiveElement.hh
@@ -16,6 +16,7 @@
 
 #include "MaterialProperties.hh"
 #include "global_constants.hh"
+#include "CoordinateOperations.hh"
 namespace insur {
   /**
    * @class InactiveElement
@@ -42,12 +43,17 @@ namespace insur {
     void setZOffset(double zoffset);
     double getZLength() const;
     void setZLength(double zlength);
+    const double getZMax() const;
     double getInnerRadius() const;
     void setInnerRadius(double iradius);
     double getRWidth() const;
     void setRWidth(double width);
+    const double getOuterRadius() const;
     virtual double getLength() const;
     double getVolume() const;
+    std::pair<double, double> getEtaMinMax() const;
+    //bool checkTrackHits(const XYZVector& trackOrig, const Polar3DVector& trackDir, Material& hitMaterial, XYZVector& hitPos) const;
+    const bool checkTrackHits(const XYZVector& trackOrig, const double& trackEta) const;
     int getFeederIndex();
     void setFeederIndex(int layer);
     InType getFeederType();
@@ -60,7 +66,6 @@ namespace insur {
     void setLocalMass(double mass);
     void setRadiationLength(double rlength);
     void setInteractionLength(double ilength);
-    std::pair<double, double> getEtaMinMax();
     virtual void print();
   protected:
     bool is_vertical, is_final;

--- a/include/InactiveElement.hh
+++ b/include/InactiveElement.hh
@@ -53,7 +53,7 @@ namespace insur {
     virtual double getLength() const;
     double getVolume() const;
     std::pair<double, double> getEtaMinMax() const;
-    const bool checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir, Material& hitMaterial, XYZVector& hitPos);
+    const bool checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir, Material& hitMaterial, XYZVector& hitPos, double& factor);
     const bool checkTrackHits(const XYZVector& trackOrig, const double& trackEta) const;
     int getFeederIndex();
     void setFeederIndex(int layer);

--- a/include/InactiveElement.hh
+++ b/include/InactiveElement.hh
@@ -17,6 +17,7 @@
 #include "MaterialProperties.hh"
 #include "global_constants.hh"
 #include "CoordinateOperations.hh"
+#include "MessageLogger.hh"
 namespace insur {
   /**
    * @class InactiveElement
@@ -52,7 +53,7 @@ namespace insur {
     virtual double getLength() const;
     double getVolume() const;
     std::pair<double, double> getEtaMinMax() const;
-    //bool checkTrackHits(const XYZVector& trackOrig, const Polar3DVector& trackDir, Material& hitMaterial, XYZVector& hitPos) const;
+    const bool checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir, Material& hitMaterial, XYZVector& hitPos);
     const bool checkTrackHits(const XYZVector& trackOrig, const double& trackEta) const;
     int getFeederIndex();
     void setFeederIndex(int layer);

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -26,6 +26,7 @@ namespace insur {
   static const std::vector<std::string> geom_name_eta_regions  = {""   ,"C","I","F","VF","VVF"};  // Name tracker eta regions
   static const std::vector<double>      geom_range_eta_regions = {0.001,0.8,1.6,2.4 ,3.2 ,4.0  }; // Name tracker eta regions
 
+  static const double geom_zero                       = 1E-6;    // mm
   static const double geom_epsilon                    = 0.1;
   static const double geom_inactive_volume_width      = 2.0;     // mm
   static const double geom_conversion_station_width   = 2.0;     // mm

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1863,18 +1863,31 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
 
   XYZVector trackDir;
   trackDir = t.getDirection();
-  //const Polar3DVector& trackDir = t.getDirection();
+  //const Polar3DVector& trackDirPolar = t.getDirection();
   Material hitMaterial;
   XYZVector hitPos;
 
   while (iter != guard) {
 
-    // Volume is hit
-    bool isHit = iter->checkTrackHits(trackOrig, trackDir, hitMaterial, hitPos);
-    //bool isHit = iter->checkTrackHits(trackOrig, trackEta);
-      if (isHit) {
+    bool isHitOld = iter->checkTrackHits(trackOrig, trackEta);
 
-	/*
+    if (isHitOld) {
+      std::cout << "eta = " << trackEta  << std::endl;
+      std::cout << "trackOrigZ = " << trackOrigZ << std::endl;
+
+      std::cout << "iter->isVertical() = " << iter->isVertical() << std::endl;
+      std::cout << "iter->getInnerRadius() = " << iter->getInnerRadius() << std::endl;
+      std::cout << "iter->getOuterRadius() = " << iter->getOuterRadius() << std::endl;
+      std::cout << "iter->getZOffset() = " << iter->getZOffset() << std::endl;
+      std::cout << "iter->getZMax() = " << iter->getZMax() << std::endl;
+
+      // Volume is hit
+      double factorNew = 0.;
+      bool isHit = iter->checkTrackHits(trackOrig, trackDir, hitMaterial, hitPos, factorNew);
+      //bool isHit = iter->checkTrackHits(trackOrig, trackEta);
+      //if (isHit) {
+
+      double factor = 0.;
         double r, z;
         // radiation and interaction lenth scaling for vertical volumes
         if (iter->isVertical()) { // Element is vertical
@@ -1886,16 +1899,19 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
           s_normal = iter->getZLength() / cos(t.getTheta());
           s_alternate = iter->getRWidth() / sin(t.getTheta());
           if (s_normal > s_alternate) { 
+	    std::cout << "Old special case " << std::endl;
             // Special case: it's easier to cross the material by going left-to-right than
             // by going bottom-to-top, so I have to rescale the material amount computation
             corr.radiation = iter->getRadiationLength() / iter->getZLength() * s_alternate;
             corr.interaction = iter->getInteractionLength() / iter->getZLength() * s_alternate;
             res += corr;
+	    factor = 1. / iter->getZLength() * s_alternate;
           } else {
             // Standard computing of the crossed material amount
             corr.radiation = iter->getRadiationLength() / cos(t.getTheta());
             corr.interaction = iter->getInteractionLength() / cos(t.getTheta());
             res += corr;
+	    factor = 1. / cos(t.getTheta());
           }
         }
         // radiation and interaction length scaling for horizontal volumes
@@ -1907,26 +1923,44 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
           // we have to take into account its finite z length
           s_normal = iter->getRWidth() / sin(t.getTheta());
           s_alternate = iter->getZLength() / cos(t.getTheta());
-          if (s_normal > s_alternate) { 
+          if (s_normal > s_alternate) {
+	    std::cout << "Old special case " << std::endl;
             // Special case: it's easier to cross the material by going left-to-right than
             // by going bottom-to-top, so I have to rescale the material amount computation
             corr.radiation = iter->getRadiationLength() / iter->getRWidth() * s_alternate;
             corr.interaction = iter->getInteractionLength() / iter->getRWidth() * s_alternate;
             res += corr;
+	    factor = 1. / iter->getRWidth() * s_alternate;
           } else {
             // Standard computing of the crossed material amount
             corr.radiation = iter->getRadiationLength() / sin(t.getTheta());
             corr.interaction = iter->getInteractionLength() / sin(t.getTheta());
             res += corr;
+	    factor = 1. / sin(t.getTheta());
           }
-	  }
+	}
 
         // Create Hit object with appropriate parameters, add to Track t
-        double rPos = r;
-        double zPos = z;*/
+        //double rPos = r;
+        //double zPos = z;
 
 	auto hitRPos = hitPos.rho();
 	auto hitZPos = hitPos.z();
+
+	
+
+	std::cout << "factorOld = " << factor << std::endl;
+	if (fabs(factor - factorNew) > 0.001 && iter->getRadiationLength() != 0.)  {
+	  std::cout << " Hey !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+	  std::cout << "r = " << r << " hitRPos = " << hitRPos << std::endl;
+	  std::cout << "z = " << z << " hitZPos = " << hitZPos << std::endl;
+	  if (r < iter->getInnerRadius() || r > iter->getOuterRadius()) std::cout << "r of the hit is out of the volume." << std::endl;
+	  if (hitRPos < iter->getInnerRadius() || hitRPos > iter->getOuterRadius()) std::cout << "hitRPos of the hit is out of the volume." << std::endl;
+	  if (z < iter->getZOffset() || z > iter->getZMax()) std::cout << "z of the hit is out of the volume." << std::endl;
+	  if (hitZPos < iter->getZOffset() || hitZPos > iter->getZMax()) std::cout << "hitZPos of the hit is out of the volume." << std::endl;
+
+	}
+	
 
 
         //HitNewPtr hit(new HitNew(rPos, zPos));

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1847,6 +1847,7 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
   double s_normal = 0;
   double s_alternate = 0;
   while (iter != guard) {
+
     // Collision detection: rays are in z+ only, so only volumes in z+ need to be considered
     // only volumes of the requested category, or those without one (which should not exist) are examined
     if ((iter->getZOffset() + iter->getZLength()) > 0) {
@@ -2380,7 +2381,7 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 	      // Consider hit modules	
 	      if ((*iHit)->isActive() && (*iHit)->getHitModule()) {
 		
-		    const auto& hitModule = (*iHit)->getHitModule();
+		const auto& hitModule = (*iHit)->getHitModule();
 		// If any parameter for resolution on local X coordinate specified for hitModule, fill maps and distributions
 		if (hitModule->hasAnyResolutionLocalXParam()) {
 		  double trackPhi = myTrack->getPhi();

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1654,7 +1654,10 @@ Material Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, TrackNew& 
   // set the track direction vector
   while (iter != guard) {
     // collision detection: rays are in z+ only, so consider only modules that lie on that side
-    if (iter->getModule().maxZ() > 0) {
+    //if (iter->getModule().maxZ() > 0) {
+
+
+
         // same method as in Tracker, same function used
         // TODO: in case origin==0,0,0 and phi==0 just check if sectionYZ and minEta, maxEta
         //distance = iter->getModule().trackCross(origin, direction);
@@ -1688,7 +1691,7 @@ Material Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, TrackNew& 
           if (isPixel) hit->setAsPixel();
           t.addHit(std::move(hit));
         }
-    }
+	//}
     iter++;
   }
   return res;
@@ -1862,7 +1865,8 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
 
     // Collision detection: rays are in z+ only, so only volumes in z+ need to be considered
     // only volumes of the requested category, or those without one (which should not exist) are examined
-    if ((iter->getZOffset() + iter->getZLength()) > 0) {
+    
+    //if ((iter->getZOffset() + iter->getZLength()) > 0) {
 
       // Volume is hit
       bool isHit = iter->checkTrackHits(trackOrig, trackEta);
@@ -1932,7 +1936,7 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
 //        t.addHit(hit);
 	// std::cout << "OLD USED" << std::endl;
       }
-    }
+      //}
 
     iter++;
   }

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1843,35 +1843,39 @@ Material Analyzer::analyzeInactiveSurfaces(std::vector<InactiveElement>& element
  * The total crossed material is returned.
  * As all inactive volumes are symmetric with respect to rotation around the z-axis, the track angle phi is not necessary.
  * @param elements A reference to the collection of inactive surfaces that is to be checked for collisions with the track
- * @param eta The pseudorapidity of the current track
- * @param theta The track angle in the yz-plane
  * @param t A reference to the current track object
+ * @param isPixel Are we inside the Inner Tracker?
  * @return The scaled and summed up crossed material amount
  */
   Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elements, TrackNew& t, bool isPixel) {
-    //std::vector<InactiveElement>::iterator iter = elements.begin();
-    //std::vector<InactiveElement>::iterator guard = elements.end();
     const XYZVector& trackOrig = t.getOrigin();
     XYZVector trackDir;
     trackDir = t.getDirection();
+
     Material total;
  
+    // Loop on inactive elements
     for (auto& elem : elements) {
-
       XYZVector hitPos;
       Material hitMaterial;
+
+      // Checks whether track hits the inactive element.
+      // If yes, return true with passed hit position vector & material. 
       bool isHit = elem.checkTrackHits(trackOrig, trackDir, hitPos, hitMaterial);
       // Volume is hit
       if (isHit) {
 	const double hitRho = hitPos.Rho();
 	const double hitZ = hitPos.Z();
-	total += hitMaterial;
 
-	// Create Hit object with appropriate parameters, add to Track t
+	// Create Hit object with appropriate parameters
 	HitNewPtr hit(new HitNew(hitRho, hitZ));
 	hit->setAsPassive();
 	hit->setCorrectedMaterial(hitMaterial);
+	// Add the inactive hit to the track
 	t.addHit(std::move(hit));
+
+	// Total inactive MB
+	total += hitMaterial;
 
 	//        if (iter->isVertical()) hit->setOrientation(Hit::Vertical);
 	//        else hit->setOrientation(Hit::Horizontal);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -166,14 +166,8 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
     //std::cout << " track's phi = " << phi << std::endl; 
     track.setThetaPhiPt(theta,phi,1*Units::TeV);
 
-
-    track.setOrigin(0., 0., 70.*(myDice.Rndm()*2.-1.)); // TODO: Not assuming z-error when analyzing resolution (missing implementation of non-zero track starting point in inactive hits)
-    //track.setOrigin(0., 0., 0.); 
-
-
-
-    //track.setTheta(theta);
-    //track.setPhi(phi);
+    // TO DO: Add proper parametrization for shape of luminous region
+    track.setOrigin(0., 0., 70.*(myDice.Rndm()*2.-1.));
 
     // Assign material to the track
     tmp = findAllHits(mb, pm, track);
@@ -1646,28 +1640,15 @@ Material Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, TrackNew& 
   XYZVector origin, direction;
   origin    = t.getOrigin();
   direction = t.getDirection();
-  double distance;
-  //double r;
   int hits = 0;
   res.radiation = 0.0;
   res.interaction = 0.0;
   // set the track direction vector
   while (iter != guard) {
-    // collision detection: rays are in z+ only, so consider only modules that lie on that side
-    //if (iter->getModule().maxZ() > 0) {
-
-
-
-        // same method as in Tracker, same function used
-        // TODO: in case origin==0,0,0 and phi==0 just check if sectionYZ and minEta, maxEta
-        //distance = iter->getModule().trackCross(origin, direction);
         auto h = iter->getModule().checkTrackHits(origin, direction); 
         if (h.second != HitType::NONE) {
-        //if (distance > 0) {
-          double distance = h.first.R();
           // module was hit
           hits++;
-          // r = distance * sin(theta);
           tmp.radiation = iter->getRadiationLength();
           tmp.interaction = iter->getInteractionLength();
           // radiation and interaction length scaling for barrels
@@ -1691,7 +1672,6 @@ Material Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, TrackNew& 
           if (isPixel) hit->setAsPixel();
           t.addHit(std::move(hit));
         }
-	//}
     iter++;
   }
   return res;

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1672,8 +1672,8 @@ Material Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, TrackNew& 
           tmp.interaction = iter->getInteractionLength();
           // radiation and interaction length scaling for barrels
           if (iter->getModule().subdet() == BARREL) {
-            tmp.radiation = tmp.radiation / sin(t.getTheta());
-            tmp.interaction = tmp.interaction / sin(t.getTheta());
+            tmp.radiation = tmp.radiation / sin(t.getTheta() + iter->getModule().tiltAngle());
+            tmp.interaction = tmp.interaction / sin(t.getTheta() + iter->getModule().tiltAngle());
           }
           // radiation and interaction length scaling for endcaps
           else {

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -1861,17 +1861,20 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
   const double trackOrigZ = trackOrig.Z();
   const double& trackEta = t.getEta();
 
+  XYZVector trackDir;
+  trackDir = t.getDirection();
+  //const Polar3DVector& trackDir = t.getDirection();
+  Material hitMaterial;
+  XYZVector hitPos;
+
   while (iter != guard) {
 
-    // Collision detection: rays are in z+ only, so only volumes in z+ need to be considered
-    // only volumes of the requested category, or those without one (which should not exist) are examined
-    
-    //if ((iter->getZOffset() + iter->getZLength()) > 0) {
-
-      // Volume is hit
-      bool isHit = iter->checkTrackHits(trackOrig, trackEta);
+    // Volume is hit
+    bool isHit = iter->checkTrackHits(trackOrig, trackDir, hitMaterial, hitPos);
+    //bool isHit = iter->checkTrackHits(trackOrig, trackEta);
       if (isHit) {
 
+	/*
         double r, z;
         // radiation and interaction lenth scaling for vertical volumes
         if (iter->isVertical()) { // Element is vertical
@@ -1916,15 +1919,21 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
             corr.interaction = iter->getInteractionLength() / sin(t.getTheta());
             res += corr;
           }
-	}
+	  }
 
         // Create Hit object with appropriate parameters, add to Track t
         double rPos = r;
-        double zPos = z;
+        double zPos = z;*/
 
-        HitNewPtr hit(new HitNew(rPos, zPos));
+	auto hitRPos = hitPos.rho();
+	auto hitZPos = hitPos.z();
+
+
+        //HitNewPtr hit(new HitNew(rPos, zPos));
+	HitNewPtr hit(new HitNew(hitRPos, hitZPos));
         hit->setAsPassive();
-        hit->setCorrectedMaterial(corr);
+        //hit->setCorrectedMaterial(corr);
+	hit->setCorrectedMaterial(hitMaterial);
         t.addHit(std::move(hit));
 
 //        Hit* hit = new Hit((theta == 0) ? r : (r / sin(theta)));
@@ -1936,7 +1945,6 @@ Material Analyzer::findHitsInactiveSurfaces(std::vector<InactiveElement>& elemen
 //        t.addHit(hit);
 	// std::cout << "OLD USED" << std::endl;
       }
-      //}
 
     iter++;
   }

--- a/src/InactiveElement.cc
+++ b/src/InactiveElement.cc
@@ -154,7 +154,6 @@ namespace insur {
       return res;
     }
 
-  
 
   /**
    * Checks whether track hits the inactive element -> if yes, return true with passed hit position vector & material. 

--- a/src/InactiveElement.cc
+++ b/src/InactiveElement.cc
@@ -164,6 +164,7 @@ namespace insur {
   const bool InactiveElement::checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir, XYZVector& hitPos, Material& hitMaterial) {
 
     // Initialize
+    bool hitFound = false;
     hitPos.SetX(0.);
     hitPos.SetY(0.);
     hitPos.SetZ(0.);
@@ -213,7 +214,6 @@ namespace insur {
 	  // PART B
 	  // FIND OUT WHETHER THE TRACK CROSSES THE INSIDE OF THE VOLUME.
 	  // IF SO, COMPUTES HIT POSITION AND PATH LENGTH.
-	  bool hitFound = false;
 	  double hitPathLength = 0.;  // length of the track path crossing the volume.
 
 	  // Track enters and exits the volume between extrema radii cylinders.
@@ -283,6 +283,7 @@ namespace insur {
       else { logERROR("InactiveElement::checkTrackHits : Try to compute inactive MB on eta < 0., which is not supported"); }
 
     }
+    return hitFound;
   }
 
 

--- a/src/InactiveElement.cc
+++ b/src/InactiveElement.cc
@@ -190,37 +190,29 @@ namespace insur {
      * @return The pair <i>(Eta_min, Eta_max)</i>
      */
     std::pair<double, double> InactiveElement::getEtaMinMax() {
-        std::pair<double, double> res;
-        double theta0, theta1;
-        // volumes crossing z=0
-        if ((getZOffset() < 0) && (getZOffset() + getZLength() > 0)) {
-            // lower left of tube wall above z-axis
-            theta0 = atan(getInnerRadius() / (-1 * getZOffset()));
-            theta0 = M_PI - theta0;
-            // lower right of tube wall above z-axis
-            theta1 = atan(getInnerRadius() / (getZOffset() + getZLength()));
-        }
-        // volumes on either side of z=0
-        else {
-            // rings
-            if (isVertical()) {
-                // upper centre of tube wall above z-axis
-                theta0 = atan((getInnerRadius() + getRWidth()) / (getZLength() / 2.0 + getZOffset()));
-                // lower centre of tube wall above z-axis
-                theta1 = atan(getInnerRadius() / (getZLength() / 2.0 + getZOffset()));
-            }
-            // tubes
-            else {
-                // centre left of tube wall above z-axis
-                theta0 = atan((getRWidth() / 2.0 + getInnerRadius()) / getZOffset());
-                // centre right of tube wall above z-axis
-                theta1 = atan((getRWidth() / 2.0 + getInnerRadius()) / (getZOffset() + getZLength()));
-            }
-        }
-        // convert angle theta to pseudorapidity eta
-        res.first = -1 * log(tan(theta0 / 2.0));    // TODO change to the default converters
-        res.second = -1 * log(tan(theta1 / 2.0));   // TODO change to the default converters
-        return res;
+      std::pair<double, double> res;
+      double theta0, theta1;
+
+      // rings
+      if (isVertical()) {
+	// upper centre of tube wall above z-axis
+	theta0 = atan((getInnerRadius() + getRWidth()) / (getZLength() / 2.0 + getZOffset()));
+	// lower centre of tube wall above z-axis
+	theta1 = atan(getInnerRadius() / (getZLength() / 2.0 + getZOffset()));
+      }
+
+      // tubes
+      else {
+	// centre left of tube wall above z-axis
+	theta0 = atan((getRWidth() / 2.0 + getInnerRadius()) / getZOffset());
+	// centre right of tube wall above z-axis
+	theta1 = atan((getRWidth() / 2.0 + getInnerRadius()) / (getZOffset() + getZLength()));
+      }
+
+      // convert angle theta to pseudorapidity eta
+      res.first = -1 * log(tan(theta0 / 2.0));    // TODO change to the default converters
+      res.second = -1 * log(tan(theta1 / 2.0));   // TODO change to the default converters
+      return res;
     }
     
     /**


### PR DESCRIPTION
**In this PR:**
- A) Instead of IP = (0,0,0), a flat luminous region from Z = -70 mm to Z = 70 mm is chosen for resolution studies.
- B) BUG FIX:  One should not select the Z > 0 inactive volumes only (assuming eta >= 0). Indeed, the IP can be at Z < 0, hence inactive volumes on (-Z) side can be hit.
- C) BUG FIX:  One should not select the Z > 0 sensors only (assuming eta >= 0). Indeed, the IP can be at Z < 0, hence sensors on (-Z) side can be hit.
- D) BUG FIX: Sensors tilt angle was not taken into account for crossed MB calculation, in tracking resolution studies.
- E) Improved code on hits on inactive elements. This is used to calculate hit position and crossed MB. (though, on this point, issues were rather in devLite than in master).


**Results (on OT613_200_IT404 geometry) :**
- Before this PR, with Ernesto's parametrization: http://ghugo.web.cern.ch/ghugo/layouts/July/OT613_200_IT404/errorstracker.html 
- Before this PR, with Riccardo's parametrization: http://ghugo.web.cern.ch/ghugo/layouts/September/OT613_200_IT404/errorstracker.html
- After merging this PR, with Riccardo's parametrization: http://ghugo.web.cern.ch/ghugo/layouts/channels/OT613_200_IT404/errorstracker.html 

The effects are significant on resolution (pixel), resolution (tracker) and resolution (trigger).
**Example: Longitudinal impact parameter resolution vs. η (const Pt across η):**
- Before this PR: 
![before](https://user-images.githubusercontent.com/11192654/33369826-0c369ed8-d4f6-11e7-8e06-04ecc6e4c243.png)

- After merging this PR: 
![after](https://user-images.githubusercontent.com/11192654/33369830-109da6ce-d4f6-11e7-96b5-ed682a580c35.png)



**NB: Details:**
A detail of the impact of the fixes can be found here:
- Initial: http://ghugo.web.cern.ch/ghugo/layouts/test/OT613_200_IT404_distr_InactiveEtaMinMaxFixed_zError0/errorstracker.html 
- +A: http://ghugo.web.cern.ch/ghugo/layouts/test/OT613_200_IT404_distr_InactiveEtaMinMaxFixed/errorstracker.html
- +B: http://ghugo.web.cern.ch/ghugo/layouts/test/OT613_200_IT404_distr_InactiveEtaMinMaxFixed_NoMax/errorstracker.html 
- +C: http://ghugo.web.cern.ch/ghugo/layouts/test/OT613_200_IT404_distr_InactiveEtaMinMaxFixed_NoMaxMod/errorstracker.html
- +D: http://ghugo.web.cern.ch/ghugo/layouts/test/OT613_200_IT404_distr_InactiveEtaMinMaxFixed_NoMaxMod_tilt/errorstracker.html 

**NB: TO DO list (coming in further PR):**
- Cleaner handling of shape of luminous region (in Simparms).
- Remove old duplicated code on hits on Materials (tested, will have no effect on MB) + remove InactiveElement::getEtaMinMax().
- Report issue in InactiveElement::checkTrackHits in devLite.
