### PR TITLE
Added IT layouts with large pixel aspect ratio (50x200 and 100x100).

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX
@@ -1,5 +1,6 @@
 // Pixel endcap disks material
 // Small disks (108 modules)
+// 2500 um^2 pixels everywhere
 
 Materials FPIX_disk {
   type layer

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_10000
@@ -1,0 +1,150 @@
+// Pixel endcap disks material
+// Small disks (108 modules)
+
+Materials FPIX_disk {
+  type layer
+
+  // Cooling for the module
+  // Average on disk
+  Component {
+    componentName Cooling
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName Ti
+      quantity 10.21
+      unit g
+    }
+    Element {
+      elementName CO2
+      quantity 9.69
+      unit g
+    }
+  }
+  // fake numbers for calculating conversion with a factor of 1000
+  // 8 pipes per disk
+  Component {
+    componentName "Cooling"
+    service true
+    scaleOnSensor 0
+    Element {
+      elementName FPIX_Ti
+      quantity 0.0266
+      unit g/m
+    }
+    Element {
+      elementName FPIX_CO2
+      quantity 0.026
+      unit g/m
+    }
+  }
+
+  // Power for the module
+  // Average on disk
+  // 3/4 of the amount in disk_FPIX : half of the services are divided by 2
+  Component {
+    componentName "Power wires"
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName Al
+      quantity 9.98
+      unit g
+    }
+    Element {
+      elementName Cu
+      quantity 1.54
+      unit g
+    }
+    Element {
+      elementName PE
+      quantity 3.37
+      unit g
+    }
+  }
+  // fake numbers for calculating conversion with a factor of 1000
+  // 12 chains per disk
+  Component {
+    componentName "Power wires"
+    service true
+    scaleOnSensor 0
+    Element {
+      elementName FPIX_Al
+      quantity 0.07
+      unit g/m
+    }
+    Element {
+      elementName FPIX_Cu
+      quantity 0.01
+      unit g/m
+    }
+    Element {
+      elementName FPIX_PE
+      quantity 0.023
+      unit g/m
+    }
+  }
+
+  // HV power wires
+  // Power for the module
+  Component {
+    componentName "Sensor HV line"
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName Al_HV
+      quantity 1.46
+      unit g
+    }
+    Element {
+      elementName Cu
+      quantity 0.52
+      unit g
+    }
+    Element {
+      elementName PE
+      quantity 5.24
+      unit g
+    }
+  }
+  // fake numbers for calculating conversion with a factor of 1000
+  // 12 chains per disk, 2 wires per chain
+  Component {
+    componentName "Sensor HV line"
+    service true
+    scaleOnSensor 0
+    Element {
+      elementName FPIX_Al_HV
+      quantity 0.0064
+      unit g/m
+    }
+    Element {
+      elementName FPIX_Cu
+      quantity 0.0023
+      unit g/m
+    }
+    Element {
+      elementName FPIX_PE
+      quantity 0.0231
+      unit g/m
+    }
+  }
+
+  // Support Mechanics
+  //Mechanics
+  Component {
+    componentName "Disk support mechanics"
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName CF
+      quantity 0.4
+      unit mm
+    }
+    Element {
+      elementName Airex
+      quantity 4
+      unit mm
+    }
+  }
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2
@@ -1,6 +1,7 @@
 // Pixel endcap disks material
 // Large disks (220 modules)
 // 2.41 times bigger than small disk
+// 2500 um^2 pixels everywhere
 
 Materials FPIX_2_disk {
   type layer
@@ -40,9 +41,9 @@ Materials FPIX_2_disk {
     }
   }
 
