### PR TITLE
More realistic description of the OTST from Mechanics.

### DIFF
--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
@@ -1,16 +1,15 @@
 Support {
   type custom
   customZMin 0
-  //customRMin 1200
-  customRMin 1190
-  customLength 2900
+  customRMin 1191.5
+  customLength 2650
   customDir horizontal
 
   Component {
     componentName outerCylinder
     Element {
       elementName CF
-      quantity 2.0
+      quantity 4.0
       unit mm
     }
   }


### PR DESCRIPTION
Actually 4 mm of CF instead of 2 mm.
Half - length of OTST in present latest designs is 2650 mm.