### PR TITLE
Add minor info on documentation (which was removed from drupal website)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
+# Prerequisites
+
+tkLayout requires:
+
+    ROOT version > 5.34.09 (root and root-config should be in user's path)
+    BOOST version > 1.55
+    gcc version > 4.7
+
+If you are on lxplus, you can just run a bash shell and then:
+
+     source setup_slc6.sh
+     
+     
 # Getting the code
 
      git clone https://github.com/tkLayout/tkLayout.git
      cd tkLayout
 
-# Before the compilation/run
-
-You need a working version of root active (root and root-config should be in your path) and a few
-libraries are required:
-  * boost_filesystem
-  * boost_regex
-  * the root library set
-
-If you are on lxplus you just have to run a bash shell and then
-
-     source setup_slc6.sh
-
+The latest official version is at tkLayout/master branch, the latest devolpment version at tkLayout/dev branch.
 
 # Compilation
 
@@ -43,27 +45,27 @@ This will build the needed programs, copy the executables into tkLayout/bin dire
 
      make install
 
-## First-time install
-If this is the first time that you install tkLayout, a few questions will be asked and a configuration
-fle will be created in $HOME/.tkgeometry:
+### First-time install
+If this is the first time that you install tkLayout, a few questions will be asked. You will need to provide:
 
-1. You will need to provide the destination directory for the www output of the program (proabably
-  something like /afs/cern.ch/user/y/yourname/www/layouts) this directory needs to be writable by you
-  and readable by the web server.
-     The style files will be copied during the installation to that directory (for example
-  /afs/cern.ch/user/y/yourname/www/layouts/style ). If the style files get changed during the development
-  a new ./install.sh will be needed to get this propagated to the output.
-     Alternatively, you can choose to make a symbolic link between the source directory style directory and
-  the layout directory. This avoids the need of repeating the ./install.sh at every update of the style files
-  but in order to do this the source directory should also be within the reach of the web server.
-1. The set of momentum values to be used for the simulation
-1. [...] t.b.d.
+1. The directory where you want to store the tkLayout executable.
+2. The destination directory for the web output of the program (for example: /afs/cern.ch/user/y/yourname/www/layouts). This directory needs to be writable by you and readable by the web server.    
+  The style files will be copied during the installation to that directory. If the style files get changed during the development, a new ./install.sh will be needed to get this propagated to the output.   
+  Alternatively, you can choose to make a symbolic link between the tkLayout/style directory and
+  the www/layouts directory. This avoids the need of repeating the ./install.sh at every update of the style files
+  (but in order to do this, the tkLayout/style directory should also be within the reach of the web server).
+3. The path to your tkLayout source directory (for example: /afs/cern.ch/user/y/yourname/tkLayout).
+4. The set of momentum values to be used for the simulation.
 
-# Update
-To get the latest development version (usually UNSTABLE) you simply type
+tkLayout stores the installation configuration in the file "~/.tkgeometryrc". 
+So in case wrong data is entered, you can just directly modify information there, and rerun "make install".
 
-    git fetch
-    git chechout master
-    make
-    make install
-  
+
+# Command line options
+
+Once tklayout is built and installed, you can of course see the command line options with:
+
+     tklayout --help
+
+
+# Have fun!

--- a/doc/tkdoc.doxy
+++ b/doc/tkdoc.doxy
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = tkgeometry
+PROJECT_NAME           = tkLayout
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION
Cleaned duplications of info in tkLayout website with respect to github documentation.

tkLayout drupal website (http://tklayout.web.cern.ch ) is now a simple interface to github code, documentation, and also layouts results pages.
