### PR TITLE
Adds IT layout with smaller chip size

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
@@ -1,0 +1,27 @@
+// 1x2 chips pixel module (25um x 100um)
+// Chip size 16.4x20
+moduleType pixel_2_1x2_25x100_short  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.2mm)
+width 16.4
+length 40.2
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.025
+  stripLengthEstimate 0.100
+  numROCX 1 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 4  // green

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
@@ -1,0 +1,27 @@
+// 2x2 chips pixel module (25um x 100um)
+// Chip size 16.4x20
+moduleType pixel_2_2x2_25x100_short  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.2mm)
+width 33
+length 40.2
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.025
+  stripLengthEstimate 0.100
+  numROCX 2 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 10  // orange

--- a/geometries/CMS_Phase2/OT614_200_IT430.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT430.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_3_0.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_3_0.cfg
@@ -1,0 +1,60 @@
+  Barrel PXB {
+    @include ../Supports/SupportsBPIX_V0_1_4modules.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
+    @include stations_BPIX_Service_Cylinder_near
+    
+    bigDelta 1.5
+    zOverlap -0.2 // 200 um gap along the stave
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 29
+    outerRadius 140
+
+    smallParity 1
+    bigParity -1
+
+    Layer 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      layerRotation 0.262
+      numRods 12
+    }
+    Layer 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      layerRotation 0.112
+      radiusMode fixed
+      placeRadiusHint 60
+      numRods 24
+    }
+    Layer 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      layerRotation 0.131
+      radiusMode fixed
+      placeRadiusHint 100
+      numRods 20
+    }
+    Layer 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_BPIX_v2_L4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      layerRotation 0.098
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_3_0.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 69.2 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 123
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 160
+    }
+    Disk 1 { placeZ 232.00 }
+    Disk 2 { placeZ 299.92 }
+    Disk 3 { placeZ 387.73 }
+    Disk 4 { placeZ 501.24 }
+    Disk 5 { placeZ 647.99 }
+    Disk 6 { placeZ 837.70 }
+    Disk 7 { placeZ 1082.95 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_3_0.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 104
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 56
+      ringOuterRadius 144
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 179
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 44
+      ringOuterRadius 219
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100_short
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 254
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_3_0.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_3_0.cfg
+  @include FPIX1_4_3_0.cfg
+  @include FPIX2_4_3_0.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -263,8 +263,16 @@ OT613_200_IT423.cfg                  OT Version 6.1.3
                                      Inner Tracker version 4.2.3:
                                       - geometry same as IT4.0.4
                                       - 50x50 in 1x2 modules, and 100x100 in 2x2 modules.
->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                                                                                  
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     
 
+
+OT614_200_IT430.cfg                  OT Version 6.1.4
+                                     Inner Tracker version 4.3.0: smaller chip: 16.4 mm x 20 mm chip, instead of 16.4 mm x 22 mm chip (same length as Atlas).
+                                     Based from Inner Tracker version 4.0.4.
+                                      - TBPX: shorter of 18 mm.
+                                      - TFPX: First disk moved inwards of 18 mm in Z. Other disks Z positions adjusted accordingly to have the same TFPX max Z. Radii: R1 min and R4 max identical, the radii in between are adjusted (coverage). R2 center: +1 mm, R3 center: -2 mm. 
+                                      - TEPX: 4 modules added in R4. Radii: R1 min and R5 max identical, the radii in between are adjusted (coverage). R2 center: -3 mm, R3 center: -2.5 mm, R4 center: -6 mm.  
+                                                                                             
 
 ============   TILTED INNER TRACKER STUDIES   ============                 
 OT613_200_IT500.cfg                  OT Version 6.1.3


### PR DESCRIPTION
Inner Tracker version 4.3.0: 
smaller chip: 16.4 mm x 20 mm chip, instead of 16.4 mm x 22 mm chip (same length as Atlas).

Based from Inner Tracker version 4.0.4.
- TBPX: shorter of 18 mm.
- TFPX: First disk moved inwards of 18 mm in Z. Other disks Z positions adjusted accordingly to have the same TFPX max Z. Radii: R1 min and R4 max identical, the radii in between are adjusted (coverage). R2 center: +1 mm, R3 center: -2 mm. 
- TEPX: 4 modules added in R4. Radii: R1 min and R5 max identical, the radii in between are adjusted (coverage). R2 center: -3 mm, R3 center: -2.5 mm, R4 center: -6 mm.  