### PR TITLE
Added layouts with 1x1 modules in inner rings in TFPX and / or TEPX

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x1_2500
@@ -1,0 +1,10 @@
+
+Materials FPIX2_v2_R1_1x1_2500 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_1+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x1_2500
@@ -1,0 +1,10 @@
+
+Materials FPIX_v2_R1_1x1_2500 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_3+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
@@ -1,0 +1,27 @@
+// 1x1 chip pixel module (25um x 100um)
+// Chip size 16.4x22
+moduleType pixel_2_1x1_25x100  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+
+width 16.4
+length 22
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.025
+  stripLengthEstimate 0.100
+  numROCX 1 
+  numROCY 1
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 4  // green

--- a/geometries/CMS_Phase2/OT614_200_IT440.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT440.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_4_0.cfg

--- a/geometries/CMS_Phase2/OT614_200_IT441.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT441.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_4_1.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_4_1.cfg
@@ -1,0 +1,70 @@
+
+  Endcap FPIX_1 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_1_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 51 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 93
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 127
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 160
+    }
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX1_4_4_1.cfg
@@ -24,7 +24,7 @@
     zRotation 1.570796327
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX_v2_R1_1x1_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 20
       ringOuterRadius 51 

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_0.cfg
@@ -24,7 +24,7 @@
     zRotation 1.570796327
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x1_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 36
       ringOuterRadius 86

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_0.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 86
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 52
+      ringOuterRadius 130
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 171
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 215
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 254
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_1.cfg
@@ -24,7 +24,7 @@
     zRotation 1.570796327
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x1_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 32
       ringOuterRadius 86

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_1.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 86
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 127
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 169
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 213
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 254
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_0.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_0.cfg
+  @include FPIX1_4_0_2.cfg
+  @include FPIX2_4_4_0.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_1.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_0.cfg
+  @include FPIX1_4_4_1.cfg
+  @include FPIX2_4_4_1.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -266,12 +266,35 @@ OT613_200_IT423.cfg                  OT Version 6.1.3
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>     
 
 
+===============    ATLAS CHIP SIZE STUDY   ===============      
 OT614_200_IT430.cfg                  OT Version 6.1.4
                                      Inner Tracker version 4.3.0: smaller chip: 16.4 mm x 20 mm chip, instead of 16.4 mm x 22 mm chip (same length as Atlas).
                                      Based from Inner Tracker version 4.0.4.
                                       - TBPX: shorter of 18 mm.
                                       - TFPX: First disk moved inwards of 18 mm in Z. Other disks Z positions adjusted accordingly to have the same TFPX max Z. Radii: R1 min and R4 max identical, the radii in between are adjusted (coverage). R2 center: +1 mm, R3 center: -2 mm. 
                                       - TEPX: 4 modules added in R4. Radii: R1 min and R5 max identical, the radii in between are adjusted (coverage). R2 center: -3 mm, R3 center: -2.5 mm, R4 center: -6 mm.  
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
+
+
+=================   1X1 MODULES STUDIES   ================      
+OT614_200_IT440.cfg                  OT Version 6.1.4
+                                     Inner Tracker version 4.4.0: 1x1 modules in TEPX Ring 1 (Swiss layout).
+                                     TEPX: 
+                                     - Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 36.
+                                     - Ring 2: Rhigh: 149 mm -> 130 mm, numModules: 56 -> 52.
+                                     - Ring 3: Rhigh: 188.5 mm -> 171 mm.
+                                     - Ring 4: Rhigh: 232 mm -> 215 mm.
+                                     
+OT614_200_IT441.cfg                  OT Version 6.1.4
+                                     Inner Tracker version 4.4.1: Also 1x1 modules in TFPX Ring 1 (Correction by Duccio on Swiss layout).
+                                     TFPX: 
+                                     - Ring 1: Rhigh: 73.2 mm -> 51 mm.
+                                     TEPX: 
+                                     - Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 32.
+                                     - Ring 2: Rhigh: 149 mm -> 127 mm, numModules: 56 -> 48.
+                                     - Ring 3: Rhigh: 188.5 mm -> 169 mm.
+                                     - Ring 4: Rhigh: 232 mm -> 213 mm.
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
                                                                                              
 
 ============   TILTED INNER TRACKER STUDIES   ============                 


### PR DESCRIPTION
**Inner Tracker version 4.4.0:** 
1x1 modules in TEPX Ring 1 (Swiss layout).
TEPX:  
- Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 36.
- Ring 2: Rhigh: 149 mm -> 130 mm, numModules: 56 -> 52.
- Ring 3: Rhigh: 188.5 mm -> 171 mm.
- Ring 4: Rhigh: 232 mm -> 215 mm.
                                
**Inner Tracker version 4.4.1:** 
Also 1x1 modules in TFPX Ring 1 (Correction by Duccio on Swiss layout).  
TFPX:
- Ring 1: Rhigh: 73.2 mm -> 51 mm.

TEPX:
- Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 32.
- Ring 2: Rhigh: 149 mm -> 127 mm, numModules: 56 -> 48.
- Ring 3: Rhigh: 188.5 mm -> 169 mm.
- Ring 4: Rhigh: 232 mm -> 213 mm.


Using 1x1 modules allow to reduce the total silicon area (hence lower material budget).
Radii and number of modules were adjusted so that z coverage, phi coverage, and mechanical clearance are reasonable.