### PR TITLE
Inner Tracker 'offline' stubs + Detailed hits counts in IT and OT + Detailed stubs count in IT and OT

### DIFF
--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -107,7 +107,7 @@ namespace insur {
   static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
   static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
   static const int plotMaxNumberOfOuterTrackerStubs = 11;
-  static const int plotMaxNumberOfInnerTrackerStubs = 7;
+  static const int plotMaxNumberOfInnerTrackerStubs = 3;
 
 
   class Analyzer : private AnalyzerTools {

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -102,8 +102,7 @@ namespace insur {
   //typedef double TrackCollectionKey;
   typedef std::map<int, TrackCollection> TrackCollectionMap;
 
-  typedef std::map<int, TProfile> LayerCoverageInfoPerNumberOfHits;
-  typedef std::pair<TProfile, LayerCoverageInfoPerNumberOfHits> LayerCoverageInfo;
+  typedef std::map<int, TProfile> CoveragePerNumberOfHits;
   static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
   static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
   static const int plotMaxNumberOfOuterTrackerStubs = 11;
@@ -239,14 +238,15 @@ namespace insur {
     TProfile& getTotalEtaProfile() {return totalEtaProfile; }
     TProfile& getTotalEtaProfileSensors() {return totalEtaProfileSensors; }
     TProfile& getTotalEtaProfileStubs() {return totalEtaProfileStubs; }
-    std::map<int, TProfile>& getTotalEtaProfileNumberOfStubsRatios() { return totalEtaProfileNumberOfStubsRatios_; }
+    std::map<int, TProfile>& getTracksDistributionPerNumberOfStubs() { return tracksDistributionPerNumberOfStubs_; }
     TProfile& getTotalEtaProfileLayers() {return totalEtaProfileLayers; }
     TGraph& getPowerDensity() {return powerDensity;};
     std::vector<TProfile>& getTypeEtaProfiles() {return typeEtaProfile; }
     std::vector<TProfile>& getTypeEtaProfilesSensors() {return typeEtaProfileSensors; }
     std::vector<TProfile>& getTypeEtaProfilesStubs() {return typeEtaProfileStubs; }
-    std::map<std::string, LayerCoverageInfo>& getLayerEtaCoverageProfiles() {return layerEtaCoverageProfile;}
-    std::map<std::string, TProfile>& getLayerEtaCoverageProfilesStubs() {return layerEtaCoverageProfileStubs; }
+    std::map<std::string, TProfile>& getHitCoveragePerLayer() { return hitCoveragePerLayer_;}
+    std::map<std::string, CoveragePerNumberOfHits>& getHitCoveragePerLayerDetails() { return hitCoveragePerLayerDetails_;}
+    std::map<std::string, TProfile>& getStubCoveragePerLayer() { return stubCoveragePerLayer_; }
     std::map<std::string, std::map<std::string, TH1I*>>& getStubEfficiencyCoverageProfiles() { return stubEfficiencyCoverageProfiles_; } // map of maps: inner map has momenta as keys
     std::vector<TObject> getSavingVector();
     TCanvas* getGeomLite() {if (geomLiteCreated) return geomLite; else return NULL; };
@@ -446,10 +446,11 @@ namespace insur {
 
     TGraph powerDensity;
     TProfile totalEtaProfile, totalEtaProfileSensors, totalEtaProfileStubs, totalEtaProfileLayers;
-    std::map<int, TProfile> totalEtaProfileNumberOfStubsRatios_;
+    std::map<int, TProfile> tracksDistributionPerNumberOfStubs_;
     std::vector<TProfile> typeEtaProfile, typeEtaProfileSensors, typeEtaProfileStubs;
-    std::map<std::string, LayerCoverageInfo> layerEtaCoverageProfile;
-    std::map<std::string, TProfile> layerEtaCoverageProfileStubs;
+    std::map<std::string, TProfile> hitCoveragePerLayer_;
+    std::map<std::string, CoveragePerNumberOfHits> hitCoveragePerLayerDetails_;
+    std::map<std::string, TProfile> stubCoveragePerLayer_;
 
     std::map<std::string, std::map<std::string, TH1I*>> stubEfficiencyCoverageProfiles_;
 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -102,6 +102,10 @@ namespace insur {
   //typedef double TrackCollectionKey;
   typedef std::map<int, TrackCollection> TrackCollectionMap;
 
+  typedef std::map<int, TProfile> LayerCoverageInfoPerNumberOfHits;
+  typedef std::pair<TProfile, LayerCoverageInfoPerNumberOfHits> LayerCoverageInfo;
+  static const int plotMaxNumberOfStubsInPixel = 3;
+
 
   class Analyzer : private AnalyzerTools {
   public:
@@ -232,12 +236,13 @@ namespace insur {
     TProfile& getTotalEtaProfile() {return totalEtaProfile; }
     TProfile& getTotalEtaProfileSensors() {return totalEtaProfileSensors; }
     TProfile& getTotalEtaProfileStubs() {return totalEtaProfileStubs; }
+    std::map<int, TProfile>& getTotalEtaProfilePixelStubsDetails() {return totalEtaProfilePixelStubsDetails; }
     TProfile& getTotalEtaProfileLayers() {return totalEtaProfileLayers; }
     TGraph& getPowerDensity() {return powerDensity;};
     std::vector<TProfile>& getTypeEtaProfiles() {return typeEtaProfile; }
     std::vector<TProfile>& getTypeEtaProfilesSensors() {return typeEtaProfileSensors; }
     std::vector<TProfile>& getTypeEtaProfilesStubs() {return typeEtaProfileStubs; }
-    std::map<std::string, TProfile>& getLayerEtaCoverageProfiles() {return layerEtaCoverageProfile;}
+    std::map<std::string, LayerCoverageInfo>& getLayerEtaCoverageProfiles() {return layerEtaCoverageProfile;}
     std::map<std::string, TProfile>& getLayerEtaCoverageProfilesStubs() {return layerEtaCoverageProfileStubs; }
     std::map<std::string, std::map<std::string, TH1I*>>& getStubEfficiencyCoverageProfiles() { return stubEfficiencyCoverageProfiles_; } // map of maps: inner map has momenta as keys
     std::vector<TObject> getSavingVector();
@@ -438,8 +443,10 @@ namespace insur {
 
     TGraph powerDensity;
     TProfile totalEtaProfile, totalEtaProfileSensors, totalEtaProfileStubs, totalEtaProfileLayers;
+    std::map<int, TProfile> totalEtaProfilePixelStubsDetails;
     std::vector<TProfile> typeEtaProfile, typeEtaProfileSensors, typeEtaProfileStubs;
-    std::map<std::string, TProfile> layerEtaCoverageProfile, layerEtaCoverageProfileStubs;
+    std::map<std::string, LayerCoverageInfo> layerEtaCoverageProfile;
+    std::map<std::string, TProfile> layerEtaCoverageProfileStubs;
 
     std::map<std::string, std::map<std::string, TH1I*>> stubEfficiencyCoverageProfiles_;
 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -108,6 +108,17 @@ namespace insur {
   static const int plotMaxNumberOfOuterTrackerStubs = 11;
   static const int plotMaxNumberOfInnerTrackerStubs = 3;
 
+  //class LayerNameVisitor;
+  class LayerNameVisitor : public ConstGeometryVisitor {
+    string id_;
+  public:
+    std::set<string> data;
+    LayerNameVisitor(const Tracker& t) { t.accept(*this); }
+    void visit(const Barrel& b) { id_ = b.myid(); }
+    void visit(const Endcap& e) { id_ = e.myid(); }
+    void visit(const Layer& l) { data.insert(id_ + " " + any2str(l.myid())); }
+    void visit(const Disk& d) { data.insert(id_ + " " + any2str(d.myid())); }
+  };
 
   class Analyzer : private AnalyzerTools {
   public:
@@ -506,6 +517,7 @@ namespace insur {
     void transformEtaToZ();
     double findXThreshold(const TProfile& aProfile, const double& yThreshold, const bool& goForward );
     std::pair<double, double> computeMinMaxTracksEta(const Tracker& t) const;
+
   private:
     // A random number generator
     TRandom3 myDice; 
@@ -527,6 +539,20 @@ namespace insur {
 
     bool isModuleInEtaSector(const Tracker& tracker, const Module* module, int etaSector) const;
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;
+
+    
+    const std::pair<int, int> computeCoveragePerLayer(const std::pair<XYZVector, double>& aLine, 
+						      std::vector<std::pair<Module*, HitType>>& hitModules, 
+						      LayerNameVisitor& layerNames, 
+						      const bool isPixelTracker, 
+						      const double maxEta);
+    void createCoveragePerLayerPlots(LayerNameVisitor& layerNames, 
+				     const bool isPixelTracker, 
+				     const double maxEta);
+    void computeCoveragePlotsAllLayers(const std::pair<XYZVector, double>& aLine, 
+				       const int numLayersWithAtLeastOneHit, 
+				       const int numStubsPerTrack,
+				       const int plotMaxNumberOfStubs);
 
     void computeTrackingVolumeMaterialBudget(const Track& track, const int nTracks, const std::map<std::string, Material>& innerTrackerModulesComponentsRI, const std::map<std::string, Material>& outerTrackerModulesComponentsRI);
     void fillRIServicesDetailsHistos(std::map<std::string, TH1D*>& rServicesDetails, std::map<std::string, TH1D*>& iServicesDetails, const std::unique_ptr<Hit>& hitOnService, const double eta, const double theta, const int nTracks, const double etaMax) const;

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -108,7 +108,6 @@ namespace insur {
   static const int plotMaxNumberOfOuterTrackerStubs = 11;
   static const int plotMaxNumberOfInnerTrackerStubs = 3;
 
-  //class LayerNameVisitor;
   class LayerNameVisitor : public ConstGeometryVisitor {
     string id_;
   public:
@@ -542,11 +541,11 @@ namespace insur {
 
     
     const std::pair<int, int> computeCoveragePerLayer(const std::pair<XYZVector, double>& aLine, 
-						      std::vector<std::pair<Module*, HitType>>& hitModules, 
-						      LayerNameVisitor& layerNames, 
+						      const std::vector<std::pair<Module*, HitType>>& hitModules, 
+						      const LayerNameVisitor& layerNames, 
 						      const bool isPixelTracker, 
 						      const double maxEta);
-    void createCoveragePerLayerPlots(LayerNameVisitor& layerNames, 
+    void createCoveragePerLayerPlots(const LayerNameVisitor& layerNames, 
 				     const bool isPixelTracker, 
 				     const double maxEta);
     void computeCoveragePlotsAllLayers(const std::pair<XYZVector, double>& aLine, 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -104,7 +104,10 @@ namespace insur {
 
   typedef std::map<int, TProfile> LayerCoverageInfoPerNumberOfHits;
   typedef std::pair<TProfile, LayerCoverageInfoPerNumberOfHits> LayerCoverageInfo;
-  static const int plotMaxNumberOfStubsInPixel = 3;
+  static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
+  static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
+  static const int plotMaxNumberOfOuterTrackerStubs = 11;
+  static const int plotMaxNumberOfInnerTrackerStubs = 3;
 
 
   class Analyzer : private AnalyzerTools {
@@ -236,7 +239,7 @@ namespace insur {
     TProfile& getTotalEtaProfile() {return totalEtaProfile; }
     TProfile& getTotalEtaProfileSensors() {return totalEtaProfileSensors; }
     TProfile& getTotalEtaProfileStubs() {return totalEtaProfileStubs; }
-    std::map<int, TProfile>& getTotalEtaProfilePixelStubsDetails() {return totalEtaProfilePixelStubsDetails; }
+    std::map<int, TProfile>& getTotalEtaProfileNumberOfStubsRatios() { return totalEtaProfileNumberOfStubsRatios_; }
     TProfile& getTotalEtaProfileLayers() {return totalEtaProfileLayers; }
     TGraph& getPowerDensity() {return powerDensity;};
     std::vector<TProfile>& getTypeEtaProfiles() {return typeEtaProfile; }
@@ -443,7 +446,7 @@ namespace insur {
 
     TGraph powerDensity;
     TProfile totalEtaProfile, totalEtaProfileSensors, totalEtaProfileStubs, totalEtaProfileLayers;
-    std::map<int, TProfile> totalEtaProfilePixelStubsDetails;
+    std::map<int, TProfile> totalEtaProfileNumberOfStubsRatios_;
     std::vector<TProfile> typeEtaProfile, typeEtaProfileSensors, typeEtaProfileStubs;
     std::map<std::string, LayerCoverageInfo> layerEtaCoverageProfile;
     std::map<std::string, TProfile> layerEtaCoverageProfileStubs;

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -244,9 +244,9 @@ namespace insur {
     std::vector<TProfile>& getTypeEtaProfiles() {return typeEtaProfile; }
     std::vector<TProfile>& getTypeEtaProfilesSensors() {return typeEtaProfileSensors; }
     std::vector<TProfile>& getTypeEtaProfilesStubs() {return typeEtaProfileStubs; }
-    std::map<std::string, TProfile>& getHitCoveragePerLayer() { return hitCoveragePerLayer_;}
-    std::map<std::string, CoveragePerNumberOfHits>& getHitCoveragePerLayerDetails() { return hitCoveragePerLayerDetails_;}
-    std::map<std::string, TProfile>& getStubCoveragePerLayer() { return stubCoveragePerLayer_; }
+    std::map<std::string, TProfile>& getHitCoveragePerLayer() { return hitCoveragePerLayer_; } // Layer coverage: hits
+    std::map<std::string, CoveragePerNumberOfHits>& getHitCoveragePerLayerDetails() { return hitCoveragePerLayerDetails_; } // Layer coverage: hits details
+    std::map<std::string, TProfile>& getStubCoveragePerLayer() { return stubCoveragePerLayer_; } // Layer coverage: stubs
     std::map<std::string, std::map<std::string, TH1I*>>& getStubEfficiencyCoverageProfiles() { return stubEfficiencyCoverageProfiles_; } // map of maps: inner map has momenta as keys
     std::vector<TObject> getSavingVector();
     TCanvas* getGeomLite() {if (geomLiteCreated) return geomLite; else return NULL; };

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -523,6 +523,7 @@ namespace insur {
     int materialTracksUsed;
     void fillAvailableSpacing(Tracker& tracker, std::vector<double>& spacingOptions);
     static constexpr double maximum_n_planes = 13.;
+    static constexpr double plotNumberOfStubsMaxY = 10.;
 
     bool isModuleInEtaSector(const Tracker& tracker, const Module* module, int etaSector) const;
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -107,7 +107,7 @@ namespace insur {
   static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
   static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
   static const int plotMaxNumberOfOuterTrackerStubs = 11;
-  static const int plotMaxNumberOfInnerTrackerStubs = 3;
+  static const int plotMaxNumberOfInnerTrackerStubs = 7;
 
 
   class Analyzer : private AnalyzerTools {

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -195,8 +195,8 @@ namespace insur {
     bool drawEtaProfilesSensors(TVirtualPad& myPad, Analyzer& analyzer, bool total=true);
     bool drawEtaProfilesStubs(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesStubs(TVirtualPad& myPad, Analyzer& analyzer);
-    bool drawEtaProfilesStubsDetails(TCanvas& myCanvas, Analyzer& analyzer);
-    bool drawEtaProfilesStubsDetails(TVirtualPad& myPad, Analyzer& analyzer);
+    bool drawEtaProfilesNumberOfStubsRatios(TCanvas& myCanvas, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawEtaProfilesNumberOfStubsRatios(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker);
     bool drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TVirtualPad& myPad, Analyzer& analyzer);
     bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type); // generic business logic called by hit or stub version

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -200,9 +200,9 @@ namespace insur {
     bool drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TVirtualPad& myPad, Analyzer& analyzer);
     bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker); // generic business logic called by hit or stub version
-    bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, LayerCoverageInfo>& layerEtaCoverage, const std::string& type);
+    bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, TProfile>& hitCoveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& hitCoveragePerLayerDetails, const std::string& type);
     bool drawEtaCoverage(RootWPage& myPage, Analyzer& analyzer); // for hits
-    bool drawEtaCoverageStubs(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawStubCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     int momentumColor(int iMomentum);
     void closeGraph(TGraph& myGraph);
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -195,14 +195,18 @@ namespace insur {
     bool drawEtaProfilesSensors(TVirtualPad& myPad, Analyzer& analyzer, bool total=true);
     bool drawEtaProfilesStubs(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesStubs(TVirtualPad& myPad, Analyzer& analyzer);
-    bool drawEtaProfilesNumberOfStubsRatios(TCanvas& myCanvas, Analyzer& analyzer, const bool isPixelTracker);
-    bool drawEtaProfilesNumberOfStubsRatios(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawTracksDistributionPerNumberOfStubs(TCanvas& myCanvas, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawTracksDistributionPerNumberOfStubs(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker);
     bool drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TVirtualPad& myPad, Analyzer& analyzer);
-    bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker); // generic business logic called by hit or stub version
-    bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, TProfile>& hitCoveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& hitCoveragePerLayerDetails, const std::string& type);
-    bool drawEtaCoverage(RootWPage& myPage, Analyzer& analyzer); // for hits
+
+    // COVERAGE PER LAYER: HITS AND STUBS
+    bool drawHitCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     bool drawStubCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawLayerCoverage(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits> coveragePerLayerDetails = std::map<std::string, CoveragePerNumberOfHits>());
+    //bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker); // generic business logic called by hit or stub version
+    //bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, TProfile>& hitCoveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& hitCoveragePerLayerDetails, const std::string& type);
+
     int momentumColor(int iMomentum);
     void closeGraph(TGraph& myGraph);
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -195,8 +195,8 @@ namespace insur {
     bool drawEtaProfilesSensors(TVirtualPad& myPad, Analyzer& analyzer, bool total=true);
     bool drawEtaProfilesStubs(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesStubs(TVirtualPad& myPad, Analyzer& analyzer);
-    bool drawTracksDistributionPerNumberOfStubs(TCanvas& myCanvas, Analyzer& analyzer, const bool isPixelTracker);
-    bool drawTracksDistributionPerNumberOfStubs(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawTracksDistributionPerNumberOfStubs(TCanvas& myCanvas, Analyzer& analyzer, const bool isPixelTracker); // plots for each number of stubs
+    bool drawTracksDistributionPerNumberOfStubs(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker); // plots for each number of stubs
     bool drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TVirtualPad& myPad, Analyzer& analyzer);
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -203,10 +203,8 @@ namespace insur {
     // COVERAGE PER LAYER: HITS AND STUBS
     bool drawHitCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     bool drawStubCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
-    bool drawCoveragePerlayer(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits> coveragePerLayerDetails = std::map<std::string, CoveragePerNumberOfHits>());
+    bool drawCoveragePerlayer(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& coveragePerLayerDetails);
     bool drawCoveragePerlayerDetails(CoveragePerNumberOfHits& coveragePerLayerDetails, const std::string type, TLegend* layerLegend, const int plotMaxNumberOfHits);
-    //bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker); // generic business logic called by hit or stub version
-    //bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, TProfile>& hitCoveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& hitCoveragePerLayerDetails, const std::string& type);
 
     int momentumColor(int iMomentum);
     void closeGraph(TGraph& myGraph);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -195,9 +195,12 @@ namespace insur {
     bool drawEtaProfilesSensors(TVirtualPad& myPad, Analyzer& analyzer, bool total=true);
     bool drawEtaProfilesStubs(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesStubs(TVirtualPad& myPad, Analyzer& analyzer);
+    bool drawEtaProfilesStubsDetails(TCanvas& myCanvas, Analyzer& analyzer);
+    bool drawEtaProfilesStubsDetails(TVirtualPad& myPad, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TVirtualPad& myPad, Analyzer& analyzer);
     bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type); // generic business logic called by hit or stub version
+    bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, LayerCoverageInfo>& layerEtaCoverage, const std::string& type);
     bool drawEtaCoverage(RootWPage& myPage, Analyzer& analyzer); // for hits
     bool drawEtaCoverageStubs(RootWPage& myPage, Analyzer& analyzer);
     int momentumColor(int iMomentum);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -199,10 +199,10 @@ namespace insur {
     bool drawEtaProfilesNumberOfStubsRatios(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker);
     bool drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer);
     bool drawEtaProfilesLayers(TVirtualPad& myPad, Analyzer& analyzer);
-    bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type); // generic business logic called by hit or stub version
+    bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker); // generic business logic called by hit or stub version
     bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, LayerCoverageInfo>& layerEtaCoverage, const std::string& type);
     bool drawEtaCoverage(RootWPage& myPage, Analyzer& analyzer); // for hits
-    bool drawEtaCoverageStubs(RootWPage& myPage, Analyzer& analyzer);
+    bool drawEtaCoverageStubs(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     int momentumColor(int iMomentum);
     void closeGraph(TGraph& myGraph);
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -203,7 +203,8 @@ namespace insur {
     // COVERAGE PER LAYER: HITS AND STUBS
     bool drawHitCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     bool drawStubCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
-    bool drawLayerCoverage(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits> coveragePerLayerDetails = std::map<std::string, CoveragePerNumberOfHits>());
+    bool drawCoveragePerlayer(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits> coveragePerLayerDetails = std::map<std::string, CoveragePerNumberOfHits>());
+    bool drawCoveragePerlayerDetails(CoveragePerNumberOfHits& coveragePerLayerDetails, const std::string type, TLegend* layerLegend, const int plotMaxNumberOfHits);
     //bool drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker); // generic business logic called by hit or stub version
     //bool drawEtaCoverageHits(RootWPage& myPage, std::map<std::string, TProfile>& hitCoveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& hitCoveragePerLayerDetails, const std::string& type);
 

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -50,7 +50,7 @@ namespace insur {
 
   static const int    default_n_tracks                = 100;                       // Default number of tracks simulated (max_eta_coverage/default_n_tracks = etaStep)
 
-  static const double hits_zero = 1.E-10;
+  static const double hits_negligible = 1.E-10;
 
   /**
    * Visualisation constants: material parameters for active surfaces, services and supports, plus top volume padding.

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -50,6 +50,8 @@ namespace insur {
 
   static const int    default_n_tracks                = 100;                       // Default number of tracks simulated (max_eta_coverage/default_n_tracks = etaStep)
 
+  static const double hits_zero = 1.E-10;
+
   /**
    * Visualisation constants: material parameters for active surfaces, services and supports, plus top volume padding.
    * The selected materials are completely arbitrary and only meant to distinguish one type of surface from another visually.

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3190,7 +3190,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 					    100, maxEta, maxEta);
       hitsCountPerLayer.GetXaxis()->SetTitle("#eta");
       hitsCountPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
-      (hitCoveragePerLayerDetails_[layerName])[numberOfHits] = hitsCountPerLayer;
+      hitCoveragePerLayerDetails_[layerName][numberOfHits] = hitsCountPerLayer;
     }
 
     // STUBS PER LAYER
@@ -3282,7 +3282,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
         moduleTypeCount[mh.first->moduleType()]++;
 
         if (mh.second == HitType::INNER || mh.second == HitType::OUTER) {
-	  // Important NB: If Tracker is InnerTracker, all hits are of type INNER
+	  // Important NB: For Inner Tracker modules, all hits are of type INNER
           sensorTypeCount[mh.first->moduleType()]++;
           numHits++;
         }
@@ -3350,9 +3350,6 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
         hitCoveragePerLayer_[layerName].Fill(aLine.second, hasLayerAtLeastOneHit);
 	
 	// all other hit counts
-	//if (numHitsPerLayer >= 5) std::cout << layerName << " numHitsPerLayer >= 5: numHitsPerLayer = " << numHitsPerLayer << std::endl;
-	//if (numHitsPerLayer == 3 || numHitsPerLayer == 4) std::cout << layerName << " numHitsPerLayer == " << numHitsPerLayer << std::endl;
-	//if (numHitsPerLayer > plotMaxNumberOfHitsPerLayer) std::cout << "ERROR " << layerName << " numHitsPerLayer = " << numHitsPerLayer << std::endl;
 	for (const auto& numHitsIndexIt : hitCoveragePerLayerDetails_[layerName]) {
 	  const int numHitsIndex = numHitsIndexIt.first;
 	  int result = 0;
@@ -3361,7 +3358,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 	       ) { 
 	    result = 1;
 	  }
-	  (hitCoveragePerLayerDetails_[layerName])[numHitsIndex].Fill(aLine.second, result);
+	  hitCoveragePerLayerDetails_[layerName][numHitsIndex].Fill(aLine.second, result);
 	}
 
 	// layer with at least one hit
@@ -3374,19 +3371,18 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 
 
       // COVERAGE FOR ALL LAYERS (GIVEN SUBDETECTOR)
-
       // Number of hit layers
       totalEtaProfileLayers.Fill(fabs(aLine.second), numLayersWithAtLeastOneHit);
 
       // Number of stubs
       const int numStubsPerTrack = (!tracker.isPixelTracker() ? numOuterTrackerStubs : numInnerTrackerStubs);
-      //if (tracker.isPixelTracker()) { std::cout << "numStubsPerTrack = " << numStubsPerTrack << std::endl; }
       totalEtaProfileStubs.Fill(fabs(aLine.second), numStubsPerTrack);
     
-      // Ratio of tracks with a given number of stubs
+      // Distribution of tracks per number of stubs
       for (const auto& numStubsIndexIt : tracksDistributionPerNumberOfStubs_) {
 	const int numStubsIndex = numStubsIndexIt.first;
 	int result = 0;
+	// Select the TProfile with the matching number of stubs
 	if ( numStubsIndex == numStubsPerTrack
 	     || (numStubsIndex == plotMaxNumberOfStubs && numStubsPerTrack > plotMaxNumberOfStubs)
 	     ) { 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3142,33 +3142,35 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 
   LayerNameVisitor layerNames(tracker);
 
-  // CREATING THE LAYER HIT/STUB COVERAGE PROFILES
-  const int plotMaxNumberOfHitsPerLayer = (!tracker.isPixelTracker() ? plotMaxNumberOfOuterTrackerHitsPerLayer : plotMaxNumberOfInnerTrackerHitsPerLayer);
+  // CREATING THE LAYER HIT/STUB COVERAGE PROFILES  
   layerEtaCoverageProfile.clear();
   layerEtaCoverageProfileStubs.clear();
-  for (auto it = layerNames.data.begin(); it!=layerNames.data.end(); ++it) { // CUIDADO this is horrible code (not mine). refactor!
-    TProfile* aProfile = new TProfile(Form("layerEtaCoverageProfileHits%s", it->c_str()), 
-				      it->c_str(),
+  const int plotMaxNumberOfHitsPerLayer = (!tracker.isPixelTracker() ? plotMaxNumberOfOuterTrackerHitsPerLayer : plotMaxNumberOfInnerTrackerHitsPerLayer);
+  for (const auto& layerName : layerNames.data) {
+    // HITS (>=1) PER LAYER
+    TProfile hitsPerLayer = TProfile(Form("layerEtaCoverageProfileHits%s", layerName.c_str()), 
+				      layerName.c_str(),
 				      200, maxEta, maxEta);
-    aProfile->GetXaxis()->SetTitle("#eta");
-    aProfile->GetYaxis()->SetTitle("Fraction of tracks");
-    TProfile* aProfileStubs = new TProfile(Form("layerEtaCoverageProfileStubs%s", it->c_str()),
-					   it->c_str(),
-					   200, maxEta, maxEta);
-    aProfileStubs->GetXaxis()->SetTitle("#eta");
-    aProfileStubs->GetYaxis()->SetTitle("Fraction of tracks");
-    layerEtaCoverageProfile[*it].first = (*aProfile);
-    layerEtaCoverageProfileStubs[*it] = (*aProfileStubs);
-    delete aProfile;
-    delete aProfileStubs;
+    hitsPerLayer.GetXaxis()->SetTitle("#eta");
+    hitsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
+    layerEtaCoverageProfile[layerName].first = hitsPerLayer;
 
+    // STUBS PER LAYER
+    TProfile stubsPerLayer = TProfile(Form("layerEtaCoverageProfileStubs%s", layerName.c_str()),
+					   layerName.c_str(),
+					   200, maxEta, maxEta);
+    stubsPerLayer.GetXaxis()->SetTitle("#eta");
+    stubsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");   
+    layerEtaCoverageProfileStubs[layerName] = stubsPerLayer;
+
+    // DETAILED HITS COUNTS PER LAYER
     for (int numberOfHits = 1; numberOfHits <= plotMaxNumberOfHitsPerLayer; numberOfHits++) {
-      TProfile hitProfile = TProfile(Form("layerEtaCoverageProfileHits%s%d", it->c_str(), numberOfHits), 
-				     it->c_str(),
+      TProfile hitsCountPerLayer = TProfile(Form("layerEtaCoverageProfileHits%s%d", layerName.c_str(), numberOfHits), 
+				     layerName.c_str(),
 				     100, maxEta, maxEta);
-      hitProfile.GetXaxis()->SetTitle("#eta");
-      hitProfile.GetYaxis()->SetTitle("Fraction of tracks");
-      (layerEtaCoverageProfile[*it].second)[numberOfHits] = hitProfile;
+      hitsCountPerLayer.GetXaxis()->SetTitle("#eta");
+      hitsCountPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
+      (layerEtaCoverageProfile[layerName].second)[numberOfHits] = hitsCountPerLayer;
     }
   }
 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3142,38 +3142,6 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 
   LayerNameVisitor layerNames(tracker);
 
-  // CREATING THE LAYER HIT/STUB COVERAGE PROFILES  
-  layerEtaCoverageProfile.clear();
-  layerEtaCoverageProfileStubs.clear();
-  const int plotMaxNumberOfHitsPerLayer = (!tracker.isPixelTracker() ? plotMaxNumberOfOuterTrackerHitsPerLayer : plotMaxNumberOfInnerTrackerHitsPerLayer);
-  for (const auto& layerName : layerNames.data) {
-    // HITS (>=1) PER LAYER
-    TProfile hitsPerLayer = TProfile(Form("layerEtaCoverageProfileHits%s", layerName.c_str()), 
-				      layerName.c_str(),
-				      200, maxEta, maxEta);
-    hitsPerLayer.GetXaxis()->SetTitle("#eta");
-    hitsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
-    layerEtaCoverageProfile[layerName].first = hitsPerLayer;
-
-    // STUBS PER LAYER
-    TProfile stubsPerLayer = TProfile(Form("layerEtaCoverageProfileStubs%s", layerName.c_str()),
-					   layerName.c_str(),
-					   200, maxEta, maxEta);
-    stubsPerLayer.GetXaxis()->SetTitle("#eta");
-    stubsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");   
-    layerEtaCoverageProfileStubs[layerName] = stubsPerLayer;
-
-    // DETAILED HITS COUNTS PER LAYER
-    for (int numberOfHits = 1; numberOfHits <= plotMaxNumberOfHitsPerLayer; numberOfHits++) {
-      TProfile hitsCountPerLayer = TProfile(Form("layerEtaCoverageProfileHits%s%d", layerName.c_str(), numberOfHits), 
-				     layerName.c_str(),
-				     100, maxEta, maxEta);
-      hitsCountPerLayer.GetXaxis()->SetTitle("#eta");
-      hitsCountPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
-      (layerEtaCoverageProfile[layerName].second)[numberOfHits] = hitsCountPerLayer;
-    }
-  }
-
   etaProfileByType.clear();
   etaProfileByTypeSensors.clear();
   etaProfileByTypeStubs.clear();
@@ -3199,6 +3167,41 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     aProfileStubs.SetName(mel.first.c_str());
     aProfileStubs.SetTitle(mel.first.c_str());
   }
+
+
+  // CREATING THE LAYER HIT/STUB COVERAGE PROFILES  
+  layerEtaCoverageProfile.clear();
+  layerEtaCoverageProfileStubs.clear();
+  const int plotMaxNumberOfHitsPerLayer = (!tracker.isPixelTracker() ? plotMaxNumberOfOuterTrackerHitsPerLayer : plotMaxNumberOfInnerTrackerHitsPerLayer);
+  for (const auto& layerName : layerNames.data) {
+    // HITS (>=1) PER LAYER
+    TProfile hitsPerLayer = TProfile(Form("layerEtaCoverageProfileHits%s", layerName.c_str()), 
+				      layerName.c_str(),
+				      200, maxEta, maxEta);
+    hitsPerLayer.GetXaxis()->SetTitle("#eta");
+    hitsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
+    layerEtaCoverageProfile[layerName].first = hitsPerLayer;
+
+    // DETAILED HITS COUNTS PER LAYER
+    for (int numberOfHits = 1; numberOfHits <= plotMaxNumberOfHitsPerLayer; numberOfHits++) {
+      TProfile hitsCountPerLayer = TProfile(Form("layerEtaCoverageProfileHits%s%d", layerName.c_str(), numberOfHits), 
+					    layerName.c_str(),
+					    100, maxEta, maxEta);
+      hitsCountPerLayer.GetXaxis()->SetTitle("#eta");
+      hitsCountPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
+      (layerEtaCoverageProfile[layerName].second)[numberOfHits] = hitsCountPerLayer;
+    }
+
+    // STUBS PER LAYER
+    TProfile stubsPerLayer = TProfile(Form("layerEtaCoverageProfileStubs%s", layerName.c_str()),
+					   layerName.c_str(),
+					   200, maxEta, maxEta);
+    stubsPerLayer.GetXaxis()->SetTitle("#eta");
+    stubsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");   
+    layerEtaCoverageProfileStubs[layerName] = stubsPerLayer;
+  }
+
+ 
 
   // The real simulation
   std::pair <XYZVector, double> aLine;

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3157,7 +3157,6 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     aProfileStubs.SetTitle(mel.first.c_str());
   }
  
-
   // The real simulation
   std::pair <XYZVector, double> aLine;
 
@@ -3412,7 +3411,6 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   return;
 }
 
-
 // public
 // TODO!!!
 // Creates the geometry objects geomLite
@@ -3601,8 +3599,8 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
    * - number of Inner Tracker 'stubs' (in the Inner Tracker, a 'stub' on a layer is defined by at least 2 hits on that layer).
    */
   const std::pair<int, int> Analyzer::computeCoveragePerLayer(const std::pair<XYZVector, double>& aLine, 
-							      std::vector<std::pair<Module*, HitType>>& hitModules, 
-							      LayerNameVisitor& layerNames, 
+							      const std::vector<std::pair<Module*, HitType>>& hitModules, 
+							      const LayerNameVisitor& layerNames, 
 							      const bool isPixelTracker, 
 							      const double maxEta) {
     // COMPUTE COVERAGE PER LAYER
@@ -3670,7 +3668,7 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
    * - detailed hits counts coverage.
    * - stub coverage.
    */
-  void Analyzer::createCoveragePerLayerPlots(LayerNameVisitor& layerNames, 
+  void Analyzer::createCoveragePerLayerPlots(const LayerNameVisitor& layerNames, 
 					     const bool isPixelTracker, 
 					     const double maxEta) {
     hitCoveragePerLayer_.clear();

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3436,7 +3436,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   savingGeometryV.push_back(totalEtaProfile);
   if (totalEtaProfile.GetMaximum()<maximum_n_planes) totalEtaProfile.SetMaximum(maximum_n_planes);
   if (totalEtaProfileSensors.GetMaximum()<maximum_n_planes) totalEtaProfileSensors.SetMaximum(maximum_n_planes);
-  if (totalEtaProfileStubs.GetMaximum()<maximum_n_planes) totalEtaProfileStubs.SetMaximum(10);
+  if (totalEtaProfileStubs.GetMaximum()<maximum_n_planes) totalEtaProfileStubs.SetMaximum(plotNumberOfStubsMaxY);
   totalEtaProfile.Draw();
   totalEtaProfileSensors.Draw();
   totalEtaProfileStubs.Draw();

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3147,15 +3147,27 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   layerEtaCoverageProfile.clear();
   layerEtaCoverageProfileStubs.clear();
   for (auto it = layerNames.data.begin(); it!=layerNames.data.end(); ++it) { // CUIDADO this is horrible code (not mine). refactor!
-    TProfile* aProfile = new TProfile(Form("layerEtaCoverageProfileHits%s", it->c_str()), it->c_str(), 200, maxEta, maxEta);
-    TProfile* aProfileStubs = new TProfile(Form("layerEtaCoverageProfileStubs%s", it->c_str()), it->c_str(), 200, maxEta, maxEta);
+    TProfile* aProfile = new TProfile(Form("layerEtaCoverageProfileHits%s", it->c_str()), 
+				      it->c_str(),
+				      200, maxEta, maxEta);
+    aProfile->GetXaxis()->SetTitle("#eta");
+    aProfile->GetYaxis()->SetTitle("Fraction of tracks");
+    TProfile* aProfileStubs = new TProfile(Form("layerEtaCoverageProfileStubs%s", it->c_str()),
+					   it->c_str(),
+					   200, maxEta, maxEta);
+    aProfileStubs->GetXaxis()->SetTitle("#eta");
+    aProfileStubs->GetYaxis()->SetTitle("Fraction of tracks");
     layerEtaCoverageProfile[*it].first = (*aProfile);
     layerEtaCoverageProfileStubs[*it] = (*aProfileStubs);
     delete aProfile;
     delete aProfileStubs;
 
     for (int numberOfHits = 1; numberOfHits <= plotMaxNumberOfHitsPerLayer; numberOfHits++) {
-      TProfile hitProfile = TProfile(Form("layerEtaCoverageProfileHits%s%d", it->c_str(), numberOfHits), it->c_str(), 100, maxEta, maxEta);
+      TProfile hitProfile = TProfile(Form("layerEtaCoverageProfileHits%s%d", it->c_str(), numberOfHits), 
+				     it->c_str(),
+				     100, maxEta, maxEta);
+      hitProfile.GetXaxis()->SetTitle("#eta");
+      hitProfile.GetYaxis()->SetTitle("Fraction of tracks");
       (layerEtaCoverageProfile[*it].second)[numberOfHits] = hitProfile;
     }
   }
@@ -3228,7 +3240,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   const int plotMaxNumberOfStubs = (!tracker.isPixelTracker() ? plotMaxNumberOfOuterTrackerStubs :  plotMaxNumberOfInnerTrackerStubs);
   for (int numberOfStubs = 0; numberOfStubs <= plotMaxNumberOfStubs; numberOfStubs++) {
     TProfile stubProfile = TProfile( Form("layerEtaCoverageProfileNumberOfStubs%d", numberOfStubs), 
-				     "Number of stubs;#eta;Fraction of tracks", 
+				     "Distribution of number of stub(s) per track;#eta;Fraction of tracks", 
 				     100, 0, maxEta);
     totalEtaProfileNumberOfStubsRatios_[numberOfStubs] = stubProfile;
   }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2684,13 +2684,11 @@ namespace insur {
     myImage->setComment("Stub coverage across eta");
     myContent->addItem(myImage);
 
-    if (tracker.isPixelTracker()) {
-      myCanvas = new TCanvas("EtaProfilePixelStubsDetails", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      drawEtaProfilesStubsDetails(*myCanvas, analyzer);
-      myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Stub coverage across eta");
-      myContent->addItem(myImage);
-    }
+    myCanvas = new TCanvas("EtaProfileNumberOfStubsRatios", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    drawEtaProfilesNumberOfStubsRatios(*myCanvas, analyzer, (name=="pixel"));
+    myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage->setComment("Stub coverage across eta");
+    myContent->addItem(myImage);
 
     myCanvas = new TCanvas("EtaProfileLayers", "Eta profile (Layers)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     drawEtaProfilesLayers(*myCanvas, analyzer);
@@ -2771,19 +2769,19 @@ namespace insur {
     return drawEtaProfilesAny(totalEtaProfileStubs, etaProfilesStubs);
   }
 
-  bool Vizard::drawEtaProfilesStubsDetails(TVirtualPad& myPad, Analyzer& analyzer) {
+  bool Vizard::drawEtaProfilesNumberOfStubsRatios(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker) {
     myPad.cd();
     myPad.SetFillColor(color_plot_background);
-    std::map<int, TProfile>& totalEtaProfileStubsDetails = analyzer.getTotalEtaProfilePixelStubsDetails();
+    std::map<int, TProfile>& totalEtaProfileNumberOfStubsRatios = analyzer.getTotalEtaProfileNumberOfStubsRatios();
     
+    const int plotMaxNumberOfStubs = (!isPixelTracker ? plotMaxNumberOfOuterTrackerStubs :  plotMaxNumberOfInnerTrackerStubs);
 
-    TLegend* layerLegend = new TLegend(0.1,0.6,0.35,0.9);
-      
+    TLegend* layerLegend = new TLegend(0.1,0.6,0.35,0.9);   
     int colorIndex = 1;
-    for (auto& detailIt : totalEtaProfileStubsDetails) {
+    for (auto& detailIt : totalEtaProfileNumberOfStubsRatios) {
       const int numberOfStubs = detailIt.first;
       ostringstream titleStream;
-      if (numberOfStubs < plotMaxNumberOfStubsInPixel) {
+      if (numberOfStubs < plotMaxNumberOfStubs) {
 	titleStream << "= " << numberOfStubs << " stub";
 	if (numberOfStubs >= 2) titleStream << "s";
       }
@@ -2849,10 +2847,10 @@ namespace insur {
     return drawEtaProfilesStubs(*myVirtualPad, analyzer);
   }
 
-  bool Vizard::drawEtaProfilesStubsDetails(TCanvas& myCanvas, Analyzer& analyzer) {
+  bool Vizard::drawEtaProfilesNumberOfStubsRatios(TCanvas& myCanvas, Analyzer& analyzer, const bool isPixelTracker) {
     TVirtualPad* myVirtualPad = myCanvas.GetPad(0);
     if (!myVirtualPad) return false;
-    return drawEtaProfilesStubsDetails(*myVirtualPad, analyzer);
+    return drawEtaProfilesNumberOfStubsRatios(*myVirtualPad, analyzer, isPixelTracker);
   }
 
   bool Vizard::drawEtaProfilesLayers(TCanvas& myCanvas, Analyzer& analyzer) {
@@ -2999,8 +2997,9 @@ namespace insur {
 	  detailProfile.SetMaximum(1.05);
 	  detailProfile.SetMarkerColor(Palette::color(colorIndex));
 	  detailProfile.SetLineColor(Palette::color(colorIndex));
-	  detailProfile.SetMarkerStyle(1);
-	  detailProfile.SetTitle("");  // TO DO!!!!
+	  detailProfile.SetMarkerStyle(8);
+	  detailProfile.SetMarkerSize(0.3);  
+	  //detailProfile.SetMarkerStyle(1);
 	  detailProfile.Draw("same");
 	  layerLegend->AddEntry(&detailProfile, titleStream.str().c_str());
 	}

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2640,23 +2640,23 @@ namespace insur {
 
     if (summaryCanvas) {
       myImage = new RootWImage(summaryCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Tracker summary: modules position in XY (endcap and barrel), YZ and number of hits vs. eta");
+      myImage->setComment("Tracker summary: modules position in XY (endcap and barrel), YZ and number of hits vs. eta.");
       myContent->addItem(myImage);
     }
 
     if (RZCanvas) {
       myImage = new RootWImage(RZCanvas, RZCanvas->GetWindowWidth(), RZCanvas->GetWindowHeight() );
-      myImage->setComment("RZ positions of the modules");
+      myImage->setComment("RZ positions of the modules.");
       myContent->addItem(myImage);
     }
     if ((RZCanvasBarrel) && (name == "pixel")) {
       myImage = new RootWImage(RZCanvasBarrel, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("RZ positions of the barrel modules");
+      myImage->setComment("RZ positions of the barrel modules.");
       myContent->addItem(myImage);
     }
     if (XYCanvas) {
       myImage = new RootWImage(XYCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("XY Section of the tracker barrel");
+      myImage->setComment("XY Section of the tracker barrel.");
       myContent->addItem(myImage);
     }
     for (auto XYCanvasEC : XYCanvasesEC ) {
@@ -2669,31 +2669,31 @@ namespace insur {
     myCanvas = new TCanvas("EtaProfileHits", "Eta profile (Hit Modules)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     drawEtaProfiles(*myCanvas, analyzer);
     myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    myImage->setComment("Hit modules across eta");
+    myImage->setComment("Hit modules across eta.");
     myContent->addItem(myImage);
 
     myCanvas = new TCanvas("EtaProfileSensors", "Eta profile (Hits)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     drawEtaProfilesSensors(*myCanvas, analyzer);
     myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    myImage->setComment("Hit coverage across eta");
+    myImage->setComment("Hit coverage across eta.");
     myContent->addItem(myImage);
 
     myCanvas = new TCanvas("EtaProfileStubs", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     drawEtaProfilesStubs(*myCanvas, analyzer);
     myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    myImage->setComment("Stub coverage across eta");
+    myImage->setComment("Stub coverage across eta.");
     myContent->addItem(myImage);
 
     myCanvas = new TCanvas("EtaProfileNumberOfStubsRatios", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     drawEtaProfilesNumberOfStubsRatios(*myCanvas, analyzer, (name=="pixel"));
     myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    myImage->setComment("Stub coverage across eta");
+    myImage->setComment("Stub coverage across eta.");
     myContent->addItem(myImage);
 
     myCanvas = new TCanvas("EtaProfileLayers", "Eta profile (Layers)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     drawEtaProfilesLayers(*myCanvas, analyzer);
     myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    myImage->setComment("Layer coverage across eta");
+    myImage->setComment("Layer coverage across eta.");
     myContent->addItem(myImage);
 
     if (name != "pixel") {
@@ -2776,27 +2776,30 @@ namespace insur {
     
     const int plotMaxNumberOfStubs = (!isPixelTracker ? plotMaxNumberOfOuterTrackerStubs :  plotMaxNumberOfInnerTrackerStubs);
 
-    TLegend* layerLegend = new TLegend(0.1,0.6,0.35,0.9);   
+    TLegend* layerLegend = new TLegend(0.905, 0.5, 1., 0.9);
+    //layerLegend->SetHeader("Number of stubs");
     int colorIndex = 1;
     for (auto& detailIt : totalEtaProfileNumberOfStubsRatios) {
       const int numberOfStubs = detailIt.first;
       ostringstream titleStream;
       if (numberOfStubs < plotMaxNumberOfStubs) {
-	titleStream << "= " << numberOfStubs << " stub";
+	titleStream << numberOfStubs << " stub";
 	if (numberOfStubs >= 2) titleStream << "s";
       }
-      else { titleStream << ">= " << numberOfStubs << " stubs"; }
+      else { titleStream << ">=" << numberOfStubs << " stubs"; }
 
       TProfile& detailProfile = detailIt.second;
       detailProfile.SetMinimum(0);
       detailProfile.SetMaximum(1.05);
       detailProfile.SetMarkerColor(Palette::color(colorIndex));
       detailProfile.SetLineColor(Palette::color(colorIndex));
+      detailProfile.SetFillColor(Palette::color(colorIndex));
       detailProfile.SetMarkerStyle(8);
-      detailProfile.SetMarkerSize(1.);  
+      detailProfile.SetMarkerSize(1.);
+      detailProfile.GetYaxis()->SetTitleOffset(1.3);
       detailProfile.SetStats(0);
       detailProfile.Draw("same");
-      layerLegend->AddEntry(&detailProfile, titleStream.str().c_str());
+      layerLegend->AddEntry(&detailProfile, titleStream.str().c_str(), "f");
       colorIndex++;
     }
     layerLegend->Draw("same");
@@ -2891,9 +2894,6 @@ namespace insur {
       myCanvas->cd();
 
       if (isPixelTracker && type == "Stubs") {
-	//TPad* centralPad = new TPad(Form("%s_central", myCanvas->GetName()), "central", 0, 0, 1, 1);
-	//centralPad->Draw();
-	//centralPad->cd();
 	aProfile.Draw();
       }
       else {
@@ -2932,7 +2932,8 @@ namespace insur {
       }
 
       RootWImage* myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Layer coverage in eta for " + type + " (multiple occurrences in the same layer are counted once here)");
+      if (isPixelTracker && type == "Stubs") { myImage->setComment("Layer coverage in eta for " + type + "."); }
+      else { myImage->setComment("Layer coverage in eta for " + type + " (multiple occurrences in the same layer are counted once here)."); }
       myContent->addItem(myImage);
     }
     return true;
@@ -2988,9 +2989,9 @@ namespace insur {
       zoomedProfile->SetTitle("");
 
       upperLeftPad->cd();
-      TLegend* layerLegend = new TLegend(0.1,0.6,0.35,0.9);
+      TLegend* layerLegend = new TLegend(0.85, 0.65, 0.999, 0.95);
       aProfile.Draw();
-      std::string aProfileTitle = ">= 1 hit(s)";
+      std::string aProfileTitle = ">=1 hit(s)";
       layerLegend->AddEntry(&aProfile, aProfileTitle.c_str());
       
       int colorIndex = 2;
@@ -3001,7 +3002,7 @@ namespace insur {
 	  titleStream << "= " << numberOfHits << " hit";
 	  if (numberOfHits >= 2) titleStream << "s";
 	}
-	else { titleStream << ">= " << numberOfHits << " hits"; }
+	else { titleStream << ">=" << numberOfHits << " hits"; }
 
 	TProfile& detailProfile = detailIt.second;
 	//std::cout << layerIt.first << " " << detailProfile.GetEntries() << std::endl;
@@ -3012,7 +3013,6 @@ namespace insur {
 	  detailProfile.SetLineColor(Palette::color(colorIndex));
 	  detailProfile.SetMarkerStyle(8);
 	  detailProfile.SetMarkerSize(0.3);  
-	  //detailProfile.SetMarkerStyle(1);
 	  detailProfile.Draw("same");
 	  layerLegend->AddEntry(&detailProfile, titleStream.str().c_str());
 	}
@@ -3028,7 +3028,7 @@ namespace insur {
       zoomedProfile->Draw();
 
       RootWImage* myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Layer coverage in eta for " + type + " (multiple occurrences in the same layer are counted once here)");
+      myImage->setComment("Layer coverage in eta for " + type + " (multiple occurrences in the same layer are counted once here).");
       myContent->addItem(myImage);
     }
     return true;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2686,7 +2686,7 @@ namespace insur {
     myContent->addItem(myImage);
 
     myCanvas = new TCanvas("EtaProfileNumberOfStubsRatios", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    drawTracksDistributionPerNumberOfStubs(*myCanvas, analyzer, isPixelTracker);
+    if (myCanvas) drawTracksDistributionPerNumberOfStubs(*myCanvas, analyzer, isPixelTracker);
     myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Stub coverage across eta.");
     myContent->addItem(myImage);
@@ -2770,6 +2770,10 @@ namespace insur {
     return drawEtaProfilesAny(totalEtaProfileStubs, etaProfilesStubs);
   }
 
+  /*
+   * Draw the distribution of tracks which have exactly a given number of stubs.
+   * If the stubs number is higher than plotMaxNumberOfStubs, all the tracks are gathered into the same category.
+   */
   bool Vizard::drawTracksDistributionPerNumberOfStubs(TVirtualPad& myPad, Analyzer& analyzer, const bool isPixelTracker) {
     myPad.cd();
     myPad.SetFillColor(color_plot_background);
@@ -2778,16 +2782,15 @@ namespace insur {
     const int plotMaxNumberOfStubs = (!isPixelTracker ? plotMaxNumberOfOuterTrackerStubs :  plotMaxNumberOfInnerTrackerStubs);
 
     TLegend* layerLegend = new TLegend(0.905, 0.5, 1., 0.9);
-    //layerLegend->SetHeader("Number of stubs");
     int colorIndex = 1;
     for (auto& detailIt : tracksDistributionPerNumberOfStubs) {
       const int numberOfStubs = detailIt.first;
       ostringstream titleStream;
       if (numberOfStubs < plotMaxNumberOfStubs) {
 	titleStream << numberOfStubs << " stub";
-	if (numberOfStubs >= 2) titleStream << "s";
       }
-      else { titleStream << ">=" << numberOfStubs << " stubs"; }
+      else { titleStream << ">=" << numberOfStubs << " stub"; }
+      if (numberOfStubs >= 2) titleStream << "s";
 
       TProfile& detailProfile = detailIt.second;
       detailProfile.SetMinimum(0);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2864,11 +2864,11 @@ namespace insur {
   }
 
   bool Vizard::drawEtaCoverage(RootWPage& myPage, Analyzer& analyzer) {
-    return drawEtaCoverageHits(myPage, analyzer.getLayerEtaCoverageProfiles(), "Hits");
+    return drawEtaCoverageHits(myPage, analyzer.getLayerEtaCoverageProfiles(), "hit");
   }
 
   bool Vizard::drawEtaCoverageStubs(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker) {
-    return drawEtaCoverageAny(myPage, analyzer.getLayerEtaCoverageProfilesStubs(), "Stubs", isPixelTracker);
+    return drawEtaCoverageAny(myPage, analyzer.getLayerEtaCoverageProfilesStubs(), "stub", isPixelTracker);
   }
 
   bool Vizard::drawEtaCoverageAny(RootWPage& myPage, std::map<std::string, TProfile>& layerEtaCoverage, const std::string& type, const bool isPixelTracker) {
@@ -2893,8 +2893,13 @@ namespace insur {
       myCanvas = new TCanvas(Form("LayerCoverage%s%s", it->first.c_str(), type.c_str()), ("Layer eta coverage (" + type + ")").c_str(), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myCanvas->cd();
 
-      if (isPixelTracker && type == "Stubs") {
+      if (isPixelTracker && type == "stub") {
 	aProfile.Draw();
+	TLegend* centralLegend = new TLegend(0.85, 0.8, 0.999, 0.9);
+	std::ostringstream entry;
+	entry << "= 1 stub";
+	centralLegend->AddEntry(&aProfile, entry.str().c_str());
+	centralLegend->Draw();
       }
       else {
 	myCanvas->cd();
@@ -2929,11 +2934,15 @@ namespace insur {
 	zoomedProfile->SetTitle("");
 	lowerPad->cd();
 	zoomedProfile->Draw();
+	std::ostringstream entry;
+	entry << ">=1 " << type << "(s)";
+	TLegend* zoomedLegend = new TLegend(0.85, 0.65, 0.999, 0.95);
+	zoomedLegend->AddEntry(zoomedProfile, entry.str().c_str());
+	zoomedLegend->Draw();
       }
 
       RootWImage* myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
-      if (isPixelTracker && type == "Stubs") { myImage->setComment("Layer coverage in eta for " + type + "."); }
-      else { myImage->setComment("Layer coverage in eta for " + type + " (multiple occurrences in the same layer are counted once here)."); }
+      myImage->setComment("Layer coverage in eta for " + type + ".");
       myContent->addItem(myImage);
     }
     return true;
@@ -3026,9 +3035,14 @@ namespace insur {
 
       lowerPad->cd();
       zoomedProfile->Draw();
+      TLegend* zoomedLegend = new TLegend(0.85, 0.65, 0.999, 0.95);
+      std::ostringstream entry;
+      entry << ">=1 " << type << "(s)";
+      zoomedLegend->AddEntry(zoomedProfile, entry.str().c_str());
+      zoomedLegend->Draw();
 
       RootWImage* myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment("Layer coverage in eta for " + type + " (multiple occurrences in the same layer are counted once here).");
+      myImage->setComment("Layer coverage in eta for " + type + ".");
       myContent->addItem(myImage);
     }
     return true;


### PR DESCRIPTION
Please see [various_updates.pdf](https://github.com/tkLayout/tkLayout/files/2141960/various_updates.pdf)

Notably:
Hit coverage:
- Inner Tracker:
Added detailed hit count information, here on TFPX Disk 1:
![fpx_disk1](https://user-images.githubusercontent.com/11192654/41985126-bdbbf1ee-7a32-11e8-96b0-9098656121e2.png)

- Outer Tracker:
Added detailed hit count information, here on TBPS Layer 1:
![tbps_1](https://user-images.githubusercontent.com/11192654/41985106-b3dd3a16-7a32-11e8-9ad6-b33df01d1b5c.png)

Stub coverage:
- Inner Tracker:
Introduce 'stub' in the Inner Tracker (offline sense):
1 stub   <->   (>= 2 hits) / layer
Added detailed stub count plots.
![itstubs](https://user-images.githubusercontent.com/11192654/41985158-d47c10da-7a32-11e8-9ef5-d32ee7dd65fc.png)
Added average number of stubs over eta.
![it_total](https://user-images.githubusercontent.com/11192654/41985162-d76f1d82-7a32-11e8-992b-1d5c3d1cfa8a.png)

- Outer Tracker:
Added detailed stub count plots.
![ot](https://user-images.githubusercontent.com/11192654/41985171-ddfa581a-7a32-11e8-9711-cbfc25b1d4fa.png)



