### PR TITLE
Add IT450 for luminosity studies

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_2x2_2500
@@ -1,0 +1,13 @@
+
+Materials FPIX2_v2_R2_2x2_2500 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_TWP_2+1_HS
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
@@ -3,7 +3,6 @@
 moduleType pixel_2_1x1_25x100  // pixel modules should always have a type starting with keyword 'pixel_'
 
 // Active silicon size
-
 width 16.4
 length 22
 
@@ -24,4 +23,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4  // green
+plotColor 9  // violet

--- a/geometries/CMS_Phase2/OT614_200_IT450.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT450.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_5_0.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_4_1.cfg
@@ -30,10 +30,10 @@
       ringOuterRadius 86
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
-      numModules 48
+      numModules 28
       ringOuterRadius 127
     }
     Ring 3 {

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_5_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_5_0.cfg
@@ -23,32 +23,32 @@
     smallParity -1
     zRotation 1.570796327
     Ring 1 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x1_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x1_2500
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
-      numModules 36
-      ringOuterRadius 86
+      numModules 40
+      ringOuterRadius 108
     }
     Ring 2 {
-      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
-      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_2x2_2500
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
-      numModules 28
-      ringOuterRadius 130
+      numModules 56
+      ringOuterRadius 145
     }
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 36
-      ringOuterRadius 171
+      ringOuterRadius 182
     }
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 40
-      ringOuterRadius 215
+      ringOuterRadius 219
     }
     Ring 5 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_0.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_0.cfg
+  @include FPIX1_4_0_2.cfg
+  @include FPIX2_4_5_0.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -279,6 +279,8 @@ OT614_200_IT430.cfg                  OT Version 6.1.4
 =================   1X1 MODULES STUDIES   ================      
 OT614_200_IT440.cfg                  OT Version 6.1.4
                                      Inner Tracker version 4.4.0: 1x1 modules in TEPX Ring 1 (Swiss layout).
+                                     2x2 modules in TEPX Ring 2.
+                                     Based from Inner Tracker version 4.0.4.
                                      TEPX: 
                                      - Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 36.
                                      - Ring 2: Rhigh: 149 mm -> 130 mm, numModules: 56 -> 52.
@@ -287,6 +289,8 @@ OT614_200_IT440.cfg                  OT Version 6.1.4
                                      
 OT614_200_IT441.cfg                  OT Version 6.1.4
                                      Inner Tracker version 4.4.1: Also 1x1 modules in TFPX Ring 1 (Correction by Duccio on Swiss layout).
+                                     2x2 modules in TEPX Ring 2.
+                                     Based from Inner Tracker version 4.0.4.
                                      TFPX: 
                                      - Ring 1: Rhigh: 73.2 mm -> 51 mm.
                                      TEPX: 
@@ -294,6 +298,23 @@ OT614_200_IT441.cfg                  OT Version 6.1.4
                                      - Ring 2: Rhigh: 149 mm -> 127 mm, numModules: 56 -> 48.
                                      - Ring 3: Rhigh: 188.5 mm -> 169 mm.
                                      - Ring 4: Rhigh: 232 mm -> 213 mm.
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
+
+
+=================   LUMINOSITY STUDIES   =================     
+OT614_200_IT450.cfg                  OT Version 6.1.4
+                                     Inner Tracker version 4.5.0: Tune radii in TEPX to have radially distributed luminosity measurements.
+                                     Based from Inner Tracker version 4.0.4.
+                                     TEPX:
+                                     - Ring 2: Rhigh: 149 mm -> 145 mm.
+                                     - Ring 3: Rhigh: 188.5 mm -> 182 mm.
+                                     - Ring 4: Rhigh: 232 mm -> 219 mm.
+                                     The resulting radial spacings are, using (Ring (i) Rhigh)  - (Ring (i+1) Rmin):
+                                     - i=1: 7.2 mm
+                                     - i=2: 7.2 mm
+                                     - i=3: 7.2 mm
+                                     - i=4: 9.2 mm
+                                     
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
                                                                                              
 


### PR DESCRIPTION
- Add IT450: TEPX rings are radially equidistant. 
This is a first attempt to try to have the number of IT stubs ~uniformly distributed in radius.
This will need further tuning, since, for a given r-overlap, the stubs rates is higher at inner radius, due to phiOverlap effects.

TEPX:
From IT404:
Ring 2: Rhigh: 149 mm -> 145 mm.
Ring 3: Rhigh: 188.5 mm -> 182 mm.
Ring 4: Rhigh: 232 mm -> 219 mm.
The resulting radial spacings are, using (Ring (i) Rhigh)  - (Ring (i+1) Rmin):
i=1: 7.2 mm
i=2: 7.2 mm
i=3: 7.2 mm
i=4: 9.2 mm

+ Off-topic: Update IT440 and IT441: switch to 2x2 modules in TEPX Ring 2.
Hence, in the 'Swiss layout', there is now only 2 types of modules: 1x1 and 2x2 modules.