-// Power for the module
-// Average on disk
-// Rescaled on surface *2.41
+  // Power for the module
+  // Average on disk
+  // Rescaled on surface *2.41
   Component {
     componentName "Power wires"
     service false

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
@@ -1,7 +1,8 @@
 // Pixel endcap disks material
 // Small disks (108 modules)
+// 2500 um^2 pixels in 1x2 modules, 10000 um^2 pixels in 2x2 modules
 
-Materials FPIX_disk {
+Materials FPIX_disk_2500_10000 {
   type layer
 
   // Cooling for the module
@@ -41,7 +42,7 @@ Materials FPIX_disk {
 
   // Power for the module
   // Average on disk
-  // 3/4 of the amount in disk_FPIX : half of the services are divided by 2
+  // 75% of the amount in disk_FPIX : 50% reduction in 2 rings out of 4 (hence reduction is 0.5*0.5 = 0.25)
   Component {
     componentName "Power wires"
     service false
@@ -64,6 +65,7 @@ Materials FPIX_disk {
   }
   // fake numbers for calculating conversion with a factor of 1000
   // 12 chains per disk
+  // 75% of the amount in disk_FPIX : 50% reduction in 2 rings out of 4 (hence reduction is 0.5*0.5 = 0.25)
   Component {
     componentName "Power wires"
     service true

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
@@ -1,0 +1,156 @@
+// Pixel endcap disks material
+// Large disks (220 modules)
+// 2.41 times bigger than small disk
+
+Materials FPIX_2_disk {
+  type layer
+
+  // Cooling for the module
+  // Average on disk (scales on surface)
+  Component {
+    componentName Cooling
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName Ti
+      quantity 24.94
+      unit g
+    }
+    Element {
+      elementName CO2
+      quantity 23.66
+      unit g
+    }
+  }
+  // fake numbers for calculating conversion with a factor of 1000
+  // 16 pipes per disk
+  Component {
+    componentName "Cooling"
+    service true
+    scaleOnSensor 0
+    Element {
+      elementName FPIX_Ti
+      quantity 0.0532
+      unit g/m
+    }
+    Element {
+      elementName FPIX_CO2
+      quantity 0.052
+      unit g/m
+    }
+  }
+
+// Power for the module
+// Average on disk
+// Rescaled on surface *2.41
+// 0.7 of the amount in disk_FPIX_2 
+  Component {
+    componentName "Power wires"
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName Al
+      quantity 6.96
+      unit g
+    }
+    Element {
+      elementName Cu
+      quantity 2.48
+      unit g
+    }
+    Element {
+      elementName PE
+      quantity 4.45
+      unit g
+    }
+  }
+  // fake numbers for calculating conversion with a factor of 1000
+  // 24 chains per disk
+  Component {
+    componentName "Power wires"
+    service true
+    scaleOnSensor 0
+    Element {
+      elementName FPIX_Al
+      quantity 0.037
+      unit g/m
+    }
+    Element {
+      elementName FPIX_Cu
+      quantity 0.013
+      unit g/m
+    }
+    Element {
+      elementName FPIX_PE
+      quantity 0.023
+      unit g/m
+    }
+  }
+
+// HV power wires
+// Power for the module
+// Rescaled on surface *2.41
+// Proportional to PP0-SEH-HV (700067231 Rev 01)
+  Component {
+    componentName "Sensor HV line"
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName Al_HV
+      quantity 3.34
+      unit g
+    }
+    Element {
+      elementName Cu
+      quantity 1.19
+      unit g
+    }
+    Element {
+      elementName PE
+      quantity 12.01
+      unit g
+    }
+  }
+  // fake numbers for calculating conversion with a factor of 1000
+  // 24 chains per disk
+  // Proportional to PP0-SEH-HV (700067231 Rev 01)
+
+  Component {
+    componentName "Sensor HV line"
+    service true
+    scaleOnSensor 0
+    Element {
+      elementName FPIX_Al_HV
+      quantity 0.0110
+      unit g/m
+    }
+    Element {
+      elementName FPIX_Cu
+      quantity 0.0039
+      unit g/m
+    }
+    Element {
+      elementName FPIX_PE
+      quantity 0.0396
+      unit g/m
+    }
+  }
+
+  // Support Mechanics
+  //Mechanics
+  Component {
+    componentName "Disk support mechanics"
+    service false
+    scaleOnSensor 0
+    Element {
+      elementName CF
+      quantity 0.4
+      unit mm
+    }
+    Element {
+      elementName Airex
+      quantity 4
+      unit mm
+    }
+  }
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
@@ -1,8 +1,9 @@
 // Pixel endcap disks material
 // Large disks (220 modules)
 // 2.41 times bigger than small disk
+// 2500 um^2 pixels in 1x2 modules, 10000 um^2 pixels in 2x2 modules
 
-Materials FPIX_2_disk {
+Materials FPIX_2_disk_2500_10000 {
   type layer
 
   // Cooling for the module
@@ -40,10 +41,10 @@ Materials FPIX_2_disk {
     }
   }
 
-// Power for the module
-// Average on disk
-// Rescaled on surface *2.41
-// 0.7 of the amount in disk_FPIX_2 
+  // Power for the module
+  // Average on disk
+  // Rescaled on surface *2.41
+  // 70% of the amount in disk_FPIX_2 : 50% reduction in 3 rings out of 5 (hence reduction is 0.5*0.6 = 0.30)
   Component {
     componentName "Power wires"
     service false
@@ -66,6 +67,7 @@ Materials FPIX_2_disk {
   }
   // fake numbers for calculating conversion with a factor of 1000
   // 24 chains per disk
+  // 70% of the amount in disk_FPIX_2 : 50% reduction in 3 rings out of 5 (hence reduction is 0.5*0.6 = 0.30)
   Component {
     componentName "Power wires"
     service true

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials BPIX_v2_L3_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_BPIX_Cooling_Blocks_Light
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials BPIX_v2_L4_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_BPIX_Cooling_Blocks_Light
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials FPIX2_v2_R3_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials FPIX2_v2_R4_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials FPIX2_v2_R5_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials FPIX_v2_R3_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_2+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
@@ -1,0 +1,13 @@
+
+Materials FPIX_v2_R4_2x2_10000 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
@@ -1,0 +1,14 @@
+// BPIX ROD material
+// In rod service true means that exit from the rod
+//        service false means that stay in the rod (but in the service cylinder)
+
+Materials BPIX_rod_L3_10000 {
+  type rod
+
+  @include-std CMS_Phase2/Pixel/Materials/Components/Cooling_Titanium_L3
+  @include-std CMS_Phase2/Pixel/Materials/Components/Cooling_Titanium_L3
+  @include-std CMS_Phase2/Pixel/Materials/Components/Power_0.8mm2
+  @include-std CMS_Phase2/Pixel/Materials/Components/HV_Wires
+  @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_Support_Structure_0.2
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
@@ -1,0 +1,14 @@
+// BPIX ROD material
+// In rod service true means that exit from the rod
+//        service false means that stay in the rod (but in the service cylinder)
+
+Materials BPIX_rod_L4_10000 {
+  type rod
+
+  @include-std CMS_Phase2/Pixel/Materials/Components/Cooling_Titanium_L4
+  @include-std CMS_Phase2/Pixel/Materials/Components/Cooling_Titanium_L4
+  @include-std CMS_Phase2/Pixel/Materials/Components/Power_0.8mm2
+  @include-std CMS_Phase2/Pixel/Materials/Components/HV_Wires
+  @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_Support_Structure_0.2
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
@@ -1,0 +1,27 @@
+// 2x2 chips pixel module (100um x 100um)
+// Chip size 16.4x22
+moduleType pixel_2_2x2_100x100  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.2mm)
+width 33
+length 44.2
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.100
+  stripLengthEstimate 0.100
+  numROCX 2 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 7  // dark green

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
@@ -1,0 +1,27 @@
+// 2x2 chips pixel module (50um x 200um)
+// Chip size 16.4x22
+moduleType pixel_2_2x2_50x200  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.2mm)
+width 33
+length 44.2
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.050
+  stripLengthEstimate 0.200
+  numROCX 2 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 11  // purple

--- a/geometries/CMS_Phase2/OT613_200_IT420.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT420.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_2_0.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT421.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT421.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_2_1.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT422.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT422.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_2_2.cfg

--- a/geometries/CMS_Phase2/OT613_200_IT423.cfg
+++ b/geometries/CMS_Phase2/OT613_200_IT423.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V613_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_2_3.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_0.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_1.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_2.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_3.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_0.cfg
@@ -1,0 +1,73 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_0.cfg
@@ -8,6 +8,7 @@
 
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
     @include stations_FPIX_1_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
     
     moduleShape rectangular
     alignEdges true 
@@ -24,7 +25,6 @@
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 20
       ringOuterRadius 73.2 
@@ -32,7 +32,6 @@
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 32
       ringOuterRadius 93
@@ -40,7 +39,6 @@
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       numModules 24
       ringOuterRadius 127
@@ -48,7 +46,6 @@
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       numModules 32 
       ringOuterRadius 159.99

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_1.cfg
@@ -8,6 +8,7 @@
 
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
     @include stations_FPIX_1_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
     
     moduleShape rectangular
     alignEdges true 
@@ -24,7 +25,6 @@
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 20
       ringOuterRadius 73.2 
@@ -32,7 +32,6 @@
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 32
       ringOuterRadius 93
@@ -40,7 +39,6 @@
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       numModules 24
       ringOuterRadius 127
@@ -48,7 +46,6 @@
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       numModules 32 
       ringOuterRadius 159.99

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_1.cfg
@@ -1,0 +1,73 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_2.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_2_3.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 20
+      ringOuterRadius 73.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 32 
+      ringOuterRadius 159.99
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_0.cfg
@@ -7,6 +7,7 @@
 
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
     @include stations_FPIX_2_3_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
     
     moduleShape rectangular
     alignEdges true 
@@ -24,7 +25,6 @@
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 40
       ringOuterRadius 108
@@ -32,7 +32,6 @@
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 56
       ringOuterRadius 149
@@ -40,7 +39,6 @@
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       numModules 36
       ringOuterRadius 188.5
@@ -48,7 +46,6 @@
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       numModules 40
       ringOuterRadius 232
@@ -56,7 +53,6 @@
     Ring 5 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       numModules 48
       ringOuterRadius 253.99

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_0.cfg
@@ -1,0 +1,74 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_1.cfg
@@ -7,6 +7,7 @@
 
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
     @include stations_FPIX_2_3_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
     
     moduleShape rectangular
     alignEdges true 
@@ -24,7 +25,6 @@
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 40
       ringOuterRadius 108
@@ -32,7 +32,6 @@
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 56
       ringOuterRadius 149
@@ -40,7 +39,6 @@
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       numModules 36
       ringOuterRadius 188.5
@@ -48,7 +46,6 @@
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       numModules 40
       ringOuterRadius 232
@@ -56,7 +53,6 @@
     Ring 5 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
-      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       numModules 48
       ringOuterRadius 253.99

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_1.cfg
@@ -1,0 +1,74 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
+      @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_2.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_50x200
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/50x200
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_2_3.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_50x50
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/50x50
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 36
+      ringOuterRadius 188.5
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 40
+      ringOuterRadius 232
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_100x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_10000
+      @includestd CMS_Phase2/Pixel/Resolutions/100x100
+      numModules 48
+      ringOuterRadius 253.99
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_0.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_2_0.cfg
+  @include FPIX1_4_2_0.cfg
+  @include FPIX2_4_2_0.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_1.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_2_1.cfg
+  @include FPIX1_4_2_1.cfg
+  @include FPIX2_4_2_1.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_2.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_2_2.cfg
+  @include FPIX1_4_2_2.cfg
+  @include FPIX2_4_2_2.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_3.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_2_3.cfg
+  @include FPIX1_4_2_3.cfg
+  @include FPIX2_4_2_3.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -234,12 +234,12 @@ OT613_200_IT408.cfg                  OT Version 6.1.3
 OT613_200_IT420.cfg                  OT Version 6.1.3
                                      Inner Tracker version 4.2.0:
                                       - geometry same as IT4.0.4
-                                      - module type 25x100 everywhere in inner layers and rings, and 50x200 in outer layers and rings.  
+                                      - 25x100 in 1x2 modules, and 50x200 in 2x2 modules.
                                       
 OT613_200_IT421.cfg                  OT Version 6.1.3
                                      Inner Tracker version 4.2.1:
                                       - geometry same as IT4.0.4
-                                      - module type 25x100 everywhere in inner layers and rings, and 100x100 in outer layers and rings.                                                                                                                
+                                      - 25x100 in 1x2 modules, and 100x100 in 2x2 modules.                                                                                                         
                         
 OT613_200_IT500.cfg                  OT Version 6.1.3
                                      Inner Tracker version 5.0.0 : tilted Inner Tracker. Head of series.

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -190,13 +190,16 @@ OT711_200_IT4025.cfg                      Like 6.1.1 TDR geometry but with paire
                                           
 OT612_200_IT4025.cfg	Like 6.1.1 but with slightly larger PS modules
 
+---------------------------------------------------------   TDR LAYOUT   -------------------------------------------------------------------------------------------------------
+
 OT613_200_IT4025.cfg	   Like 6.1.2 but fixing bigDelta according to Nick 2017-03-27
                          Zd=29.7mm or bigDelta=14.85
-                         New geometry 6.1.3 with slight adjustment in TEDD1 and TEDD2: bigDeelta moved from 14.15mm to 14.85mm
+                         New geometry 6.1.3 with slight adjustment in TEDD1 and TEDD2: bigDelta moved from 14.15mm to 14.85mm
                          this would cause a movement of 1.243mm and 1.351mm in innermost rings of TEDD1 and TEDD2 respectively
                          and add 4 modules in one ring of TEDD2.
                         Any ring movement was instead *avoided* by constraining the ring radii to those of 6.1.2, so that the geometry in the
                         xy plane is exactly the same
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
                         
 OT614_200_IT4025.cfg	  OT 614: Like 6.1.3 but updates from Nick 2017-11-07 in TEDD.
                         'Identical dees' design (simplify cooling design, huge saving :) ):
@@ -231,6 +234,8 @@ OT613_200_IT407.cfg                  OT Version 6.1.3
 OT613_200_IT408.cfg                  OT Version 6.1.3
                                      Inner Tracker version 4.0.8:  IT4.0.2.5 with 1 disk less in FPX1 and 1 disk less in FPX2      
                                      
+---------------------------------------------------------   LARGE PIXEL ASPECT RATIO IN 2X2 MODULES STUDIES --------------------------------------------------------------------                               
+                                     
 OT613_200_IT420.cfg                  OT Version 6.1.3
                                      Inner Tracker version 4.2.0:
                                       - geometry same as IT4.0.4
@@ -239,8 +244,20 @@ OT613_200_IT420.cfg                  OT Version 6.1.3
 OT613_200_IT421.cfg                  OT Version 6.1.3
                                      Inner Tracker version 4.2.1:
                                       - geometry same as IT4.0.4
-                                      - 25x100 in 1x2 modules, and 100x100 in 2x2 modules.                                                                                                         
-                        
+                                      - 25x100 in 1x2 modules, and 100x100 in 2x2 modules. 
+                                      
+OT613_200_IT422.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.2.2:
+                                      - geometry same as IT4.0.4
+                                      - 50x50 in 1x2 modules, and 50x200 in 2x2 modules.
+                                      
+OT613_200_IT423.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.2.3:
+                                      - geometry same as IT4.0.4
+                                      - 50x50 in 1x2 modules, and 100x100 in 2x2 modules.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                                                          
+
+---------------------------------------------------------   TILTED INNER TRACKER STUDIES    ------------------------------------------------------------------------------------                        
 OT613_200_IT500.cfg                  OT Version 6.1.3
                                      Inner Tracker version 5.0.0 : tilted Inner Tracker. Head of series.
                                      First-jet optimization :)
@@ -269,6 +286,7 @@ OT613_200_IT503.cfg                  OT Version 6.1.3
                                      Inner Tracker version 5.0.3: 
                                       - geometry same as IT5.0.1
                                       - 50x50 in 1x1 and 1x2 modules, 25x100 in 2x2 modules.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
                                                                                                            
 
 

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -229,7 +229,17 @@ OT613_200_IT407.cfg                  OT Version 6.1.3
                                       - 50x50 in 1x2 modules, 25x100 in 2x2 modules.   
                                       
 OT613_200_IT408.cfg                  OT Version 6.1.3
-                                     Inner Tracker version 4.0.8:  IT4.0.2.5 with 1 disk less in FPX1 and 1 disk less in FPX2                                                                   
+                                     Inner Tracker version 4.0.8:  IT4.0.2.5 with 1 disk less in FPX1 and 1 disk less in FPX2      
+                                     
+OT613_200_IT420.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.2.0:
+                                      - geometry same as IT4.0.4
+                                      - module type 25x100 everywhere in inner layers and rings, and 50x200 in outer layers and rings.  
+                                      
+OT613_200_IT421.cfg                  OT Version 6.1.3
+                                     Inner Tracker version 4.2.1:
+                                      - geometry same as IT4.0.4
+                                      - module type 25x100 everywhere in inner layers and rings, and 100x100 in outer layers and rings.                                                                                                                
                         
 OT613_200_IT500.cfg                  OT Version 6.1.3
                                      Inner Tracker version 5.0.0 : tilted Inner Tracker. Head of series.


### PR DESCRIPTION
- IT420: http://ghugo.web.cern.ch/ghugo/layouts/january/OT613_200_IT420/layoutpixel.html
Geometry with 'reduced radii' in BPIX (same as IT404).
Pixel aspect ratio:
50x200 in outer layers and rings.
25x100 in the inner layers and rings.

- IT421: http://ghugo.web.cern.ch/ghugo/layouts/january/OT613_200_IT421/layoutpixel.html
Geometry with 'reduced radii' in BPIX (same as IT404).
Pixel aspect ratio:
100x100 in outer layers and rings.
25x100 in the inner layers and rings.

- As a reminder, IT404: http://cms-tklayout.web.cern.ch/cms-tklayout/layouts-work/recent-layouts/OT613_200_IT404/layoutpixel.html 
Geometry with 'reduced radii' in BPIX.
Pixel aspect ratio: 25x100 everywhere.


This PR also adds the materials files for the modules with large pixel aspect ratio (10 000 um^2 instead of 2 500 um^2):
- Bumps MB is divided by 4.
- Use 0.8 mm^2 instead of 1.6 mm^2 serial power chains (ie, use 4A instead of 8A serial power chains).
- Cooling not modified for the moment (approximation).

Adding these layouts is obviously in the context of studying the trade-off (resolution) VS (power consumption (+MB) ).
