### PR TITLE
Support of TEPX design in view of luminosity measurements

### DIFF
--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -3,8 +3,8 @@ SimParms {
     bunchSpacingNs 25
     
     // Luminous region used in analysis (IP always on (Z) axis, with Z centered around 0)
-    lumiRegZError                   0      // mm
-    lumiRegShape                    spot   // Choose among { spot, flat, gaussian }
+    lumiRegZError                   70     // mm
+    lumiRegShape                    flat   // Choose among { spot, flat, gaussian }
     lumiRegShapeInMatBudgetAnalysis spot
 
     // Adds IP to the track with corresponding resolution

--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -3,8 +3,8 @@ SimParms {
     bunchSpacingNs 25
     
     // Luminous region used in analysis (IP always on (Z) axis, with Z centered around 0)
-    lumiRegZError                   70     // mm
-    lumiRegShape                    flat   // Choose among { spot, flat, gaussian }
+    lumiRegZError                   0      // mm
+    lumiRegShape                    spot   // Choose among { spot, flat, gaussian }
     lumiRegShapeInMatBudgetAnalysis spot
 
     // Adds IP to the track with corresponding resolution

--- a/geometries/CMS_Phase2/OT614_200_IT451.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT451.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_5_1.cfg

--- a/geometries/CMS_Phase2/OT614_200_IT452.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT452.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V4/Pixel_V4_5_2.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_5_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_5_1.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 56
+      ringOuterRadius 146
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 183
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 44
+      ringOuterRadius 220
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 254
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_5_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/FPIX2_4_5_2.cfg
@@ -1,0 +1,70 @@
+  Endcap FPIX_2 {
+
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R1_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 40
+      ringOuterRadius 108
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_1x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R2_1x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 56
+      ringOuterRadius 149
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 186
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 44
+      ringOuterRadius 223
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2_2x2_25x100
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_v2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 254
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_1.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_0.cfg
+  @include FPIX1_4_0_2.cfg
+  @include FPIX2_4_5_1.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_2.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_4_4_0.cfg
+  @include FPIX1_4_0_2.cfg
+  @include FPIX2_4_5_2.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -315,6 +315,19 @@ OT614_200_IT450.cfg                  OT Version 6.1.4
                                      - i=3: 7.2 mm
                                      - i=4: 9.2 mm
                                      
+OT614_200_IT451.cfg                  OT Version 6.1.4
+                                     Inner Tracker version 4.5.1: Tune radii and numModules in TEPX to try to equilibrate luminosity measurements.
+                                     Based from Inner Tracker version 4.5.0.
+                                     TEPX:
+                                     - Ring 2: Rhigh: 145 mm -> 146 mm.
+                                     - Ring 3: Rhigh: 182 mm -> 183 mm.
+                                     - Ring 4: Rhigh: 219 mm -> 220 mm, numModules: 40 -> 44.
+                                     The resulting radial spacings are, using (Ring (i) Rhigh)  - (Ring (i+1) Rmin):
+                                     - i=1: 6.2 mm
+                                     - i=2: 7.2 mm
+                                     - i=3: 7.2 mm
+                                     - i=4: 10.2 mm
+                                     
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
                                                                                              
 

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -283,7 +283,7 @@ OT614_200_IT440.cfg                  OT Version 6.1.4
                                      Based from Inner Tracker version 4.0.4.
                                      TEPX: 
                                      - Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 36.
-                                     - Ring 2: Rhigh: 149 mm -> 130 mm, numModules: 56 -> 52.
+                                     - Ring 2: Rhigh: 149 mm -> 130 mm, numModules: 56 -> 28.
                                      - Ring 3: Rhigh: 188.5 mm -> 171 mm.
                                      - Ring 4: Rhigh: 232 mm -> 215 mm.
                                      
@@ -295,7 +295,7 @@ OT614_200_IT441.cfg                  OT Version 6.1.4
                                      - Ring 1: Rhigh: 73.2 mm -> 51 mm.
                                      TEPX: 
                                      - Ring 1: Rhigh: 108 mm -> 86 mm,  numModules: 40 -> 32.
-                                     - Ring 2: Rhigh: 149 mm -> 127 mm, numModules: 56 -> 48.
+                                     - Ring 2: Rhigh: 149 mm -> 127 mm, numModules: 56 -> 28.
                                      - Ring 3: Rhigh: 188.5 mm -> 169 mm.
                                      - Ring 4: Rhigh: 232 mm -> 213 mm.
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -328,6 +328,19 @@ OT614_200_IT451.cfg                  OT Version 6.1.4
                                      - i=3: 7.2 mm
                                      - i=4: 10.2 mm
                                      
+OT614_200_IT452.cfg                  OT Version 6.1.4
+                                     Inner Tracker version 4.5.2: Tune radii in TEPX, perfectly equilibrated among rings thanks to the precise counts of fraction of tracks with at least 3 hits.
+                                     Based from Inner Tracker version 4.5.0.
+                                     TEPX:                                     
+                                     * Ring 2: Rhigh: 145 mm -> 149 mm.
+                                     * Ring 3: Rhigh: 182 mm -> 186 mm.
+                                     * Ring 4: Rhigh: 219 mm -> 223 mm, numModules: 40 -> 44.
+                                     The resulting radial spacings are, using (Ring (i) Rhigh)  - (Ring (i+1) Rmin):
+                                     * i=1: 3.2 mm
+                                     * i=2: 7.2 mm
+                                     * i=3: 7.2 mm
+                                     * i=4: 13.2 mm
+                                     
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
                                                                                              
 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -235,6 +235,7 @@ namespace insur {
     std::map<std::string, CoveragePerNumberOfHits>& getHitCoveragePerLayerDetails() { return hitCoveragePerLayerDetails_; } // Layer coverage: hits details
     std::map<std::string, TProfile>& getStubCoveragePerLayer() { return stubCoveragePerLayer_; } // Layer coverage: stubs
     std::map<std::string, TProfile>& getStubWith3HitsCoveragePerLayer() { return stubWith3HitsCoveragePerLayer_; } // IT Layer coverage: stubs with 3 hits
+    std::map<std::string, std::map<int, double> >& getStubWith3HitsCountPerDiskAndRing() { return stubWith3HitsCountPerDiskAndRing_; } // TEPX only
     std::map<std::string, std::map<std::string, TH1I*>>& getStubEfficiencyCoverageProfiles() { return stubEfficiencyCoverageProfiles_; } // map of maps: inner map has momenta as keys
     std::vector<TObject> getSavingVector();
     TCanvas* getGeomLite() {if (geomLiteCreated) return geomLite; else return NULL; };
@@ -440,6 +441,7 @@ namespace insur {
     std::map<std::string, CoveragePerNumberOfHits> hitCoveragePerLayerDetails_;
     std::map<std::string, TProfile> stubCoveragePerLayer_;
     std::map<std::string, TProfile> stubWith3HitsCoveragePerLayer_;
+    std::map<std::string, std::map<int, double> > stubWith3HitsCountPerDiskAndRing_;
 
     std::map<std::string, std::map<std::string, TH1I*>> stubEfficiencyCoverageProfiles_;
 

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -524,6 +524,13 @@ namespace insur {
 						      const LayerNameVisitor& layerNames, 
 						      const bool isPixelTracker, 
 						      const double maxEta);
+    void computeInnerTrackerStubsInfoPerLayer(const int numHitsPerLayer,
+					      const bool isTEPX,
+					      const std::vector<int>& hitTEPXRingsIndexes,
+					      const std::string layerName,
+					      int& numInnerTrackerStubs, 
+					      int& hasLayerAtLeastOneStub, 
+					      int& hasLayerOneStubWith3Hits);
     void createCoveragePerLayerPlots(const LayerNameVisitor& layerNames, 
 				     const bool isPixelTracker, 
 				     const double maxEta);

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -234,6 +234,7 @@ namespace insur {
     std::map<std::string, TProfile>& getHitCoveragePerLayer() { return hitCoveragePerLayer_; } // Layer coverage: hits
     std::map<std::string, CoveragePerNumberOfHits>& getHitCoveragePerLayerDetails() { return hitCoveragePerLayerDetails_; } // Layer coverage: hits details
     std::map<std::string, TProfile>& getStubCoveragePerLayer() { return stubCoveragePerLayer_; } // Layer coverage: stubs
+    std::map<std::string, TProfile>& getStubWith3HitsCoveragePerLayer() { return stubWith3HitsCoveragePerLayer_; } // IT Layer coverage: stubs with 3 hits
     std::map<std::string, std::map<std::string, TH1I*>>& getStubEfficiencyCoverageProfiles() { return stubEfficiencyCoverageProfiles_; } // map of maps: inner map has momenta as keys
     std::vector<TObject> getSavingVector();
     TCanvas* getGeomLite() {if (geomLiteCreated) return geomLite; else return NULL; };
@@ -438,6 +439,7 @@ namespace insur {
     std::map<std::string, TProfile> hitCoveragePerLayer_;
     std::map<std::string, CoveragePerNumberOfHits> hitCoveragePerLayerDetails_;
     std::map<std::string, TProfile> stubCoveragePerLayer_;
+    std::map<std::string, TProfile> stubWith3HitsCoveragePerLayer_;
 
     std::map<std::string, std::map<std::string, TH1I*>> stubEfficiencyCoverageProfiles_;
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -203,6 +203,7 @@ namespace insur {
     // COVERAGE PER LAYER: HITS AND STUBS
     bool drawHitCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     bool drawStubCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
+    bool drawStubWith3HitsCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer);
     bool drawCoveragePerlayer(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& coveragePerLayerDetails);
     bool drawCoveragePerlayerDetails(CoveragePerNumberOfHits& coveragePerLayerDetails, const std::string type, TLegend* layerLegend, const int plotMaxNumberOfHits);
 

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -204,7 +204,10 @@ namespace insur {
     bool drawHitCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     bool drawStubCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer, const bool isPixelTracker);
     bool drawStubWith3HitsCoveragePerLayer(RootWPage& myPage, Analyzer& analyzer);
-    bool drawCoveragePerlayer(RootWPage& myPage, const bool isPixelTracker, const std::string type, std::map<std::string, TProfile>& coveragePerLayer, std::map<std::string, CoveragePerNumberOfHits>& coveragePerLayerDetails);
+    bool drawCoveragePerlayer(RootWPage& myPage, const bool isPixelTracker, const std::string type, 
+			      std::map<std::string, TProfile>& coveragePerLayer,			      
+			      std::map<std::string, CoveragePerNumberOfHits>& coveragePerLayerDetails,
+			      std::map<std::string, std::map<int, double> >& stubWith3HitsCountPerDiskAndRing);
     bool drawCoveragePerlayerDetails(CoveragePerNumberOfHits& coveragePerLayerDetails, const std::string type, TLegend* layerLegend, const int plotMaxNumberOfHits);
 
     int momentumColor(int iMomentum);

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -128,6 +128,11 @@ namespace insur {
 
 
   /**
+   * Internal string constants for luminosity measurements
+   */
+  static const std::string lumi_subdetector = "FPIX_2";
+
+  /**
    * Internal string constants for standard one-sided and specialised double-sided, rotated types
    */
   static const std::string type_rphi   = "rphi";

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3136,7 +3136,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   etaProfileByTypeStubs.clear();
 
   const int coveragePlotsBinsNumber = 30;  //  HEREEEEEEEEEEEEEEEEEEE
-  const int coveragePlotsStubsDetailsBinsNumber = 20;  //  HEREEEEEEEEEEEEEEEEEEE
+  const int coveragePlotsStubsDetailsBinsNumber = 30;  //  HEREEEEEEEEEEEEEEEEEEE
 
   for (std::map <std::string, int>::iterator it = moduleTypeCount.begin();
        it!=moduleTypeCount.end(); it++) {
@@ -3153,11 +3153,13 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     aProfileStubs.SetTitle(mel.first.c_str());
   }
 
-  for (auto mel : moduleTypeCountStubs) {
-    TProfile& aProfileStubs = etaProfileByTypeStubs[mel.first];
-    aProfileStubs.SetBins(coveragePlotsBinsNumber, 0, maxEta);
-    aProfileStubs.SetName(mel.first.c_str());
-    aProfileStubs.SetTitle(mel.first.c_str());
+  if (!tracker.isPixelTracker()) {
+    for (auto mel : moduleTypeCountStubs) {
+      TProfile& aProfileStubs = etaProfileByTypeStubs[mel.first];
+      aProfileStubs.SetBins(coveragePlotsBinsNumber, 0, maxEta);
+      aProfileStubs.SetName(mel.first.c_str());
+      aProfileStubs.SetTitle(mel.first.c_str());
+    }
   }
  
   // The real simulation
@@ -3174,6 +3176,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfile.SetName("totalEtaProfile");
   totalEtaProfile.SetMarkerStyle(8);
   totalEtaProfile.SetMarkerColor(1);
+  totalEtaProfile.SetLineColor(1);
   totalEtaProfile.SetMarkerSize(1.5);
   totalEtaProfile.SetTitle("Number of modules with at least one hit;#eta;Number of hit modules");
   totalEtaProfile.SetBins(coveragePlotsBinsNumber, 0, maxEta);
@@ -3183,6 +3186,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfileSensors.SetName("totalEtaProfileSensors");
   totalEtaProfileSensors.SetMarkerStyle(8);
   totalEtaProfileSensors.SetMarkerColor(1);
+  totalEtaProfileSensors.SetLineColor(1);
   totalEtaProfileSensors.SetMarkerSize(1.5);
   totalEtaProfileSensors.SetTitle("Number of hits;#eta;Number of hits");
   totalEtaProfileSensors.SetBins(coveragePlotsBinsNumber, 0, maxEta);
@@ -3192,6 +3196,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfileStubs.SetName("totalEtaProfileStubs");
   totalEtaProfileStubs.SetMarkerStyle(8);
   totalEtaProfileStubs.SetMarkerColor(1);
+  totalEtaProfileStubs.SetLineColor(1);
   totalEtaProfileStubs.SetMarkerSize(1.5);
   if (!tracker.isPixelTracker()) { totalEtaProfileStubs.SetTitle("Number of modules with a stub;#eta;Number of stubs"); }
   else { totalEtaProfileStubs.SetTitle("Number of stubs;#eta;Number of stubs"); }
@@ -3211,6 +3216,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfileLayers.SetName("totalEtaProfileLayers");
   totalEtaProfileLayers.SetMarkerStyle(8);
   totalEtaProfileLayers.SetMarkerColor(1);
+  totalEtaProfileLayers.SetLineColor(1);
   totalEtaProfileLayers.SetMarkerSize(1.5);
   totalEtaProfileLayers.SetTitle("Number of layers with at least a hit;#eta;Number of layers");
   totalEtaProfileLayers.SetBins(100, 0, maxEta);
@@ -3269,8 +3275,10 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
         etaProfileByTypeSensors[mel.first].Fill(fabs(aLine.second), mel.second);
       }
 
-      for (auto& mel : moduleTypeCountStubs) {
-        etaProfileByTypeStubs[mel.first].Fill(fabs(aLine.second), mel.second);
+      if (!tracker.isPixelTracker()) {
+	for (auto& mel : moduleTypeCountStubs) {
+	  etaProfileByTypeStubs[mel.first].Fill(fabs(aLine.second), mel.second);
+	}
       }
       // Fill other plots
       mapPhiEta.Fill(aLine.first.Phi(), aLine.second, hitModules.size()); // phi, eta 2d plot
@@ -3346,6 +3354,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     savingGeometryV.push_back(*myProfile); // TODO: remove savingGeometryV everywhere :-) [VERY obsolete...]
     myProfile->SetMarkerStyle(8);
     myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
+    myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetMarkerSize(1);
     std::string profileName = "etaProfile"+(*it).first;
     myProfile->SetName(profileName.c_str());
@@ -3361,6 +3370,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     TProfile* myProfile=(TProfile*)it->second.Clone();
     myProfile->SetMarkerStyle(8);
     myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
+    myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetMarkerSize(1);
     std::string profileName = "etaProfileSensors"+(*it).first;
     myProfile->SetName(profileName.c_str());
@@ -3371,19 +3381,22 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     typeEtaProfileSensors.push_back(*myProfile);
   }
 
-  for (std::map <std::string, TProfile>::iterator it = etaProfileByTypeStubs.begin();
-       it!=etaProfileByTypeStubs.end(); it++) {
-    TProfile* myProfile=(TProfile*)it->second.Clone();
-    myProfile->SetMarkerStyle(8);
-    myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
-    myProfile->SetMarkerSize(1);
-    std::string profileName = "etaProfileStubs"+(*it).first;
-    myProfile->SetName(profileName.c_str());
-    myProfile->SetTitle((*it).first.c_str());
-    myProfile->GetXaxis()->SetTitle("eta");
-    myProfile->GetYaxis()->SetTitle("Number of stubs");
-    myProfile->Draw("same");
-    typeEtaProfileStubs.push_back(*myProfile);
+  if (!tracker.isPixelTracker()) {
+    for (std::map <std::string, TProfile>::iterator it = etaProfileByTypeStubs.begin();
+	 it!=etaProfileByTypeStubs.end(); it++) {
+      TProfile* myProfile=(TProfile*)it->second.Clone();
+      myProfile->SetMarkerStyle(8);
+      myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
+      myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
+      myProfile->SetMarkerSize(1);
+      std::string profileName = "etaProfileStubs"+(*it).first;
+      myProfile->SetName(profileName.c_str());
+      myProfile->SetTitle((*it).first.c_str());
+      myProfile->GetXaxis()->SetTitle("eta");
+      myProfile->GetYaxis()->SetTitle("Number of stubs");
+      myProfile->Draw("same");
+      typeEtaProfileStubs.push_back(*myProfile);
+    }
   }
 
 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3428,15 +3428,13 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
                           typeToPower[aSensorType] / typeToSurface[aSensorType] );
   }
 
-  std::cout << pow(nTracksPerSide, 2.) << std::endl;
-  std::cout << nTracks << std::endl;
   for (auto& diskIt : stubWith3HitsCountPerDiskAndRing_) {
     //const std::string diskName = diskIt.first;
     std::map<int, double>& stubWith3HitsCountPerRing = diskIt.second;
     for (auto& ringTransitionIt : stubWith3HitsCountPerRing) {
       //const int ringTransition = ringTransitionIt.first;
       double& stubWith3HitsCount = ringTransitionIt.second;
-      //stubWith3HitsCountPerDiskAndRing_[diskName][ringTransition] /= (nTracksPerSide^2);
+      //stubWith3HitsCountPerDiskAndRing_[diskName][ringTransition] /= nTracks;
       stubWith3HitsCount /= nTracks;
     }
   }

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3135,24 +3135,27 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   etaProfileByTypeSensors.clear();
   etaProfileByTypeStubs.clear();
 
+  const int coveragePlotsBinsNumber = 30;  //  HEREEEEEEEEEEEEEEEEEEE
+  const int coveragePlotsStubsDetailsBinsNumber = 20;  //  HEREEEEEEEEEEEEEEEEEEE
+
   for (std::map <std::string, int>::iterator it = moduleTypeCount.begin();
        it!=moduleTypeCount.end(); it++) {
     TProfile& aProfile = etaProfileByType[(*it).first];
-    aProfile.SetBins(100, 0, maxEta);
+    aProfile.SetBins(coveragePlotsBinsNumber, 0, maxEta);  
     aProfile.SetName((*it).first.c_str());
     aProfile.SetTitle((*it).first.c_str());
   }
 
   for (auto mel : sensorTypeCount) {
     TProfile& aProfileStubs = etaProfileByTypeSensors[mel.first];
-    aProfileStubs.SetBins(100, 0, maxEta);
+    aProfileStubs.SetBins(coveragePlotsBinsNumber, 0, maxEta);
     aProfileStubs.SetName(mel.first.c_str());
     aProfileStubs.SetTitle(mel.first.c_str());
   }
 
   for (auto mel : moduleTypeCountStubs) {
     TProfile& aProfileStubs = etaProfileByTypeStubs[mel.first];
-    aProfileStubs.SetBins(100, 0, maxEta);
+    aProfileStubs.SetBins(coveragePlotsBinsNumber, 0, maxEta);
     aProfileStubs.SetName(mel.first.c_str());
     aProfileStubs.SetTitle(mel.first.c_str());
   }
@@ -3173,7 +3176,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfile.SetMarkerColor(1);
   totalEtaProfile.SetMarkerSize(1.5);
   totalEtaProfile.SetTitle("Number of modules with at least one hit;#eta;Number of hit modules");
-  totalEtaProfile.SetBins(100, 0, maxEta);
+  totalEtaProfile.SetBins(coveragePlotsBinsNumber, 0, maxEta);
   totalEtaProfile.SetStats(0);
 
   totalEtaProfileSensors.Reset();
@@ -3182,7 +3185,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfileSensors.SetMarkerColor(1);
   totalEtaProfileSensors.SetMarkerSize(1.5);
   totalEtaProfileSensors.SetTitle("Number of hits;#eta;Number of hits");
-  totalEtaProfileSensors.SetBins(100, 0, maxEta);
+  totalEtaProfileSensors.SetBins(coveragePlotsBinsNumber, 0, maxEta);
   totalEtaProfileSensors.SetStats(0);
 
   totalEtaProfileStubs.Reset();
@@ -3192,7 +3195,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfileStubs.SetMarkerSize(1.5);
   if (!tracker.isPixelTracker()) { totalEtaProfileStubs.SetTitle("Number of modules with a stub;#eta;Number of stubs"); }
   else { totalEtaProfileStubs.SetTitle("Number of stubs;#eta;Number of stubs"); }
-  totalEtaProfileStubs.SetBins(100, 0, maxEta);
+  totalEtaProfileStubs.SetBins(coveragePlotsBinsNumber, 0, maxEta);
   totalEtaProfileStubs.SetStats(0);
 
   // CREATE PLOTS: distribution of tracks per number of stubs.
@@ -3200,7 +3203,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   for (int numberOfStubs = 0; numberOfStubs <= plotMaxNumberOfStubs; numberOfStubs++) {
     TProfile stubProfile = TProfile( Form("layerEtaCoverageProfileNumberOfStubs%d", numberOfStubs), 
 				     "Distribution of number of stub(s) per track;#eta;Fraction of tracks", 
-				     100, 0, maxEta);
+				     coveragePlotsStubsDetailsBinsNumber, 0, maxEta); 
     tracksDistributionPerNumberOfStubs_[numberOfStubs] = stubProfile;
   }
 
@@ -3658,7 +3661,9 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
 
       // STUB COVERAGE
       // stub >= 1
-      stubCoveragePerLayer_[layerName].Fill(aLine.second, hasLayerAtLeastOneStub);
+      const bool isBarrel = (layerName.find("PXB") != std::string::npos);
+      const double eta = (isBarrel ? aLine.second : fabs(aLine.second));
+      stubCoveragePerLayer_[layerName].Fill(eta, hasLayerAtLeastOneStub);
     } // loop on all layers
 
     return std::make_pair(numLayersWithAtLeastOneHit, numInnerTrackerStubs);
@@ -3693,16 +3698,18 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
       for (int numberOfHits = 1; numberOfHits <= plotMaxNumberOfHitsPerLayer; numberOfHits++) {
 	TProfile hitsCountPerLayer = TProfile(Form("hitCoveragePerLayerDetails%s%d", layerName.c_str(), numberOfHits), 
 					      layerName.c_str(),
-					      100, maxEta, maxEta);
+					      100, maxEta, maxEta);   //  HEREEEEEEEEEEEEEEEEEEE
 	hitsCountPerLayer.GetXaxis()->SetTitle("#eta");
 	hitsCountPerLayer.GetYaxis()->SetTitle("Fraction of tracks");
 	hitCoveragePerLayerDetails_[layerName][numberOfHits] = hitsCountPerLayer;
       }
 
       // STUBS PER LAYER
+      const bool isBarrel = (layerName.find("PXB") != std::string::npos);
+      const double stubsPerLayerMinX = (isBarrel ? -maxEta : 0.);
       TProfile stubsPerLayer = TProfile(Form("stubCoveragePerLayer%s", layerName.c_str()),
 					layerName.c_str(),
-					200, maxEta, maxEta);
+					400, stubsPerLayerMinX, maxEta);  //  HEREEEEEEEEEEEEEEEEEEE
       stubsPerLayer.GetXaxis()->SetTitle("#eta");
       stubsPerLayer.GetYaxis()->SetTitle("Fraction of tracks");   
       stubCoveragePerLayer_[layerName] = stubsPerLayer;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2800,7 +2800,7 @@ namespace insur {
       detailProfile.SetLineColor(Palette::color(colorIndex));
       detailProfile.SetFillColor(Palette::color(colorIndex));
       detailProfile.SetMarkerStyle(8);
-      detailProfile.SetMarkerSize(1.);
+      detailProfile.SetMarkerSize(1.5);
       detailProfile.GetYaxis()->SetTitleOffset(1.3);
       detailProfile.SetStats(0);
       detailProfile.Draw("same");
@@ -2988,6 +2988,7 @@ namespace insur {
       myContent->addItem(myImage);
     }
 
+    // IT only: add tables with detailed 3-hit stubs counts, per ring transition.
     if (is3HitsStubStudy && !stubWith3HitsCountPerDiskAndRing.empty()) {
       for (const auto& diskIt : stubWith3HitsCountPerDiskAndRing) {
 	RootWTable* stubWith3HitsCountTable = new RootWTable();
@@ -2996,7 +2997,6 @@ namespace insur {
 	stubWith3HitsCountTable->setContent(0, 0, diskName);
 	stubWith3HitsCountTable->setContent(1, 0, "Ring transition (Ring i & i+1):");
 	stubWith3HitsCountTable->setContent(2, 0, "Fraction of tracks (‰)");
-	//stubWith3HitsCountTable->setContent(2, 0, "Number of tracks ");
 
 	for (const auto& ringTransitionIt : stubWith3HitsCountPerRing) {
 	  const int ringTransition = ringTransitionIt.first;


### PR DESCRIPTION
In addition of https://github.com/tkLayout/tkLayout/pull/433 and https://github.com/tkLayout/tkLayout/pull/435, this allows to tune TEPX design in view of luminosity measurements.

See https://indico.cern.ch/event/688869/contributions/3076687/attachments/1687212/2713554/TEPX_layout_discussion.pdf .

Notably, the 3-hit stubs concept is added in IT:
- computes and adds detailed 3-hit stubs coverage plots, for each layer.
- also computes an integral 'per ring transition' of the 3-hit stubs, for each TEPX disk.

Example with IT 450:
![it450](https://user-images.githubusercontent.com/11192654/42952004-cc818800-8b77-11e8-8e15-dd032f45231e.png)
![3hits](https://user-images.githubusercontent.com/11192654/42951950-b4b53000-8b77-11e8-87cc-1c123483b6f4.png)
![table](https://user-images.githubusercontent.com/11192654/42951967-bc67f35a-8b77-11e8-855e-d4e7a25f3c59.png)


2 IT layouts are added:
- IT451: 
Tune radii and numModules in TEPX to try to equilibrate luminosity measurements.
Based from Inner Tracker version 4.5.0.
TEPX:
Ring 2: Rhigh: 145 mm -> 146 mm.
Ring 3: Rhigh: 182 mm -> 183 mm.
Ring 4: Rhigh: 219 mm -> 220 mm, numModules: 40 -> 44.
The resulting radial spacings are, using (Ring (i) Rhigh)  - (Ring (i+1) Rmin):
i=1: 6.2 mm
i=2: 7.2 mm
i=3: 7.2 mm
i=4: 10.2 mm

![it451](https://user-images.githubusercontent.com/11192654/42952258-5eaa40d2-8b78-11e8-8f83-4df201a451f2.png)
![untitled](https://user-images.githubusercontent.com/11192654/42952267-63621672-8b78-11e8-9b2d-c9262768f7af.png)


- IT 452:
Tune radii in TEPX, perfectly equilibrated among rings thanks to the precise counts of fraction of tracks with at least 3 hits.
Based from Inner Tracker version 4.5.0.
TEPX:                                     
Ring 2: Rhigh: 145 mm -> 149 mm.
Ring 3: Rhigh: 182 mm -> 186 mm.
Ring 4: Rhigh: 219 mm -> 223 mm, numModules: 40 -> 44.
The resulting radial spacings are, using (Ring (i) Rhigh)  - (Ring (i+1) Rmin):
i=1: 3.2 mm
i=2: 7.2 mm
i=3: 7.2 mm
i=4: 13.2 mm

![it452](https://user-images.githubusercontent.com/11192654/42952039-da3df0fa-8b77-11e8-9e60-e0381027f978.png)
![table2](https://user-images.githubusercontent.com/11192654/42952152-199296c0-8b78-11e8-8bd1-845986b4f48f.png)

This study shows that trying to perfectly equilibrate the rates among rings (as in 452) might not be what we want, as the total fraction of 3-hit stubs is lower for this geometry.
This was not considered before, and is a precious tool for TEPX design.