### PR TITLE
Set the geometry coverage plots maxY (for comparison between layouts purposes)

### DIFF
--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -54,42 +54,6 @@ class TProfile;
 
 namespace insur {
 
-  /**
-   * A warning that may occur during processing
-   */
-  static const std::string msg_module_warning = "Warning: tracker module with undefined subdetector type found.";
-
-
-  /**
-   * Constants specific to the Analyzer
-   */
-  static const std::string outer_tracker_id = "Outer";
-  static const std::string beam_pipe = "Beam Pipe";
-  static const std::string services_under_pixel_tracking_volume = "Services under Pixel Tracking Volume";
-  static const std::string services_in_pixel_tracking_volume = "Services in Pixel Tracking Volume";
-  static const std::string supports_in_pixel_tracking_volume = "Supports in Pixel Tracking Volume";
-  static const std::string services_and_supports_in_interstice = "Services and supports in interstice";
-  static const std::string services_in_outer_tracking_volume = "Services in Outer Tracking Volume";
-  static const std::string supports_in_outer_tracking_volume = "Supports in Outer Tracking Volume";
-
-
-
-  /**
-   * Two comparison functions for <i>std::pair<int, int></i> entries.
-   */
-  bool compareIntPairFirst(std::pair<int, int> p, std::pair<int, int> q);
-  bool compareIntPairSecond(std::pair<int, int> p, std::pair<int, int> q);
-  /**
-   * @class Analyzer
-   * @brief This class analyses the properties of a given <i>MaterialBudget</i> instance with respect to eta.
-   *
-   * It simulates a series of tracks that start at the origin (z = 0), maintain a fixed value of PI / 2 for phi and cover
-   * an eta range from 0 to the maximal eta found in the provided geometry. Each volume hit by a track contributes
-   * its radiation and interaction lengths to a grand total for that track. Those grand totals, recorded by eta, are
-   * stored in a series of histograms that give a complete profile of the expected interaction of the tracker itself with
-   * the particles that pass through it.
-   */
-
   typedef std::map<std::pair<std::string, int>, TH1D*> StubRateHistos;
   typedef std::vector<Module*> ModuleVector;
   typedef std::vector<Layer*> LayerVector;
@@ -115,6 +79,23 @@ namespace insur {
     void visit(const Disk& d) { data.insert(id_ + " " + any2str(d.myid())); }
   };
 
+  /**
+   * Two comparison functions for <i>std::pair<int, int></i> entries.
+   */
+  bool compareIntPairFirst(std::pair<int, int> p, std::pair<int, int> q);
+  bool compareIntPairSecond(std::pair<int, int> p, std::pair<int, int> q);
+
+
+  /**
+   * @class Analyzer
+   * @brief This class analyses the properties of a given <i>MaterialBudget</i> instance with respect to eta.
+   *
+   * It simulates a series of tracks that start at the origin (z = 0), maintain a fixed value of PI / 2 for phi and cover
+   * an eta range from 0 to the maximal eta found in the provided geometry. Each volume hit by a track contributes
+   * its radiation and interaction lengths to a grand total for that track. Those grand totals, recorded by eta, are
+   * stored in a series of histograms that give a complete profile of the expected interaction of the tracker itself with
+   * the particles that pass through it.
+   */
   class Analyzer : private AnalyzerTools {
   public:
     Analyzer();

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -103,10 +103,6 @@ namespace insur {
   typedef std::map<int, TrackCollection> TrackCollectionMap;
 
   typedef std::map<int, TProfile> CoveragePerNumberOfHits;
-  static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
-  static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
-  static const int plotMaxNumberOfOuterTrackerStubs = 11;
-  static const int plotMaxNumberOfInnerTrackerStubs = 3;
 
   class LayerNameVisitor : public ConstGeometryVisitor {
     string id_;
@@ -533,8 +529,6 @@ namespace insur {
     int geometryTracksUsed;
     int materialTracksUsed;
     void fillAvailableSpacing(Tracker& tracker, std::vector<double>& spacingOptions);
-    static constexpr double maximum_n_planes = 13.;
-    static constexpr double plotNumberOfStubsMaxY = 10.;
 
     bool isModuleInEtaSector(const Tracker& tracker, const Module* module, int etaSector) const;
     bool isModuleInPhiSector(const Tracker& tracker, const Module* module, int phiSector) const;

--- a/include/AnalyzerTools.hh
+++ b/include/AnalyzerTools.hh
@@ -7,6 +7,46 @@
 #include <string>
 
 namespace insur {
+  // const specific to the Analyzer
+
+  /**
+   * Geometry coverage plots constants.
+   **/
+
+  // If there are more hits (or stubs) than the specified max, hits (or stubs) are counted in the max category.
+  // Example: if plotNumberOfInnerTrackerStubs == 3, and a track has 4 stubs, it will be counted in the (>=3 stubs) category.
+  static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
+  static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
+  static const int plotMaxNumberOfOuterTrackerStubs = 11;
+  static const int plotMaxNumberOfInnerTrackerStubs = 3;
+
+  // Simply set the plots MaxY.
+  static const double plotNumberOfOuterTrackerHitModulesMaxY = 10.;
+  static const double plotNumberOfInnerTrackerHitModulesMaxY = 20.;
+  static const double plotNumberOfHitsMaxY = 20.;
+  static const double plotNumberOfStubsMaxY = 10.;
+  static const double plotNumberOfOuterTrackerHitLayersMaxY = 8.;
+  static const double plotNumberOfInnerTrackerHitLayersMaxY = 13.;
+  static const double plotNumberOfTriggeredPointsMaxY = 10.;
+
+  /**
+   * Warnings.
+   **/
+  static const std::string msg_module_warning = "Warning: tracker module with undefined subdetector type found.";
+
+
+  /**
+   * Categories.
+   **/
+  static const std::string outer_tracker_id = "Outer";
+  static const std::string beam_pipe = "Beam Pipe";
+  static const std::string services_under_pixel_tracking_volume = "Services under Pixel Tracking Volume";
+  static const std::string services_in_pixel_tracking_volume = "Services in Pixel Tracking Volume";
+  static const std::string supports_in_pixel_tracking_volume = "Supports in Pixel Tracking Volume";
+  static const std::string services_and_supports_in_interstice = "Services and supports in interstice";
+  static const std::string services_in_outer_tracking_volume = "Services in Outer Tracking Volume";
+  static const std::string supports_in_outer_tracking_volume = "Supports in Outer Tracking Volume";
+
 
 class AnalyzerTools {
 protected:

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -54,27 +54,6 @@ namespace insur {
 
 
   /**
-   * Geometry coverage plots constants.
-   **/
-
-  // If there are more hits (or stubs) than the specified max, hits (or stubs) are counted in the max category.
-  // Example: if plotNumberOfInnerTrackerStubs == 3, and a track has 4 stubs, it will be counted in the (>=3 stubs) category.
-  static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
-  static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
-  static const int plotMaxNumberOfOuterTrackerStubs = 11;
-  static const int plotMaxNumberOfInnerTrackerStubs = 3;
-
-  // Simply set the plots MaxY.
-  static const double plotNumberOfOuterTrackerHitModulesMaxY = 10.;
-  static const double plotNumberOfInnerTrackerHitModulesMaxY = 20.;
-  static const double plotNumberOfHitsMaxY = 20.;
-  static const double plotNumberOfStubsMaxY = 10.;
-  static const double plotNumberOfOuterTrackerHitLayersMaxY = 8.;
-  static const double plotNumberOfInnerTrackerHitLayersMaxY = 13.;
-  static const double plotNumberOfTriggeredPointsMaxY = 10.;
-
-
-  /**
    * Visualisation constants: material parameters for active surfaces, services and supports, plus top volume padding.
    * The selected materials are completely arbitrary and only meant to distinguish one type of surface from another visually.
    * @param a_silicon Silicon atomic number

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -11,28 +11,28 @@
 #include <vector>
 
 namespace insur {
+
+  /**
+   * Physics constants.
+   **/
   static const double boltzmann_constant = 8.6173303E-05;  // eV/K
   static const double celsius_to_kelvin = 273.15;          // T(K) = T(°C) + celsius_to_kelvin
   static const double siliconEffectiveBandGap = 1.21;      // eV. Used in the Hamburg model (effect of temperature on sensor leakage current).
 
+
   /**
-   * Geometry constants; all length measurements are in mm
-   * @param epsilon The standard distance between one solid object and the next
-   * @param volume_width The standard geometrical thickness of an inactive volume
-   * @param inner_radius The inner radius of the tracker; the inner support tube starts immediately inside, everything below is part of the pixel detector
-   * @param outer_radius The outer radius of the tracker; the outer support tube starts immediately outside, everything above is part of ECAL
-   * @param max_length The maximum length, in +z, available to place the tracker components
+   * Geometry constants.
    */
   static const std::vector<std::string> geom_name_eta_regions  = {""   ,"C","I","F","VF","VVF"};  // Name tracker eta regions
   static const std::vector<double>      geom_range_eta_regions = {0.001,0.8,1.6,2.4 ,3.2 ,4.0  }; // Name tracker eta regions
 
   static const double geom_zero                       = 1E-6;    // mm
-  static const double geom_epsilon                    = 0.1;
-  static const double geom_inactive_volume_width      = 2.0;     // mm
+  static const double geom_epsilon                    = 0.1;     // mm, standard distance between one solid object and the next.
+  static const double geom_inactive_volume_width      = 2.0;     // mm, standard geometrical thickness of an inactive volume
   static const double geom_conversion_station_width   = 2.0;     // mm
-  static const double geom_inner_pixel_radius         = 30.0;    // mm
-  static const double geom_inner_strip_radius         = 150.0;   // mm
-  static const double geom_outer_strip_radius         = 1200.0;  // mm
+  static const double geom_inner_pixel_radius         = 30.0;    // mm, inner support tube starts immediately inside
+  static const double geom_inner_strip_radius         = 150.0;   // mm, inner support tube starts immediately inside
+  static const double geom_outer_strip_radius         = 1200.0;  // mm, outer support tube starts immediately outside
   static const double geom_z_threshold_service_zigzag = 100.0;
   static const double geom_top_volume_pad             = 200;     // mm
 
@@ -43,7 +43,7 @@ namespace insur {
 
   static const double geom_min_radius                 = geom_inner_pixel_radius;
   static const double geom_max_radius                 = geom_outer_strip_radius;
-  static const double geom_max_length                 = 2800.0; // mm
+  static const double geom_max_length                 = 2800.0; // mm, maximum length, in +z, available to place the tracker components
 
   static const double geom_max_eta_coverage           = geom_range_eta_regions[geom_range_eta_regions.size()-1]; // Tracking performed from step_eta_epsilon to max_eta_coverage in steps
   static const int    geom_n_eta_regions              = geom_range_eta_regions.size();                           // Tracking performed in the following Number of eta regions
@@ -51,6 +51,28 @@ namespace insur {
   static const int    default_n_tracks                = 100;                       // Default number of tracks simulated (max_eta_coverage/default_n_tracks = etaStep)
 
   static const double hits_negligible = 1.E-10;
+
+
+  /**
+   * Geometry coverage plots constants.
+   **/
+
+  // If there are more hits (or stubs) than the specified max, hits (or stubs) are counted in the max category.
+  // Example: if plotNumberOfInnerTrackerStubs == 3, and a track has 4 stubs, it will be counted in the (>=3 stubs) category.
+  static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
+  static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
+  static const int plotMaxNumberOfOuterTrackerStubs = 11;
+  static const int plotMaxNumberOfInnerTrackerStubs = 3;
+
+  // Simply set the plots MaxY.
+  static const double plotNumberOfOuterTrackerHitModulesMaxY = 10.;
+  static const double plotNumberOfInnerTrackerHitModulesMaxY = 20.;
+  static const double plotNumberOfHitsMaxY = 20.;
+  static const double plotNumberOfStubsMaxY = 10.;
+  static const double plotNumberOfOuterTrackerHitLayersMaxY = 8.;
+  static const double plotNumberOfInnerTrackerHitLayersMaxY = 13.;
+  static const double plotNumberOfTriggeredPointsMaxY = 10.;
+
 
   /**
    * Visualisation constants: material parameters for active surfaces, services and supports, plus top volume padding.
@@ -82,6 +104,7 @@ namespace insur {
   static const double mat_budget_overall_scaling_factor = 1.;  // WARNING: DO NOT CHANGE THIS UNLESS YOU ARE OBSOLUTELY SURE OF WHAT YOU ARE DOING!!
                                                                // This will scale absolutely all weights by the mentioned factor (modules + cabling + supports).
                                                                // Was added for CMSSW Material Budget debug purposes.
+
 
   /**
    * Display formatting parameters - eta ticks displayed with short step in range 0 - short_eta_coverage, with long step in range
@@ -124,17 +147,20 @@ namespace insur {
   static const double vis_material_eta_step  = 0.05;
   static const int    vis_n_bins             = geom_max_eta_coverage/vis_eta_step;  // Default number of bins in histogram from eta=0  to max_eta_coverage
 
+
   /**
    * Internal string constants for standard one-sided and specialised double-sided, rotated types
    */
   static const std::string type_rphi   = "rphi";
   static const std::string type_stereo = "stereo";
 
+
   /**
    * Internal string constants for modules types.
    */
   static const std::string type_pixel   = "pixel";
   static const std::string type_timing = "timing";
+
 
   /**
    * Filename and path constants

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -898,7 +898,7 @@ void Analyzer::fillTriggerEfficiencyGraphs(const Tracker& tracker,
 //      j.second->Print("all");
 //    }
 //  }
-  if (totalProfile.GetMaximum() < maximum_n_planes) totalProfile.SetMaximum(maximum_n_planes);
+  if (totalProfile.GetMaximum() < plotNumberOfTriggeredPointsMaxY) totalProfile.SetMaximum(plotNumberOfTriggeredPointsMaxY);
 }
 
 /**
@@ -3328,9 +3328,12 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   sprintf(profileName_, "etaProfileTotal%d", bsCounter++);
   // totalEtaProfile = TProfile(*total2D.ProfileX(profileName_));
   savingGeometryV.push_back(totalEtaProfile);
-  if (totalEtaProfile.GetMaximum()<maximum_n_planes) totalEtaProfile.SetMaximum(maximum_n_planes);
-  if (totalEtaProfileSensors.GetMaximum()<maximum_n_planes) totalEtaProfileSensors.SetMaximum(maximum_n_planes);
-  if (totalEtaProfileStubs.GetMaximum()<maximum_n_planes) totalEtaProfileStubs.SetMaximum(plotNumberOfStubsMaxY);
+  const double plotNumberOfHitModulesMaxY = (!tracker.isPixelTracker() ? plotNumberOfOuterTrackerHitModulesMaxY : plotNumberOfInnerTrackerHitModulesMaxY);
+  if (totalEtaProfile.GetMaximum() < plotNumberOfHitModulesMaxY) totalEtaProfile.SetMaximum(plotNumberOfHitModulesMaxY);
+  if (totalEtaProfileSensors.GetMaximum() < plotNumberOfHitsMaxY) totalEtaProfileSensors.SetMaximum(plotNumberOfHitsMaxY);
+  if (totalEtaProfileStubs.GetMaximum() < plotNumberOfStubsMaxY) totalEtaProfileStubs.SetMaximum(plotNumberOfStubsMaxY);
+  const double plotNumberOfHitLayersMaxY = (!tracker.isPixelTracker() ? plotNumberOfOuterTrackerHitLayersMaxY : plotNumberOfInnerTrackerHitLayersMaxY);
+  if (totalEtaProfileLayers.GetMaximum() < plotNumberOfHitLayersMaxY) totalEtaProfileLayers.SetMaximum(plotNumberOfHitLayersMaxY);
   totalEtaProfile.Draw();
   totalEtaProfileSensors.Draw();
   totalEtaProfileStubs.Draw();


### PR DESCRIPTION
This is gathered in an independent mini-PR, as it makes it much harder to check for regressions.