### PR TITLE
Plugged the IT 420 and 421 (large pixel studies) on OT614 (rotated TEDD).

### DIFF
--- a/geometries/CMS_Phase2/OT614_200_IT420.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT420.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_2_0.cfg

--- a/geometries/CMS_Phase2/OT614_200_IT421.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT421.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_2_1.cfg


### PR DESCRIPTION
This is so that the layouts presently incorporated in CMSSW are matching existing tkLayout descriptions.
 Corresponding OT and IT were already described in readme.

OT614_200_IT420.cfg  <->  CMSSW D22 geometry scenario
OT614_200_IT421.cfg  <->  CMSSW D23 geometry scenario