### PR TITLE
Mini-PR: Adjusted Z positions of BPX conversion stations on service cylinder in IT461

### DIFF
--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/stations_BPIX_Service_Cylinder_V2
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/stations_BPIX_Service_Cylinder_V2
@@ -4,7 +4,7 @@
 Station {
   stationName BPIX1
   type second
-  minZ 480
+  minZ 430
   maxZ 520
   @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
 }
@@ -12,23 +12,23 @@ Station {
 Station {
   stationName BPIX2
   type second
-  minZ 600
-  maxZ 640
+  minZ 530
+  maxZ 620
   @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
 }
 
 Station {
   stationName BPIX3
   type second
-  minZ 645
-  maxZ 685
+  minZ 630
+  maxZ 720
   @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
 }
 
 Station {
   stationName BPIX4
   type second
-  minZ 740
-  maxZ 780
+  minZ 730
+  maxZ 820
   @include-std CMS_Phase2/Pixel/Conversions/TWP_to_GBT
 }


### PR DESCRIPTION
BPX conversion stations on service cylinder are now nearly adjacent, from Z = 430 mm to Z = 820 mm. Since they are 2 mm thick only, making them shorter result in a huge MB concentration in one spot only. 
To be further adjusted by Andre.