### PR TITLE
TFPX and TEPX: Update serial power chains and HV lines Material Budget from Stella

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX
@@ -42,90 +42,91 @@ Materials FPIX_disk {
 
   // Power for the module
   // Average on disk
+  // 16 power chains per disk
   Component {
     componentName "Power wires"
     service false
     scaleOnSensor 0
     Element {
       elementName Al
-      quantity 13.31
+      quantity 13.52
       unit g
     }
     Element {
       elementName Cu
-      quantity 2.05
+      quantity 1.84
       unit g
     }
     Element {
       elementName PE
-      quantity 4.49
+      quantity 4.91
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 12 chains per disk
+  // 16 power chains per disk
   Component {
     componentName "Power wires"
     service true
     scaleOnSensor 0
     Element {
       elementName FPIX_Al
-      quantity 0.0954
+      quantity 0.0978
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.0143
+      quantity 0.0133
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.0317
+      quantity 0.0352
       unit g/m
     }
   }
 
-  // HV power wires
-  // Power for the module
+  // HV power lines
+  // 16 power chains per disk, 2 HV lines per power chain
   Component {
     componentName "Sensor HV line"
     service false
     scaleOnSensor 0
     Element {
       elementName Al_HV
-      quantity 1.46
+      quantity 1.56
       unit g
     }
     Element {
       elementName Cu
-      quantity 0.52
+      quantity 0.55
       unit g
     }
     Element {
       elementName PE
-      quantity 5.24
+      quantity 5.6
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 12 chains per disk, 2 wires per chain
+  // 16 power chains per disk, 2 HV lines per power chain
   Component {
     componentName "Sensor HV line"
     service true
     scaleOnSensor 0
     Element {
       elementName FPIX_Al_HV
-      quantity 0.0064
+      quantity 0.0073
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.0023
+      quantity 0.0026
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.0231
+      quantity 0.0264
       unit g/m
     }
   }

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2
@@ -43,95 +43,93 @@ Materials FPIX_2_disk {
 
   // Power for the module
   // Average on disk
-  // Rescaled on surface *2.41
+  // 28 power chains per disk
   Component {
     componentName "Power wires"
     service false
     scaleOnSensor 0
     Element {
       elementName Al
-      quantity 9.94
+      quantity 30.95
       unit g
     }
     Element {
       elementName Cu
-      quantity 3.54
+      quantity 4.21
       unit g
     }
     Element {
       elementName PE
-      quantity 6.36
+      quantity 11.02
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 24 chains per disk
+  // 28 power chains per disk
   Component {
     componentName "Power wires"
     service true
     scaleOnSensor 0
     Element {
       elementName FPIX_Al
-      quantity 0.0527
+      quantity 0.1792
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.0188
+      quantity 0.0244
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.0329
+      quantity 0.0628
       unit g/m
     }
   }
 
-// HV power wires
-// Power for the module
-// Rescaled on surface *2.41
-// Proportional to PP0-SEH-HV (700067231 Rev 01)
+  // HV power lines
+  // 28 power chains per disk, 2 HV lines per power chain
+  // Proportional to PP0-SEH-HV (700067231 Rev 01)
   Component {
     componentName "Sensor HV line"
     service false
     scaleOnSensor 0
     Element {
       elementName Al_HV
-      quantity 3.34
+      quantity 12.85
       unit g
     }
     Element {
       elementName Cu
-      quantity 1.19
+      quantity 4.58
       unit g
     }
     Element {
       elementName PE
-      quantity 12.01
+      quantity 46.2
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 24 chains per disk
+  // 28 power chains per disk, 2 HV lines per power chain
   // Proportional to PP0-SEH-HV (700067231 Rev 01)
-
   Component {
     componentName "Sensor HV line"
     service true
     scaleOnSensor 0
     Element {
       elementName FPIX_Al_HV
-      quantity 0.0110
+      quantity 0.0129
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.0039
+      quantity 0.0046
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.0396
+      quantity 0.0462
       unit g/m
     }
   }

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2500_10000
@@ -42,6 +42,7 @@ Materials FPIX_disk_2500_10000 {
 
   // Power for the module
   // Average on disk
+  // 16 power chains per disk
   // 75% of the amount in disk_FPIX : 50% reduction in 2 rings out of 4 (hence reduction is 0.5*0.5 = 0.25)
   Component {
     componentName "Power wires"
@@ -49,22 +50,22 @@ Materials FPIX_disk_2500_10000 {
     scaleOnSensor 0
     Element {
       elementName Al
-      quantity 9.98
+      quantity 10.14
       unit g
     }
     Element {
       elementName Cu
-      quantity 1.54
+      quantity 1.38
       unit g
     }
     Element {
       elementName PE
-      quantity 3.37
+      quantity 3.683
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 12 chains per disk
+  // 16 power chains per disk
   // 75% of the amount in disk_FPIX : 50% reduction in 2 rings out of 4 (hence reduction is 0.5*0.5 = 0.25)
   Component {
     componentName "Power wires"
@@ -72,62 +73,62 @@ Materials FPIX_disk_2500_10000 {
     scaleOnSensor 0
     Element {
       elementName FPIX_Al
-      quantity 0.07
+      quantity 0.073
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.01
+      quantity 0.010
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.023
+      quantity 0.026
       unit g/m
     }
   }
 
-  // HV power wires
-  // Power for the module
+  // HV power lines
+  // 16 power chains per disk, 2 HV lines per power chain
   Component {
     componentName "Sensor HV line"
     service false
     scaleOnSensor 0
     Element {
       elementName Al_HV
-      quantity 1.46
+      quantity 1.56
       unit g
     }
     Element {
       elementName Cu
-      quantity 0.52
+      quantity 0.55
       unit g
     }
     Element {
       elementName PE
-      quantity 5.24
+      quantity 5.6
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 12 chains per disk, 2 wires per chain
+  // 16 power chains per disk, 2 HV lines per power chain
   Component {
     componentName "Sensor HV line"
     service true
     scaleOnSensor 0
     Element {
       elementName FPIX_Al_HV
-      quantity 0.0064
+      quantity 0.0073
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.0023
+      quantity 0.0026
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.0231
+      quantity 0.0264
       unit g/m
     }
   }

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/disk_FPIX_2_2500_10000
@@ -43,7 +43,7 @@ Materials FPIX_2_disk_2500_10000 {
 
   // Power for the module
   // Average on disk
-  // Rescaled on surface *2.41
+  // 28 power chains per disk
   // 70% of the amount in disk_FPIX_2 : 50% reduction in 3 rings out of 5 (hence reduction is 0.5*0.6 = 0.30)
   Component {
     componentName "Power wires"
@@ -51,22 +51,22 @@ Materials FPIX_2_disk_2500_10000 {
     scaleOnSensor 0
     Element {
       elementName Al
-      quantity 6.96
+      quantity 21.665
       unit g
     }
     Element {
       elementName Cu
-      quantity 2.48
+      quantity 2.947
       unit g
     }
     Element {
       elementName PE
-      quantity 4.45
+      quantity 7.714
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 24 chains per disk
+  // 28 power chains per disk
   // 70% of the amount in disk_FPIX_2 : 50% reduction in 3 rings out of 5 (hence reduction is 0.5*0.6 = 0.30)
   Component {
     componentName "Power wires"
@@ -74,66 +74,64 @@ Materials FPIX_2_disk_2500_10000 {
     scaleOnSensor 0
     Element {
       elementName FPIX_Al
-      quantity 0.037
+      quantity 0.12544
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.013
+      quantity 0.01708
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.023
+      quantity 0.04396
       unit g/m
     }
   }
 
-// HV power wires
-// Power for the module
-// Rescaled on surface *2.41
-// Proportional to PP0-SEH-HV (700067231 Rev 01)
+  // HV power lines
+  // 28 power chains per disk, 2 HV lines per power chain
+  // Proportional to PP0-SEH-HV (700067231 Rev 01)
   Component {
     componentName "Sensor HV line"
     service false
     scaleOnSensor 0
     Element {
       elementName Al_HV
-      quantity 3.34
+      quantity 12.85
       unit g
     }
     Element {
       elementName Cu
-      quantity 1.19
+      quantity 4.58
       unit g
     }
     Element {
       elementName PE
-      quantity 12.01
+      quantity 46.2
       unit g
     }
   }
   // fake numbers for calculating conversion with a factor of 1000
-  // 24 chains per disk
+  // 28 power chains per disk, 2 HV lines per power chain
   // Proportional to PP0-SEH-HV (700067231 Rev 01)
-
   Component {
     componentName "Sensor HV line"
     service true
     scaleOnSensor 0
     Element {
       elementName FPIX_Al_HV
-      quantity 0.0110
+      quantity 0.0129
       unit g/m
     }
     Element {
       elementName FPIX_Cu
-      quantity 0.0039
+      quantity 0.0046
       unit g/m
     }
     Element {
       elementName FPIX_PE
-      quantity 0.0396
+      quantity 0.0462
       unit g/m
     }
   }


### PR DESCRIPTION
TFPX: 16 serial power chains per disk.
TEPX: 28 serial power chains per disk.

NB: Also updated MB files of layouts with large pixel aspect ratio in 2x2 modules accordingly.
(The power chains MB of layouts with large pixel aspect ratio is scaled from the MB of layouts with 2500 um^2 pixels).
