### PR TITLE
Avoid TCanvas::DrawClone() 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,11 @@ COMPILERFLAGS+=-g
 COMPILERFLAGS+=-fpermissive
 COMPILERFLAGS+=-lstdc++
 COMPILERFLAGS+=-fmax-errors=2
-#COMPILERFLAGS+=-pg
+
 #COMPILERFLAGS+=-O3
+
 LINKERFLAGS+=-Wl,--copy-dt-needed-entries
+#COMPILERFLAGS+=-pg
 #LINKERFLAGS+=-pg
 
 OUT_DIR+=$(LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,9 @@ COMPILERFLAGS+=-g
 COMPILERFLAGS+=-fpermissive
 COMPILERFLAGS+=-lstdc++
 COMPILERFLAGS+=-fmax-errors=2
-
-#COMPILERFLAGS+=-O3
-
-LINKERFLAGS+=-Wl,--copy-dt-needed-entries
 #COMPILERFLAGS+=-pg
+#COMPILERFLAGS+=-O3
+LINKERFLAGS+=-Wl,--copy-dt-needed-entries
 #LINKERFLAGS+=-pg
 
 OUT_DIR+=$(LIBDIR)

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -606,6 +606,7 @@ void PlotDrawer<CoordType, ValueGetterType, StatType>::drawFrame(TCanvas& canvas
   viewportMaxX_ = viewportMaxX_ == 0 ? getLine.maxx()*1.1 : viewportMaxX_;  // in case the viewport coord is 0, auto-viewport mode is used and getLine is queried for the farthest X or Y it has registered
   viewportMaxY_ = viewportMaxY_ == 0 ? getLine.maxy()*1.1 : viewportMaxY_;
   TH2C* frame = getFrame(viewportMaxX_, viewportMaxY_);
+  frame->SetStats(0);
   frameStyle(*frame, canvas, palette_);
 }
 

--- a/include/RootWeb.hh
+++ b/include/RootWeb.hh
@@ -14,6 +14,7 @@
 #include <TCanvas.h>
 #include <TFile.h>
 #include <vector>
+#include <memory>
 
 using namespace std;
 
@@ -108,7 +109,6 @@ typedef string RootWImageSize;
 
 class RootWImage : public RootWItem {
 public:
-  ~RootWImage();
   RootWImage();
   // TODO: the methods with TCanvas* (pointer) should be made obsolete
   RootWImage(TCanvas* myCanvas, int witdh, int height);
@@ -130,7 +130,7 @@ public:
   bool addExtension(string newExt);
   void saveSummary(std::string baseName, TFile* myTargetFile);
 private:
-  TCanvas* myCanvas_;
+  std::unique_ptr<TCanvas> myCanvas_ = nullptr;
   int zoomedWidth_;
   int zoomedHeight_;
   string relativeHtmlDirectory_;

--- a/include/RootWeb.hh
+++ b/include/RootWeb.hh
@@ -112,9 +112,10 @@ public:
   RootWImage();
   // TODO: the methods with TCanvas* (pointer) should be made obsolete
   RootWImage(TCanvas* myCanvas, int witdh, int height);
+  RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height);
   RootWImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
   void setCanvas(TCanvas* myCanvas);
-  void setCanvas(TCanvas& myCanvas);
+  void setCanvas(std::unique_ptr<TCanvas> myCanvas);
   void setComment(string newComment);
   void setName(string newName);
   std::string getName();
@@ -250,6 +251,7 @@ public:
   RootWTable& addTable();
   RootWImage& addImage();
   RootWImage& addImage(TCanvas* myCanvas, int witdh, int height);
+  RootWImage& addImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height);
   RootWImage& addImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
   RootWTextFile& addTextFile();
   RootWTextFile& addTextFile(string newFileName);

--- a/include/RootWeb.hh
+++ b/include/RootWeb.hh
@@ -282,7 +282,7 @@ private:
   string programSite_;
   string revision_;
   string targetDirectory_;
-  TFile* summaryFile_;
+  std::unique_ptr<TFile> summaryFile_;
   bool createSummaryFile_;
   string summaryFileName_;
 public:

--- a/include/RootWeb.hh
+++ b/include/RootWeb.hh
@@ -111,10 +111,8 @@ class RootWImage : public RootWItem {
 public:
   RootWImage();
   // TODO: the methods with TCanvas* (pointer) should be made obsolete
-  RootWImage(TCanvas* myCanvas, int witdh, int height);
   RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height);
-  RootWImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
-  void setCanvas(TCanvas* myCanvas);
+  RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
   void setCanvas(std::unique_ptr<TCanvas> myCanvas);
   void setComment(string newComment);
   void setName(string newName);
@@ -250,9 +248,8 @@ public:
   RootWInfo& addInfo(string description, string value);
   RootWTable& addTable();
   RootWImage& addImage();
-  RootWImage& addImage(TCanvas* myCanvas, int witdh, int height);
   RootWImage& addImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height);
-  RootWImage& addImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
+  RootWImage& addImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
   RootWTextFile& addTextFile();
   RootWTextFile& addTextFile(string newFileName);
   RootWTextFile& addTextFile(string newFileName, string newDescription);

--- a/include/RootWeb.hh
+++ b/include/RootWeb.hh
@@ -113,8 +113,6 @@ public:
   // TODO: the methods with TCanvas* (pointer) should be made obsolete
   RootWImage(TCanvas* myCanvas, int witdh, int height);
   RootWImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
-  RootWImage(TCanvas& myCanvas, int witdh, int height);
-  RootWImage(TCanvas& myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
   void setCanvas(TCanvas* myCanvas);
   void setCanvas(TCanvas& myCanvas);
   void setComment(string newComment);
@@ -253,8 +251,6 @@ public:
   RootWImage& addImage();
   RootWImage& addImage(TCanvas* myCanvas, int witdh, int height);
   RootWImage& addImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
-  RootWImage& addImage(TCanvas& myCanvas, int witdh, int height);
-  RootWImage& addImage(TCanvas& myCanvas, int witdh, int height, string relativeHtmlDirectory); // TODO: is this used for real?
   RootWTextFile& addTextFile();
   RootWTextFile& addTextFile(string newFileName);
   RootWTextFile& addTextFile(string newFileName, string newDescription);

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -10,9 +10,9 @@
  * @brief This is the header file for the core visualisation class
  */
 
-#ifndef _VIZARD_HTCanvas
+#ifndef _VIZARD_H
 #define	_VIZARD_H
-// Standard includestc
+// Standard includes
 #include <fstream>
 #include <sstream>
 // ROOT objects

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -10,9 +10,9 @@
  * @brief This is the header file for the core visualisation class
  */
 
-#ifndef _VIZARD_H
+#ifndef _VIZARD_HTCanvas
 #define	_VIZARD_H
-// Standard includes
+// Standard includestc
 #include <fstream>
 #include <sstream>
 // ROOT objects
@@ -183,19 +183,19 @@ namespace insur {
     double averageHistogramValues(TH1D& histo, double cutoff);
     double averageHistogramValues(TH1D& histo, double cutoffStart, double cutoffEnd);
 
-    void createSummaryCanvas(double maxZ, double maxRho, Analyzer& analyzer, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYCanvasEC);
-    void createSummaryCanvasNicer(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&YZCanvasBarrel, TCanvas *&XYCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createSummaryCanvas(double maxZ, double maxRho, Analyzer& analyzer, std::unique_ptr<TCanvas> &YZCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYCanvasEC);
+    void createSummaryCanvasNicer(Tracker& tracker, std::unique_ptr<TCanvas> &YZCanvas, std::unique_ptr<TCanvas> &YZCanvasBarrel, std::unique_ptr<TCanvas> &XYCanvas, std::vector<std::unique_ptr<TCanvas> > &XYCanvasEC);
 
     // OT CABLING
-    void createOuterCablingPlotsBundles(const Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas, 
-					       std::vector<TCanvas*> &XYPosBundlesDisks, std::vector<TCanvas*> &XYPosBundlesDiskSurfaces,
-					       std::vector<TCanvas*> &XYNegBundlesDisks, std::vector<TCanvas*> &XYNegBundlesDiskSurfaces);
-    void createOuterCablingPlotsDTCs(Tracker& tracker, TCanvas *&YZCanvas, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, 
-					    TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
-    void createOuterCablingPlotsServicesChannelsOptical(Tracker& tracker, const OuterCablingMap* myCablingMap, TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, std::vector<TCanvas*> &XYCanvasEC);
+    void createOuterCablingPlotsBundles(const Tracker& tracker, std::unique_ptr<TCanvas> &YZCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYNegCanvas, 
+					       std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDisks, std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDiskSurfaces,
+					       std::vector<std::unique_ptr<TCanvas> > &XYNegBundlesDisks, std::vector<std::unique_ptr<TCanvas> > &XYNegBundlesDiskSurfaces);
+    void createOuterCablingPlotsDTCs(Tracker& tracker, std::unique_ptr<TCanvas> &YZCanvas, std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYNegFlatCanvas, 
+					    std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYFlatCanvas, std::vector<std::unique_ptr<TCanvas> > &XYCanvasEC);
+    void createOuterCablingPlotsServicesChannelsOptical(Tracker& tracker, const OuterCablingMap* myCablingMap, std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYNegFlatCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYFlatCanvas, std::vector<std::unique_ptr<TCanvas> > &XYCanvasEC);
     void createOuterCablingPlotsServicesChannelsPower(Tracker& tracker, const OuterCablingMap* myCablingMap,
-						     TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
-						     std::vector<TCanvas*> &XYCanvasesDisk, std::vector<TCanvas*> &XYNegCanvasesDisk);
+						     std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYNegFlatCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYFlatCanvas, 
+						     std::vector<std::unique_ptr<TCanvas> > &XYCanvasesDisk, std::vector<std::unique_ptr<TCanvas> > &XYNegCanvasesDisk);
     RootWTable* opticalServicesChannels(const OuterCablingMap* myCablingMap, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
     void analyzeOpticalServicesChannels(const OuterCablingMap* myCablingMap, std::map<int, std::vector<int> > &cablesPerChannel, std::map<int, int> &psBundlesPerChannel, std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
     RootWTable* createOpticalServicesChannelTable(const std::map<int, std::vector<int> > &cablesPerChannel, const std::map<int, int> &psBundlesPerChannel, const std::map<int, int> &ssBundlesPerChannel, const bool isPositiveCablingSide, const ChannelSlot requestedSlot = ChannelSlot::UNKNOWN);
@@ -205,19 +205,19 @@ namespace insur {
 
     // IT CABLING
     void createInnerCablingPlotsPowerChains(const Tracker& tracker, 
-						   std::vector<TCanvas*> &ZPhiLayerPlots,
-						   TCanvas *&XYNegCanvas, TCanvas *&XYCentralCanvas, TCanvas *&XYCanvas,
-						   std::vector<TCanvas*> &XYPosPowerChainsDiskSurfaces);
+						   std::vector<std::unique_ptr<TCanvas> > &ZPhiLayerPlots,
+						   std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYCentralCanvas, std::unique_ptr<TCanvas> &XYCanvas,
+						   std::vector<std::unique_ptr<TCanvas> > &XYPosPowerChainsDiskSurfaces);
     void createInnerCablingPlotsGBTs(const Tracker& tracker,
-						 std::vector<TCanvas*> &ZPhiLayerPlots,
-						 std::vector<TCanvas*> &XYPosGBTsDiskSurfaces);
+						 std::vector<std::unique_ptr<TCanvas> > &ZPhiLayerPlots,
+						 std::vector<std::unique_ptr<TCanvas> > &XYPosGBTsDiskSurfaces);
     void createInnerCablingPlotsBundles(const Tracker& tracker,
-						    TCanvas *&XYNegCanvas, TCanvas *&XYPosCanvas,
-						    std::vector<TCanvas*> &XYPosBundlesDisks);
+						    std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYPosCanvas,
+						    std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDisks);
     void createInnerCablingPlotsDTCs(const Tracker& tracker,
-						 TCanvas *&RZCanvas,
-						 TCanvas *&XYPosCanvas,
-						 std::vector<TCanvas*> &XYPosDTCsDisks);
+						 std::unique_ptr<TCanvas> &RZCanvas,
+						 std::unique_ptr<TCanvas> &XYPosCanvas,
+						 std::vector<std::unique_ptr<TCanvas> > &XYPosDTCsDisks);
     void computeInnerCablingCount(const InnerCablingMap* myInnerCablingMap,
 				  int& numSensorsOneXSide, int& numSensorsPlusXSidePlusZEnd, int& numSensorsPlusXSideMinusZEnd,
 				  int& numPowerChainsOneXSide, int& numPowerChainsPlusXSidePlusZEnd, int& numPowerChainsPlusXSideMinusZEnd,
@@ -302,9 +302,9 @@ namespace insur {
     // int getNiceColor(unsigned int plotIndex);
     std::vector<Tracker*> trackers_;
     std::vector<MaterialBudget*> materialBudgets_;
-    TCanvas* drawFullLayoutRZ();
-    TCanvas* drawFullLayoutServicesRZ();
-    TCanvas* drawFullLayoutBarrelXY();
+    std::unique_ptr<TCanvas> drawFullLayoutRZ();
+    std::unique_ptr<TCanvas> drawFullLayoutServicesRZ();
+    std::unique_ptr<TCanvas> drawFullLayoutBarrelXY();
 
     void plotAndPrintVolumeMaterials(WeightsPerSubdetector& totalWeights, std::stringstream& allVolumesStream, std::stringstream& modulesStream, 
 				     const std::map<LocalElement, double, ElementNameCompare>& allMasses, 

--- a/src/ReportIrradiation.cc
+++ b/src/ReportIrradiation.cc
@@ -155,15 +155,15 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
 
   RootWContent& myContent = myPage.addContent("Power maps", true);
 
-  TCanvas sensorsIrradiationPowerCanvas;
-  TCanvas totalPowerCanvas;
+  TCanvas* sensorsIrradiationPowerCanvas = new TCanvas();
+  TCanvas* totalPowerCanvas = new TCanvas();
 
-  yzSensorsPowerDrawer.drawFrame<HistogramFrameStyle>(sensorsIrradiationPowerCanvas);
-  yzSensorsPowerDrawer.drawModules<ContourStyle>(sensorsIrradiationPowerCanvas);
+  yzSensorsPowerDrawer.drawFrame<HistogramFrameStyle>(*sensorsIrradiationPowerCanvas);
+  yzSensorsPowerDrawer.drawModules<ContourStyle>(*sensorsIrradiationPowerCanvas);
 
 
-  yzTotalPowerDrawer.drawFrame<HistogramFrameStyle>(totalPowerCanvas);
-  yzTotalPowerDrawer.drawModules<ContourStyle>(totalPowerCanvas);
+  yzTotalPowerDrawer.drawFrame<HistogramFrameStyle>(*totalPowerCanvas);
+  yzTotalPowerDrawer.drawModules<ContourStyle>(*totalPowerCanvas);
 
   RootWImage& sensorsIrradiationPowerImage = myContent.addImage(sensorsIrradiationPowerCanvas, insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
   sensorsIrradiationPowerImage.setComment("Power dissipation in irradiated sensors (due to leakage current) (average per module) (W)");

--- a/src/ReportIrradiation.cc
+++ b/src/ReportIrradiation.cc
@@ -155,20 +155,20 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
 
   RootWContent& myContent = myPage.addContent("Power maps", true);
 
-  TCanvas* sensorsIrradiationPowerCanvas = new TCanvas();
-  TCanvas* totalPowerCanvas = new TCanvas();
+  std::unique_ptr<TCanvas> sensorsIrradiationPowerCanvas(new TCanvas());
+  std::unique_ptr<TCanvas> totalPowerCanvas(new TCanvas());
 
-  yzSensorsPowerDrawer.drawFrame<HistogramFrameStyle>(*sensorsIrradiationPowerCanvas);
-  yzSensorsPowerDrawer.drawModules<ContourStyle>(*sensorsIrradiationPowerCanvas);
+  yzSensorsPowerDrawer.drawFrame<HistogramFrameStyle>(*sensorsIrradiationPowerCanvas.get());
+  yzSensorsPowerDrawer.drawModules<ContourStyle>(*sensorsIrradiationPowerCanvas.get());
 
 
-  yzTotalPowerDrawer.drawFrame<HistogramFrameStyle>(*totalPowerCanvas);
-  yzTotalPowerDrawer.drawModules<ContourStyle>(*totalPowerCanvas);
+  yzTotalPowerDrawer.drawFrame<HistogramFrameStyle>(*totalPowerCanvas.get());
+  yzTotalPowerDrawer.drawModules<ContourStyle>(*totalPowerCanvas.get());
 
-  RootWImage& sensorsIrradiationPowerImage = myContent.addImage(sensorsIrradiationPowerCanvas, insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  RootWImage& sensorsIrradiationPowerImage = myContent.addImage(std::move(sensorsIrradiationPowerCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
   sensorsIrradiationPowerImage.setComment("Power dissipation in irradiated sensors (due to leakage current) (average per module) (W)");
   sensorsIrradiationPowerImage.setName("sensorsIrradiationPowerMap");
-  RootWImage& totalPowerImage = myContent.addImage(totalPowerCanvas, insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  RootWImage& totalPowerImage = myContent.addImage(std::move(totalPowerCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
   totalPowerImage.setComment("Total power dissipation in irradiated modules (W)");
   totalPowerImage.setName("totalPowerMap");
   

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -212,7 +212,7 @@ pair<int, int> RootWTable::newLine() {
 
 RootWImage::RootWImage() {
   imageCounter_++;
-  myCanvas_ = NULL;
+  myCanvas_ = nullptr;
   zoomedWidth_ = 0; zoomedHeight_ = 0;
   relativeHtmlDirectory_ = "";
   targetDirectory_ = "";
@@ -224,7 +224,7 @@ RootWImage::RootWImage() {
 
 RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height) {
   imageCounter_++;
-  myCanvas_ = NULL;
+  myCanvas_ = nullptr;
   setCanvas(myCanvas);
   setZoomedSize(witdh, height);
   relativeHtmlDirectory_ = "";
@@ -237,7 +237,7 @@ RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height) {
 
 RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height, string relativehtmlDirectory) {
   imageCounter_++;
-  myCanvas_ = NULL;
+  myCanvas_ = nullptr;
   setCanvas(myCanvas);
   setZoomedSize(witdh, height);
   setRelativeHtmlDirectory(relativehtmlDirectory);
@@ -250,7 +250,7 @@ RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height, string relative
 
 RootWImage::RootWImage(TCanvas& myCanvas, int witdh, int height) {
   imageCounter_++;
-  myCanvas_ = NULL;
+  myCanvas_ = nullptr;
   setCanvas(myCanvas);
   setZoomedSize(witdh, height);
   relativeHtmlDirectory_ = "";
@@ -263,7 +263,7 @@ RootWImage::RootWImage(TCanvas& myCanvas, int witdh, int height) {
 
 RootWImage::RootWImage(TCanvas& myCanvas, int witdh, int height, string relativehtmlDirectory) {
   imageCounter_++;
-  myCanvas_ = NULL;
+  myCanvas_ = nullptr;
   setCanvas(myCanvas);
   setZoomedSize(witdh, height);
   setRelativeHtmlDirectory(relativehtmlDirectory);
@@ -272,10 +272,6 @@ RootWImage::RootWImage(TCanvas& myCanvas, int witdh, int height, string relative
   name_ = "img";
   allowedExtensions_ = DEFAULTALLOWEDEXTENSIONS;
   setDefaultExtensions();
-}
-
-RootWImage::~RootWImage() {
-  if (myCanvas_) delete myCanvas_;
 }
 
 void RootWImage::setDefaultExtensions() {
@@ -297,8 +293,9 @@ std::string RootWImage::getName() {
 }
 
 void RootWImage::setCanvas(TCanvas* myCanvas) {
-  if (myCanvas_) delete myCanvas_;
-  myCanvas_ = (TCanvas*)myCanvas->DrawClone();
+  //if (myCanvas_) delete myCanvas_;
+  myCanvas_.reset(myCanvas);
+  //myCanvas_ = (TCanvas*)myCanvas->DrawClone();
   std::ostringstream canvasName("");
   canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
   myCanvas_->SetName(canvasName.str().c_str());
@@ -439,7 +436,7 @@ bool RootWImage::addExtension(string myExtension) {
 void RootWImage::saveSummary(std::string baseName, TFile* myTargetFile) {
   if (!myCanvas_) return;
   baseName += name_;
-  saveSummaryLoop(myCanvas_, baseName, myTargetFile);
+  saveSummaryLoop(myCanvas_.get(), baseName, myTargetFile);
 }
 
 void RootWImage::saveSummaryLoop(TPad* basePad, std::string baseName, TFile* myTargetFile) {
@@ -686,7 +683,9 @@ ostream& RootWContent::dump(ostream& output) {
       if ( (myImage=dynamic_cast<RootWImage*>(myItem)) ) {
         myImage->setTargetDirectory(targetDirectory_);
 	if (summaryFile) myImage->saveSummary(baseName, summaryFile);
+	std::cout << "zoom a " << std::endl;
         myImage->saveFiles(THUMBSMALLSIZE, THUMBSMALLSIZE);
+	std::cout << "zoom b " << std::endl;
       } else {
         cout << "WARNING: this should never happen. contact the author immediately!" << endl;
       }

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -222,19 +222,6 @@ RootWImage::RootWImage() {
   setDefaultExtensions();
 }
 
-RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height) {
-  imageCounter_++;
-  myCanvas_ = nullptr;
-  setCanvas(myCanvas);
-  setZoomedSize(witdh, height);
-  relativeHtmlDirectory_ = "";
-  targetDirectory_ = "";
-  comment_ = "";
-  name_ = "img";
-  allowedExtensions_ = DEFAULTALLOWEDEXTENSIONS;
-  setDefaultExtensions();
-}
-
 RootWImage::RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height) {
   imageCounter_++;
   myCanvas_ = nullptr;
@@ -248,10 +235,10 @@ RootWImage::RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height)
   setDefaultExtensions();
 }
 
-RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height, string relativehtmlDirectory) {
+RootWImage::RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height, string relativehtmlDirectory) {
   imageCounter_++;
   myCanvas_ = nullptr;
-  setCanvas(myCanvas);
+  setCanvas(std::move(myCanvas));
   setZoomedSize(witdh, height);
   setRelativeHtmlDirectory(relativehtmlDirectory);
   targetDirectory_ = "";
@@ -279,44 +266,11 @@ std::string RootWImage::getName() {
   return name_ ;
 }
 
-void RootWImage::setCanvas(TCanvas* myCanvas) {
-  myCanvas_.reset(myCanvas);
-  std::ostringstream canvasName("");
-  canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
-  myCanvas_->SetName(canvasName.str().c_str());
-  /*TView* myView = myCanvas->GetView();
-  if (myView) {
-    TView* newView = myCanvas_->GetView();
-    if (newView) {
-      double min[3], max[3];
-      Int_t irep;
-      newView->SetView(myView->GetLongitude(),
-		       myView->GetLatitude(),
-		       myView->GetPsi(), irep);
-      myView->GetRange(min, max);
-      newView->SetRange(min, max);
-    }
-    }*/
-}
-
 void RootWImage::setCanvas(std::unique_ptr<TCanvas> myCanvas) {
   myCanvas_.reset(myCanvas.release());
   std::ostringstream canvasName("");
   canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
   myCanvas_->SetName(canvasName.str().c_str());
-  /*TView* myView = myCanvas->GetView();
-  if (myView) {
-    TView* newView = myCanvas_->GetView();
-    if (newView) {
-      double min[3], max[3];
-      Int_t irep;
-      newView->SetView(myView->GetLongitude(),
-		       myView->GetLatitude(),
-		       myView->GetPsi(), irep);
-      myView->GetRange(min, max);
-      newView->SetRange(min, max);
-    }
-    }*/
 }
 
 void RootWImage::setZoomedSize(int witdh, int height) {
@@ -595,20 +549,14 @@ RootWImage& RootWContent::addImage() {
   return (*newImage);
 }
 
-RootWImage& RootWContent::addImage(TCanvas* myCanvas, int witdh, int height) {
-  RootWImage* newImage = new RootWImage(myCanvas, witdh, height);
-  addItem(newImage);
-  return (*newImage);
-}
-
 RootWImage& RootWContent::addImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height) {
   RootWImage* newImage = new RootWImage(std::move(myCanvas), witdh, height);
   addItem(newImage);
   return (*newImage);
 }
 
-RootWImage& RootWContent::addImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory) {
-  RootWImage* newImage = new RootWImage(myCanvas, witdh, height, relativeHtmlDirectory);
+RootWImage& RootWContent::addImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height, string relativeHtmlDirectory) {
+  RootWImage* newImage = new RootWImage(std::move(myCanvas), witdh, height, relativeHtmlDirectory);
   addItem(newImage);
   return (*newImage);
 }

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -235,6 +235,19 @@ RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height) {
   setDefaultExtensions();
 }
 
+RootWImage::RootWImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height) {
+  imageCounter_++;
+  myCanvas_ = nullptr;
+  setCanvas(std::move(myCanvas));
+  setZoomedSize(witdh, height);
+  relativeHtmlDirectory_ = "";
+  targetDirectory_ = "";
+  comment_ = "";
+  name_ = "img";
+  allowedExtensions_ = DEFAULTALLOWEDEXTENSIONS;
+  setDefaultExtensions();
+}
+
 RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height, string relativehtmlDirectory) {
   imageCounter_++;
   myCanvas_ = nullptr;
@@ -271,7 +284,7 @@ void RootWImage::setCanvas(TCanvas* myCanvas) {
   std::ostringstream canvasName("");
   canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
   myCanvas_->SetName(canvasName.str().c_str());
-  TView* myView = myCanvas->GetView();
+  /*TView* myView = myCanvas->GetView();
   if (myView) {
     TView* newView = myCanvas_->GetView();
     if (newView) {
@@ -283,11 +296,27 @@ void RootWImage::setCanvas(TCanvas* myCanvas) {
       myView->GetRange(min, max);
       newView->SetRange(min, max);
     }
-  }
+    }*/
 }
 
-void RootWImage::setCanvas(TCanvas& myCanvas) {
-  setCanvas(&myCanvas);
+void RootWImage::setCanvas(std::unique_ptr<TCanvas> myCanvas) {
+  myCanvas_.reset(myCanvas.release());
+  std::ostringstream canvasName("");
+  canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
+  myCanvas_->SetName(canvasName.str().c_str());
+  /*TView* myView = myCanvas->GetView();
+  if (myView) {
+    TView* newView = myCanvas_->GetView();
+    if (newView) {
+      double min[3], max[3];
+      Int_t irep;
+      newView->SetView(myView->GetLongitude(),
+		       myView->GetLatitude(),
+		       myView->GetPsi(), irep);
+      myView->GetRange(min, max);
+      newView->SetRange(min, max);
+    }
+    }*/
 }
 
 void RootWImage::setZoomedSize(int witdh, int height) {
@@ -568,6 +597,12 @@ RootWImage& RootWContent::addImage() {
 
 RootWImage& RootWContent::addImage(TCanvas* myCanvas, int witdh, int height) {
   RootWImage* newImage = new RootWImage(myCanvas, witdh, height);
+  addItem(newImage);
+  return (*newImage);
+}
+
+RootWImage& RootWContent::addImage(std::unique_ptr<TCanvas> myCanvas, int witdh, int height) {
+  RootWImage* newImage = new RootWImage(std::move(myCanvas), witdh, height);
   addItem(newImage);
   return (*newImage);
 }

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -293,9 +293,7 @@ std::string RootWImage::getName() {
 }
 
 void RootWImage::setCanvas(TCanvas* myCanvas) {
-  //if (myCanvas_) delete myCanvas_;
   myCanvas_.reset(myCanvas);
-  //myCanvas_ = (TCanvas*)myCanvas->DrawClone();
   std::ostringstream canvasName("");
   canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
   myCanvas_->SetName(canvasName.str().c_str());
@@ -683,9 +681,7 @@ ostream& RootWContent::dump(ostream& output) {
       if ( (myImage=dynamic_cast<RootWImage*>(myItem)) ) {
         myImage->setTargetDirectory(targetDirectory_);
 	if (summaryFile) myImage->saveSummary(baseName, summaryFile);
-	std::cout << "zoom a " << std::endl;
         myImage->saveFiles(THUMBSMALLSIZE, THUMBSMALLSIZE);
-	std::cout << "zoom b " << std::endl;
       } else {
         cout << "WARNING: this should never happen. contact the author immediately!" << endl;
       }

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -267,7 +267,7 @@ std::string RootWImage::getName() {
 }
 
 void RootWImage::setCanvas(std::unique_ptr<TCanvas> myCanvas) {
-  myCanvas_.reset(myCanvas.release());
+  myCanvas_.reset(myCanvas.release()); // KEY POINT: instead of using TCanvas::DrawClone(), just transfer TCanvas object ownership from Vizard to RootWeb!
   std::ostringstream canvasName("");
   canvasName << "canvas" << setfill('0') << setw(3) << imageCounter_;
   myCanvas_->SetName(canvasName.str().c_str());
@@ -1015,9 +1015,9 @@ bool RootWSite::makeSite(bool verbose) {
 
   vector<RootWPage*>::iterator it;
   if (createSummaryFile_) {
-    summaryFile_ = new TFile(Form("%s/%s",
+    summaryFile_.reset(new TFile(Form("%s/%s",
 				  targetDirectory_.c_str(),
-				  summaryFileName_.c_str()), "RECREATE");
+				      summaryFileName_.c_str()), "RECREATE"));
   } else summaryFile_ = nullptr;
   for (it=pageList_.begin(); it!=pageList_.end(); it++) {
     myPage = (*it);
@@ -1041,7 +1041,7 @@ bool RootWSite::makeSite(bool verbose) {
 }
 
 TFile* RootWSite::getSummaryFile() {
-  return summaryFile_;
+  return summaryFile_.get();
 }
 
 void RootWSite::setSummaryFile(bool doSummary) {

--- a/src/RootWeb.cc
+++ b/src/RootWeb.cc
@@ -248,32 +248,6 @@ RootWImage::RootWImage(TCanvas* myCanvas, int witdh, int height, string relative
   setDefaultExtensions();
 }
 
-RootWImage::RootWImage(TCanvas& myCanvas, int witdh, int height) {
-  imageCounter_++;
-  myCanvas_ = nullptr;
-  setCanvas(myCanvas);
-  setZoomedSize(witdh, height);
-  relativeHtmlDirectory_ = "";
-  targetDirectory_ = "";
-  comment_ = "";
-  name_ = "img";
-  allowedExtensions_ = DEFAULTALLOWEDEXTENSIONS;
-  setDefaultExtensions();
-}
-
-RootWImage::RootWImage(TCanvas& myCanvas, int witdh, int height, string relativehtmlDirectory) {
-  imageCounter_++;
-  myCanvas_ = nullptr;
-  setCanvas(myCanvas);
-  setZoomedSize(witdh, height);
-  setRelativeHtmlDirectory(relativehtmlDirectory);
-  targetDirectory_ = "";
-  comment_ = "";
-  name_ = "img";
-  allowedExtensions_ = DEFAULTALLOWEDEXTENSIONS;
-  setDefaultExtensions();
-}
-
 void RootWImage::setDefaultExtensions() {
    //addExtension("C");
    addExtension("pdf");
@@ -599,18 +573,6 @@ RootWImage& RootWContent::addImage(TCanvas* myCanvas, int witdh, int height) {
 }
 
 RootWImage& RootWContent::addImage(TCanvas* myCanvas, int witdh, int height, string relativeHtmlDirectory) {
-  RootWImage* newImage = new RootWImage(myCanvas, witdh, height, relativeHtmlDirectory);
-  addItem(newImage);
-  return (*newImage);
-}
-
-RootWImage& RootWContent::addImage(TCanvas& myCanvas, int witdh, int height) {
-  RootWImage* newImage = new RootWImage(myCanvas, witdh, height);
-  addItem(newImage);
-  return (*newImage);
-}
-
-RootWImage& RootWContent::addImage(TCanvas& myCanvas, int witdh, int height, string relativeHtmlDirectory) {
   RootWImage* newImage = new RootWImage(myCanvas, witdh, height, relativeHtmlDirectory);
   addItem(newImage);
   return (*newImage);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -70,6 +70,9 @@ namespace insur {
     Int_t colorIndex = TColor::CreateGradientColorTable(numberOfSteps, stops, red, green, blue, vis_temperature_levels);
     for (int i=0;i<vis_temperature_levels;i++) myPalette[i] = colorIndex+i;
     gStyle->SetPalette(vis_temperature_levels, myPalette);
+
+    gStyle->SetTitleX(0.54);
+    gStyle->SetTitleW(1);
   }
 
   /**
@@ -569,6 +572,7 @@ namespace insur {
     //crProf->Rebin(10);
     crProf->SetTitle("Radiation Length Over Full Tracker Volume; #eta; x/X_{0}");
     crProf->SetFillColor(kGray + 2);
+    crProf->SetLineColor(kBlue);
     crProf->Draw("hist");
     myPad = myCanvas->GetPad(2);
     myPad->cd();
@@ -577,6 +581,7 @@ namespace insur {
     ciProf = newProfile(ci, 0., a.getEtaMaxMaterial(), materialNBins);
     ciProf->SetTitle("Interaction Length Over Full Tracker Volume; #eta; #lambda/#lambda_{0}");
     ciProf->SetFillColor(kGray + 2);
+    ciProf->SetLineColor(kBlue);
     ciProf->Draw("hist");
 
     // Put the full volume materials plots to the site
@@ -949,6 +954,7 @@ namespace insur {
       rTrackingVolume = (TH1D*)rCompTrackingVolumeStack->GetStack()->Last()->Clone();
       rTrackingVolumeProf = newProfile(rTrackingVolume, 0., a.getEtaMaxMaterial(), materialNBins);
       rTrackingVolumeProf->SetFillColor(kGray + 2);
+      rTrackingVolumeProf->SetLineColor(kBlue);
       rTrackingVolumeProf->SetTitle("Radiation Length within Tracking Volume; #eta; x/X_{0}");
       rTrackingVolumeProf->Draw("hist");
     }
@@ -959,6 +965,7 @@ namespace insur {
       iTrackingVolume = (TH1D*)iCompTrackingVolumeStack->GetStack()->Last()->Clone();
       iTrackingVolumeProf = newProfile(iTrackingVolume, 0., a.getEtaMaxMaterial(), materialNBins);
       iTrackingVolumeProf->SetFillColor(kGray + 2);
+      iTrackingVolumeProf->SetLineColor(kBlue);
       iTrackingVolumeProf->SetTitle("Interaction Length within Tracking Volume; #eta; #lambda/#lambda_{0}");
       iTrackingVolumeProf->Draw("hist");
     }
@@ -3987,18 +3994,20 @@ namespace insur {
     yzDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEtaCanvas.get());
     xyDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionPhiCanvas.get());
     std::pair<Circle, Circle> petal = analyzer.getSampleTriggerPetal();
-    TArc a1(petal.first.x0, petal.first.y0, petal.first.r, (XYPoint(petal.first.x0, petal.first.y0)).Phi()*180./M_PI + 180.);
-    TArc a2(petal.second.x0, petal.second.y0, petal.second.r, 0., (XYPoint(petal.second.x0, petal.second.y0)).Phi()*180./M_PI + 180.);
-    a1.SetFillStyle(0);
-    a2.SetFillStyle(0);
+    TArc* a1 = new TArc(petal.first.x0, petal.first.y0, petal.first.r, (XYPoint(petal.first.x0, petal.first.y0)).Phi()*180./M_PI + 180.);
+    TArc* a2 = new TArc(petal.second.x0, petal.second.y0, petal.second.r, 0., (XYPoint(petal.second.x0, petal.second.y0)).Phi()*180./M_PI + 180.);
+    a1->SetFillStyle(0);
+    a2->SetFillStyle(0);
     moduleConnectionPhiCanvas->cd();
-    a1.Draw("only");
-    a2.Draw("only");
+    a1->Draw("only");
+    a2->Draw("only");
 
     xyecDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEndcapPhiCanvas.get());
     moduleConnectionEndcapPhiCanvas->cd();
-    a1.Draw("only");
-    a2.Draw("only");
+    a1->Draw("only");
+    a2->Draw("only");
+    a1->SetBit(1);
+    a2->SetBit(1);
 
     yzDrawer.drawModules<ContourStyle>(*moduleConnectionEtaCanvas.get());
     xyDrawer.drawModules<ContourStyle>(*moduleConnectionPhiCanvas.get());

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -71,8 +71,9 @@ namespace insur {
     for (int i=0;i<vis_temperature_levels;i++) myPalette[i] = colorIndex+i;
     gStyle->SetPalette(vis_temperature_levels, myPalette);
 
-    gStyle->SetTitleX(0.54);
-    gStyle->SetTitleW(1);
+    // Each title centered and specified width
+    gStyle->SetTitleX(0.5);
+    gStyle->SetTitleW(1.);
   }
 
   /**
@@ -1109,6 +1110,7 @@ namespace insur {
     mapRad->SetContour(vis_temperature_levels, nullptr);
     mapRad->GetZaxis()->SetLabelSize(0.02);  // palette font size
     //myCanvas->SetLogz();
+    mapRad->SetStats(0);
     mapRad->Draw("COLZ");
     myImage = new RootWImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation length material map");
@@ -1122,6 +1124,7 @@ namespace insur {
     mapInt = (TH2D*)a.getHistoMapInteraction().Clone();
     mapInt->SetContour(vis_temperature_levels, nullptr);
     mapInt->GetZaxis()->SetLabelSize(0.02); // palette font size
+    mapInt->SetStats(0);
     mapInt->Draw("COLZ");
     myImage = new RootWImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Interaction length material map");
@@ -2706,8 +2709,6 @@ namespace insur {
 	myTable->setContent(3, 1, " ");
 	myTable->setContent(4, 1, " ");
 
-	gStyle->SetTitleX(0.54);
-	gStyle->SetTitleW(1);
 	gStyle->SetOptStat("emr");
 	if (parametrizedResolutionLocalXBarrelMap[tag].GetEntries() != 0) {
 	  std::unique_ptr<TCanvas> resoXBarCanvas(new TCanvas());
@@ -3634,6 +3635,7 @@ namespace insur {
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerStyle(8);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerSize(1);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMinimum(0.);
+    ((TH1D*)totalEtaStack->GetStack()->Last())->SetStats(0.);
     totalEtaStack->GetStack()->Last()->Draw();
     // add profile for types here...#####
     drawEtaProfilesSensors(*totalEtaProfileFull, analyzer, false);
@@ -5523,7 +5525,6 @@ namespace insur {
 
     // For each momentum/transverse momentum compute
     int iMomentum = 0;
-    gStyle->SetTitleW(0.9);
     TLegend* legendPtInOut = new TLegend(0.11,0.66,0.36,0.89,"p_{T} options (InOut+IP, full TRK):");
     legendPtInOut->SetTextSize(0.025);
 
@@ -5559,7 +5560,6 @@ namespace insur {
 
     // For each momentum/transverse momentum compute
     iMomentum = 0;
-    gStyle->SetTitleW(0.9);
     TLegend* legendPtOutIn = new TLegend(0.11,0.66,0.36,0.89,"p_{T} options (OutIn, full TRK):");
     legendPtOutIn->SetTextSize(0.025);
 
@@ -5859,7 +5859,6 @@ namespace insur {
 
     // For each momentum/transverse momentum compute
     iMomentum = 0;
-    gStyle->SetTitleW(0.9);
     TLegend* legendPInOut = new TLegend(0.11,0.66,0.36,0.89,"p options (InOut+IP, full TRK):");
     legendPInOut->SetTextSize(0.025);
 
@@ -5895,7 +5894,6 @@ namespace insur {
 
     // For each momentum/transverse momentum compute
     iMomentum = 0;
-    gStyle->SetTitleW(0.9);
     TLegend* legendPOutIn = new TLegend(0.11,0.66,0.36,0.89,"p options (OutIn, full TRK):");
     legendPOutIn->SetTextSize(0.025);
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2683,28 +2683,28 @@ namespace insur {
 	gStyle->SetTitleW(1);
 	gStyle->SetOptStat("emr");
 	if (parametrizedResolutionLocalXBarrelMap[tag].GetEntries() != 0) {
-	  TCanvas resoXBarCanvas;
-	  resoXBarCanvas.SetFillColor(color_plot_background);
-	  resoXBarCanvas.Divide(2,2);
+	  TCanvas* resoXBarCanvas = new TCanvas();
+	  resoXBarCanvas->SetFillColor(color_plot_background);
+	  resoXBarCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
-	  myPad = resoXBarCanvas.GetPad(0);
+	  myPad = resoXBarCanvas->GetPad(0);
 	  myPad->SetFillColor(color_pad_background);
-	  myPad = resoXBarCanvas.GetPad(1);
+	  myPad = resoXBarCanvas->GetPad(1);
 	  myPad->cd();
 	  parametrizedResolutionLocalXBarrelMap[tag].Draw();
-	  myPad = resoXBarCanvas.GetPad(2);
+	  myPad = resoXBarCanvas->GetPad(2);
 	  myPad->cd();
 	  parametrizedResolutionLocalXBarrelDistribution[tag].SetStats(1);
 	  const double normA = 1. / parametrizedResolutionLocalXBarrelDistribution[tag].Integral();
 	  parametrizedResolutionLocalXBarrelDistribution[tag].Scale(normA, "width");
 	  parametrizedResolutionLocalXBarrelDistribution[tag].Draw();
-	  myPad = resoXBarCanvas.GetPad(3);
+	  myPad = resoXBarCanvas->GetPad(3);
 	  myPad->cd();
 	  incidentAngleLocalXBarrelDistribution[tag].SetStats(1);
 	  const double normB = 1. / incidentAngleLocalXBarrelDistribution[tag].Integral();
 	  incidentAngleLocalXBarrelDistribution[tag].Scale(normB, "width");
 	  incidentAngleLocalXBarrelDistribution[tag].Draw();
-	  myPad = resoXBarCanvas.GetPad(4);
+	  myPad = resoXBarCanvas->GetPad(4);
 	  myPad->cd();
 	  trackPhiBarrelDistribution[tag].SetStats(1);
 	  const double normC = 1. / trackPhiBarrelDistribution[tag].Integral();
@@ -2715,28 +2715,28 @@ namespace insur {
 	  resoXBarImage.setName(Form("Resolution on local X coordinate for %s barrel modules", tag.c_str()));
 	}
 	if (parametrizedResolutionLocalYBarrelMap[tag].GetEntries() != 0) {
-	  TCanvas resoYBarCanvas;
-	  resoYBarCanvas.SetFillColor(color_plot_background);
-	  resoYBarCanvas.Divide(2,2);
+	  TCanvas* resoYBarCanvas = new TCanvas();
+	  resoYBarCanvas->SetFillColor(color_plot_background);
+	  resoYBarCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
-	  myPad = resoYBarCanvas.GetPad(0);
+	  myPad = resoYBarCanvas->GetPad(0);
 	  myPad->SetFillColor(color_pad_background);
-	  myPad = resoYBarCanvas.GetPad(1);
+	  myPad = resoYBarCanvas->GetPad(1);
 	  myPad->cd();
 	  parametrizedResolutionLocalYBarrelMap[tag].Draw();
-	  myPad = resoYBarCanvas.GetPad(2);
+	  myPad = resoYBarCanvas->GetPad(2);
 	  myPad->cd();
 	  parametrizedResolutionLocalYBarrelDistribution[tag].SetStats(1);
 	  const double normA = 1. / parametrizedResolutionLocalYBarrelDistribution[tag].Integral();
 	  parametrizedResolutionLocalYBarrelDistribution[tag].Scale(normA, "width");
 	  parametrizedResolutionLocalYBarrelDistribution[tag].Draw();
-	  myPad = resoYBarCanvas.GetPad(3);
+	  myPad = resoYBarCanvas->GetPad(3);
 	  myPad->cd();
 	  incidentAngleLocalYBarrelDistribution[tag].SetStats(1);
 	  const double normB = 1. / incidentAngleLocalYBarrelDistribution[tag].Integral();
 	  incidentAngleLocalYBarrelDistribution[tag].Scale(normB, "width");
 	  incidentAngleLocalYBarrelDistribution[tag].Draw();
-	  myPad = resoYBarCanvas.GetPad(4);
+	  myPad = resoYBarCanvas->GetPad(4);
 	  myPad->cd();
 	  trackEtaBarrelDistribution[tag].SetStats(1);
 	  const double normC = 1. / trackEtaBarrelDistribution[tag].Integral();
@@ -2747,28 +2747,28 @@ namespace insur {
 	  resoYBarImage.setName(Form("Resolution on local Y coordinate for %s barrel modules", tag.c_str()));
 	}
 	if (parametrizedResolutionLocalXEndcapsMap[tag].GetEntries() != 0) {
-	  TCanvas resoXEndCanvas;
-	  resoXEndCanvas.SetFillColor(color_plot_background);
-	  resoXEndCanvas.Divide(2,2);
+	  TCanvas* resoXEndCanvas = new TCanvas();
+	  resoXEndCanvas->SetFillColor(color_plot_background);
+	  resoXEndCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
-	  myPad = resoXEndCanvas.GetPad(0);
+	  myPad = resoXEndCanvas->GetPad(0);
 	  myPad->SetFillColor(color_pad_background);
-	  myPad = resoXEndCanvas.GetPad(1);
+	  myPad = resoXEndCanvas->GetPad(1);
 	  myPad->cd();
 	  parametrizedResolutionLocalXEndcapsMap[tag].Draw();
-	  myPad = resoXEndCanvas.GetPad(2);
+	  myPad = resoXEndCanvas->GetPad(2);
 	  myPad->cd();
 	  parametrizedResolutionLocalXEndcapsDistribution[tag].SetStats(1);
 	  const double normA = 1. / parametrizedResolutionLocalXEndcapsDistribution[tag].Integral();
 	  parametrizedResolutionLocalXEndcapsDistribution[tag].Scale(normA, "width");
 	  parametrizedResolutionLocalXEndcapsDistribution[tag].Draw();
-	  myPad = resoXEndCanvas.GetPad(3);
+	  myPad = resoXEndCanvas->GetPad(3);
 	  myPad->cd();
 	  incidentAngleLocalXEndcapsDistribution[tag].SetStats(1);
 	  const double normB = 1. / incidentAngleLocalXEndcapsDistribution[tag].Integral();
 	  incidentAngleLocalXEndcapsDistribution[tag].Scale(normB, "width");
 	  incidentAngleLocalXEndcapsDistribution[tag].Draw();
-	  myPad = resoXEndCanvas.GetPad(4);
+	  myPad = resoXEndCanvas->GetPad(4);
 	  myPad->cd();
 	  trackPhiEndcapsDistribution[tag].SetStats(1);
 	  const double normC = 1. / trackPhiEndcapsDistribution[tag].Integral();
@@ -2779,28 +2779,28 @@ namespace insur {
 	  resoXEndImage.setName(Form("Resolution on local X coordinate for %s endcaps modules", tag.c_str()));
 	}
 	if (parametrizedResolutionLocalYEndcapsMap[tag].GetEntries() != 0) {
-	  TCanvas resoYEndCanvas;
-	  resoYEndCanvas.SetFillColor(color_plot_background);
-	  resoYEndCanvas.Divide(2,2);
+	  TCanvas* resoYEndCanvas = new TCanvas();
+	  resoYEndCanvas->SetFillColor(color_plot_background);
+	  resoYEndCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
-	  myPad = resoYEndCanvas.GetPad(0);
+	  myPad = resoYEndCanvas->GetPad(0);
 	  myPad->SetFillColor(color_pad_background);
-	  myPad = resoYEndCanvas.GetPad(1);
+	  myPad = resoYEndCanvas->GetPad(1);
 	  myPad->cd();
 	  parametrizedResolutionLocalYEndcapsMap[tag].Draw();
-	  myPad = resoYEndCanvas.GetPad(2);
+	  myPad = resoYEndCanvas->GetPad(2);
 	  myPad->cd();
 	  parametrizedResolutionLocalYEndcapsDistribution[tag].SetStats(1);
 	  const double normA = 1. / parametrizedResolutionLocalYEndcapsDistribution[tag].Integral();
 	  parametrizedResolutionLocalYEndcapsDistribution[tag].Scale(normA, "width");
 	  parametrizedResolutionLocalYEndcapsDistribution[tag].Draw();
-	  myPad = resoYEndCanvas.GetPad(3);
+	  myPad = resoYEndCanvas->GetPad(3);
 	  myPad->cd();
 	  incidentAngleLocalYEndcapsDistribution[tag].SetStats(1);
 	  const double normB = 1. / incidentAngleLocalYEndcapsDistribution[tag].Integral();
 	  incidentAngleLocalYEndcapsDistribution[tag].Scale(normB, "width");
 	  incidentAngleLocalYEndcapsDistribution[tag].Draw();
-	  myPad = resoYEndCanvas.GetPad(4);
+	  myPad = resoYEndCanvas->GetPad(4);
 	  myPad->cd();
 	  trackEtaEndcapsDistribution[tag].SetStats(1);
 	  const double normC = 1. / trackEtaEndcapsDistribution[tag].Integral();
@@ -3820,8 +3820,8 @@ namespace insur {
 
     myContent = &myPage->addContent("Trigger bandwidth and frequency maps", true);
 
-    TCanvas triggerDataBandwidthCanvas;
-    TCanvas triggerFrequencyPerEventCanvas;
+    TCanvas* triggerDataBandwidthCanvas = new TCanvas();
+    TCanvas* triggerFrequencyPerEventCanvas = new TCanvas();
 
     PlotDrawer<YZ, Type, Max> yzbwDrawer(0, 0); // we take the MAX because the Analyzer only sweeps across the first quadrant (up to PI/2),
     PlotDrawer<YZ, Type, Max> yztfDrawer(0, 0); // so there's plenty modules in Phi which don't have their property set, but Max disregards all the 0's
@@ -3829,11 +3829,11 @@ namespace insur {
     yzbwDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL | ENDCAP);
     yztfDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL | ENDCAP);
 
-    yzbwDrawer.drawFrame<HistogramFrameStyle>(triggerDataBandwidthCanvas);
-    yztfDrawer.drawFrame<HistogramFrameStyle>(triggerFrequencyPerEventCanvas);
+    yzbwDrawer.drawFrame<HistogramFrameStyle>(*triggerDataBandwidthCanvas);
+    yztfDrawer.drawFrame<HistogramFrameStyle>(*triggerFrequencyPerEventCanvas);
 
-    yzbwDrawer.drawModules<ContourStyle>(triggerDataBandwidthCanvas);
-    yztfDrawer.drawModules<ContourStyle>(triggerFrequencyPerEventCanvas);
+    yzbwDrawer.drawModules<ContourStyle>(*triggerDataBandwidthCanvas);
+    yztfDrawer.drawModules<ContourStyle>(*triggerFrequencyPerEventCanvas);
 
     RootWImage& triggerDataBandwidthImage = myContent->addImage(triggerDataBandwidthCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     triggerDataBandwidthImage.setComment("Map of the bandwidth for trigger data in Gbps");
@@ -3858,8 +3858,8 @@ namespace insur {
         myContent = &myPage->addContent(std::string("Stub rate plots (") + layer.first + ")", false);
         currCntName = layer.first;
       }
-      TCanvas graphCanvas;
-      graphCanvas.cd();
+      TCanvas* graphCanvas = new TCanvas();
+      graphCanvas->cd();
       totalHisto->SetLineColor(1);
       totalHisto->SetMinimum(trueHisto->GetMinimum()*.9 < 0.1 ? 0 : trueHisto->GetMinimum()*.9);
       totalHisto->Draw();
@@ -3899,8 +3899,8 @@ namespace insur {
     
     myPage->addContent("Processor inbound connections").addTable().setContent(processorSummary.getContent());
     RootWContent& sharedConnContent = myPage->addContent("Processor shared inbound connections", false);
-    TCanvas sharedConnCanvas;
-    sharedConnCanvas.cd();
+    TCanvas* sharedConnCanvas = new TCanvas();
+    sharedConnCanvas->cd();
     TH2I& sharedConnMap = analyzer.getProcessorCommonConnectionMap();
     sharedConnMap.GetXaxis()->LabelsOption("v");
     sharedConnMap.GetXaxis()->SetLabelSize(0.03);
@@ -3924,9 +3924,9 @@ namespace insur {
 
     RootWContent& myContent = myPage->addContent("Module outbound connection maps", true);
 
-    TCanvas moduleConnectionEtaCanvas;
-    TCanvas moduleConnectionPhiCanvas;
-    TCanvas moduleConnectionEndcapPhiCanvas;
+    TCanvas* moduleConnectionEtaCanvas = new TCanvas();
+    TCanvas* moduleConnectionPhiCanvas = new TCanvas();
+    TCanvas* moduleConnectionEndcapPhiCanvas = new TCanvas();
 
     struct EtaConnections {
       const ModuleConnectionMap& mm_;
@@ -3947,48 +3947,48 @@ namespace insur {
     xyDrawer.addModules<CheckType<BARREL>>(tracker.modules().begin(), tracker.modules().end());
     xyecDrawer.addModules<CheckType<ENDCAP>>(tracker.modules().begin(), tracker.modules().end());
 
-    yzDrawer.drawFrame<HistogramFrameStyle>(moduleConnectionEtaCanvas);
-    xyDrawer.drawFrame<HistogramFrameStyle>(moduleConnectionPhiCanvas);
+    yzDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEtaCanvas);
+    xyDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionPhiCanvas);
     std::pair<Circle, Circle> petal = analyzer.getSampleTriggerPetal();
     TArc a1(petal.first.x0, petal.first.y0, petal.first.r, (XYPoint(petal.first.x0, petal.first.y0)).Phi()*180./M_PI + 180.);
     TArc a2(petal.second.x0, petal.second.y0, petal.second.r, 0., (XYPoint(petal.second.x0, petal.second.y0)).Phi()*180./M_PI + 180.);
     a1.SetFillStyle(0);
     a2.SetFillStyle(0);
-    moduleConnectionPhiCanvas.cd();
+    moduleConnectionPhiCanvas->cd();
     a1.Draw("only");
     a2.Draw("only");
 
-    xyecDrawer.drawFrame<HistogramFrameStyle>(moduleConnectionEndcapPhiCanvas);
-    moduleConnectionEndcapPhiCanvas.cd();
+    xyecDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEndcapPhiCanvas);
+    moduleConnectionEndcapPhiCanvas->cd();
     a1.Draw("only");
     a2.Draw("only");
 
-    yzDrawer.drawModules<ContourStyle>(moduleConnectionEtaCanvas);
-    xyDrawer.drawModules<ContourStyle>(moduleConnectionPhiCanvas);
-    xyecDrawer.drawModules<ContourStyle>(moduleConnectionEndcapPhiCanvas);
+    yzDrawer.drawModules<ContourStyle>(*moduleConnectionEtaCanvas);
+    xyDrawer.drawModules<ContourStyle>(*moduleConnectionPhiCanvas);
+    xyecDrawer.drawModules<ContourStyle>(*moduleConnectionEndcapPhiCanvas);
 
 
 
     /*
-       moduleConnectionEtaCanvas.SetFillColor(color_plot_background);
-       moduleConnectionPhiCanvas.SetFillColor(color_plot_background);
-    //moduleConnectionEndcapPhiCanvas.SetFillColor(color_plot_background);
+       moduleConnectionEtaCanvas->SetFillColor(color_plot_background);
+       moduleConnectionPhiCanvas->SetFillColor(color_plot_background);
+    //moduleConnectionEndcapPhiCanvas->SetFillColor(color_plot_background);
 
-    moduleConnectionEtaCanvas.cd();
+    moduleConnectionEtaCanvas->cd();
     moduleConnectionEtaMap.Draw("colz");
     */
     RootWImage& moduleConnectionEtaImage = myContent.addImage(moduleConnectionEtaCanvas, vis_max_canvas_sizeX, vis_min_canvas_sizeY);
     moduleConnectionEtaImage.setComment("Map of the number of connections to trigger processors per module (eta section)");
     moduleConnectionEtaImage.setName("moduleConnectionEtaMap");
     /*
-       moduleConnectionPhiCanvas.cd();
+       moduleConnectionPhiCanvas->cd();
        moduleConnectionPhiMap.Draw("colz");
        */
     RootWImage& moduleConnectionPhiImage = myContent.addImage(moduleConnectionPhiCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     moduleConnectionPhiImage.setComment("Map of the number of connections to trigger processors per barrel module (phi section)");
     moduleConnectionPhiImage.setName("moduleConnectionPhiMap");
 
-    // moduleConnectionEndcapPhiCanvas.cd();
+    // moduleConnectionEndcapPhiCanvas->cd();
     // moduleConnectionEndcapPhiMap.Draw("colz");
 
     RootWImage& moduleConnectionEndcapPhiImage = myContent.addImage(moduleConnectionEndcapPhiCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
@@ -3997,8 +3997,8 @@ namespace insur {
 
     //    myContent = myPage->addContent("Module Connections distribution", true);
 
-    TCanvas moduleConnectionsCanvas("ModuleConnectionsC", "Modules connectionsC", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    moduleConnectionsCanvas.cd();
+    TCanvas* moduleConnectionsCanvas = new TCanvas("ModuleConnectionsC", "Modules connectionsC", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    moduleConnectionsCanvas->cd();
     TH1I& moduleConnectionsDistribution = analyzer.getModuleConnectionsDistribution();
     moduleConnectionsDistribution.SetFillColor(Palette::color(2));
     moduleConnectionsDistribution.Draw();
@@ -4052,14 +4052,14 @@ namespace insur {
           scenarioStr = "noMS";
         }
 
-        TCanvas linearMomentumCanvas;
-        TCanvas momentumCanvas;
-        TCanvas distanceCanvas;
-        TCanvas angleCanvas;
-        TCanvas ctgThetaCanvas;
-        TCanvas etaCanvas;
-        TCanvas z0Canvas;
-        TCanvas pCanvas;
+        TCanvas* linearMomentumCanvas = new TCanvas();
+        TCanvas* momentumCanvas = new TCanvas();
+        TCanvas* distanceCanvas = new TCanvas();
+        TCanvas* angleCanvas = new TCanvas();
+        TCanvas* ctgThetaCanvas = new TCanvas();
+        TCanvas* etaCanvas = new TCanvas();
+        TCanvas* z0Canvas = new TCanvas();
+        TCanvas* pCanvas = new TCanvas();
 
         int myColor=0;
         int nRebin = 2;
@@ -4067,14 +4067,14 @@ namespace insur {
         double markerSize = 1.;
         double lineWidth = 2.;
 
-        linearMomentumCanvas.SetGrid(1,1);
-        momentumCanvas.SetGrid(1,1);
-        distanceCanvas.SetGrid(1,1);
-        angleCanvas.SetGrid(1,1);
-        ctgThetaCanvas.SetGrid(1,1);
-        etaCanvas.SetGrid(1,1);
-        z0Canvas.SetGrid(1,1);
-        pCanvas.SetGrid(1,1);
+        linearMomentumCanvas->SetGrid(1,1);
+        momentumCanvas->SetGrid(1,1);
+        distanceCanvas->SetGrid(1,1);
+        angleCanvas->SetGrid(1,1);
+        ctgThetaCanvas->SetGrid(1,1);
+        etaCanvas->SetGrid(1,1);
+        z0Canvas->SetGrid(1,1);
+        pCanvas->SetGrid(1,1);
         std::string plotOption = "";
         std::map<int, TGraph>::iterator g_iter, g_guard;
         // momentum canvas loop
@@ -4092,20 +4092,20 @@ namespace insur {
             momentumProfile.SetMinimum(vis_min_dPtOverPt);//4E-3*100);
             momentumProfile.SetMaximum(vis_max_dPtOverPt);//.5*100*verticalScale);
           }
-          linearMomentumCanvas.SetLogy(0);
-          momentumCanvas.SetLogy(1);
+          linearMomentumCanvas->SetLogy(0);
+          momentumCanvas->SetLogy(1);
           momentumProfile.SetLineColor(momentumColor(myColor));
           momentumProfile.SetMarkerColor(momentumColor(myColor));
           momentumProfile.SetLineWidth(lineWidth);
           myColor++;
           momentumProfile.SetMarkerStyle(markerStyle);
           momentumProfile.SetMarkerSize(markerSize);
-          momentumCanvas.SetFillColor(color_plot_background);
-          linearMomentumCanvas.SetFillColor(color_plot_background);
+          momentumCanvas->SetFillColor(color_plot_background);
+          linearMomentumCanvas->SetFillColor(color_plot_background);
           if (momentumGraph.GetN()>0) {
-            momentumCanvas.cd();
+            momentumCanvas->cd();
             momentumProfile.Draw(plotOption.c_str());
-            linearMomentumCanvas.cd();
+            linearMomentumCanvas->cd();
             momentumProfile.Draw(plotOption.c_str());
             plotOption = "same";
           }
@@ -4124,16 +4124,16 @@ namespace insur {
             distanceProfile.SetMinimum(vis_min_dD0);//4*1e-4);
             distanceProfile.SetMaximum(vis_max_dD0);//4E2*1e-4*verticalScale);
           }
-          distanceCanvas.SetLogy();
+          distanceCanvas->SetLogy();
           distanceProfile.SetLineColor(momentumColor(myColor));
           distanceProfile.SetMarkerColor(momentumColor(myColor));
           distanceProfile.SetLineWidth(lineWidth);
           myColor++;
           distanceProfile.SetMarkerStyle(markerStyle);
           distanceProfile.SetMarkerSize(markerSize);
-          distanceCanvas.SetFillColor(color_plot_background);
+          distanceCanvas->SetFillColor(color_plot_background);
           if (distanceGraph.GetN()>0) {
-            distanceCanvas.cd();
+            distanceCanvas->cd();
             distanceProfile.Draw(plotOption.c_str());
             plotOption = "same";
           }
@@ -4152,16 +4152,16 @@ namespace insur {
             angleProfile.SetMinimum(vis_min_dPhi);//1E-5);
             angleProfile.SetMaximum(vis_max_dPhi);//0.01*verticalScale);
           }
-          angleCanvas.SetLogy();
+          angleCanvas->SetLogy();
           angleProfile.SetLineColor(momentumColor(myColor));
           angleProfile.SetMarkerColor(momentumColor(myColor));
           angleProfile.SetLineWidth(lineWidth);
           myColor++;
           angleProfile.SetMarkerStyle(markerStyle);
           angleProfile.SetMarkerSize(markerSize);
-          angleCanvas.SetFillColor(color_plot_background);
+          angleCanvas->SetFillColor(color_plot_background);
           if (angleGraph.GetN() > 0) {
-            angleCanvas.cd();
+            angleCanvas->cd();
             angleProfile.Draw(plotOption.c_str());
             plotOption = "same";
           }
@@ -4177,25 +4177,25 @@ namespace insur {
 	  etaProfile.SetTitle("Pseudorapidity error - const P_{T} across #eta;#eta;#delta #eta");
           ctgThetaProfile.SetMinimum(vis_min_dCtgTheta);
           ctgThetaProfile.SetMaximum(vis_max_dCtgTheta);
-          ctgThetaCanvas.SetLogy();
+          ctgThetaCanvas->SetLogy();
           ctgThetaProfile.SetLineColor(momentumColor(myColor));
           ctgThetaProfile.SetMarkerColor(momentumColor(myColor));
           etaProfile.SetMinimum(vis_min_dCtgTheta);
           etaProfile.SetMaximum(vis_max_dCtgTheta);
-          etaCanvas.SetLogy();
+          etaCanvas->SetLogy();
           etaProfile.SetLineColor(momentumColor(myColor));
           etaProfile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           ctgThetaProfile.SetMarkerStyle(markerStyle);
           ctgThetaProfile.SetMarkerSize(markerSize);
-          ctgThetaCanvas.SetFillColor(color_plot_background);
+          ctgThetaCanvas->SetFillColor(color_plot_background);
           etaProfile.SetMarkerStyle(markerStyle);
           etaProfile.SetMarkerSize(markerSize);
-          etaCanvas.SetFillColor(color_plot_background);
+          etaCanvas->SetFillColor(color_plot_background);
           if (ctgThetaGraph.GetN() > 0) {
-            ctgThetaCanvas.cd();
+            ctgThetaCanvas->cd();
             ctgThetaProfile.Draw(plotOption.c_str());
-            etaCanvas.cd();
+            etaCanvas->cd();
             etaProfile.Draw(plotOption.c_str());
             plotOption = "same";
           }
@@ -4209,15 +4209,15 @@ namespace insur {
           TProfile& z0Profile = newProfile(z0Graph, 0, a.getEtaMaxTracker(), nRebin);
           z0Profile.SetMinimum(vis_min_dZ0);//1E-5);
           z0Profile.SetMaximum(vis_max_dZ0);//1*verticalScale);
-          z0Canvas.SetLogy();
+          z0Canvas->SetLogy();
           z0Profile.SetLineColor(momentumColor(myColor));
           z0Profile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           z0Profile.SetMarkerStyle(markerStyle);
           z0Profile.SetMarkerSize(markerSize);
-          z0Canvas.SetFillColor(color_plot_background);
+          z0Canvas->SetFillColor(color_plot_background);
           if (z0Graph.GetN() > 0) {
-            z0Canvas.cd();
+            z0Canvas->cd();
             z0Profile.Draw(plotOption.c_str());
             plotOption = "p same";
           }
@@ -4236,15 +4236,15 @@ namespace insur {
             pProfile.SetMinimum(vis_min_dPtOverPt);//4E-3*100);
             pProfile.SetMaximum(vis_max_dPtOverPt);//.11*100*verticalScale);
           }
-          pCanvas.SetLogy();
+          pCanvas->SetLogy();
           pProfile.SetLineColor(momentumColor(myColor));
           pProfile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           pProfile.SetMarkerStyle(markerStyle);
           pProfile.SetMarkerSize(markerSize);
-          pCanvas.SetFillColor(color_plot_background);
+          pCanvas->SetFillColor(color_plot_background);
           if (pGraph.GetN() > 0) {
-            pCanvas.cd();
+            pCanvas->cd();
             pProfile.Draw(plotOption.c_str());
             plotOption = "p same";
           }
@@ -4461,17 +4461,17 @@ namespace insur {
             scenarioStr = "noMS_Pt";
           }
 
-          TCanvas linMomCanvas_Pt;
-          TCanvas logMomCanvas_Pt;
-          TCanvas d0Canvas_Pt;
-          TCanvas phiCanvas_Pt;
-          TCanvas ctgThetaCanvas_Pt;
-          TCanvas etaCanvas_Pt;
-          TCanvas z0Canvas_Pt;
-          TCanvas pCanvas_Pt;
-          TCanvas lCanvas_Pt;
-          TCanvas betaCanvas_Pt;
-          TCanvas omegaCanvas_Pt;
+          TCanvas* linMomCanvas_Pt = new TCanvas();
+          TCanvas* logMomCanvas_Pt = new TCanvas();
+          TCanvas* d0Canvas_Pt = new TCanvas();
+          TCanvas* phiCanvas_Pt = new TCanvas();
+          TCanvas* ctgThetaCanvas_Pt = new TCanvas();
+          TCanvas* etaCanvas_Pt = new TCanvas();
+          TCanvas* z0Canvas_Pt = new TCanvas();
+          TCanvas* pCanvas_Pt = new TCanvas();
+          TCanvas* lCanvas_Pt = new TCanvas();
+          TCanvas* betaCanvas_Pt = new TCanvas();
+          TCanvas* omegaCanvas_Pt = new TCanvas();
 
           // Default attributes
           int myColor            = 0;
@@ -4481,17 +4481,17 @@ namespace insur {
           double lineWidth       = 2.;
           std::string plotOption = "";
 
-          linMomCanvas_Pt.SetGrid(1,1);
-          logMomCanvas_Pt.SetGrid(1,1);
-          d0Canvas_Pt.SetGrid(1,1);
-          phiCanvas_Pt.SetGrid(1,1);
-          ctgThetaCanvas_Pt.SetGrid(1,1);
-          etaCanvas_Pt.SetGrid(1,1);
-          z0Canvas_Pt.SetGrid(1,1);
-          pCanvas_Pt.SetGrid(1,1);
-          lCanvas_Pt.SetGrid(1,1);
-          betaCanvas_Pt.SetGrid(1,1);
-          omegaCanvas_Pt.SetGrid(1,1);
+          linMomCanvas_Pt->SetGrid(1,1);
+          logMomCanvas_Pt->SetGrid(1,1);
+          d0Canvas_Pt->SetGrid(1,1);
+          phiCanvas_Pt->SetGrid(1,1);
+          ctgThetaCanvas_Pt->SetGrid(1,1);
+          etaCanvas_Pt->SetGrid(1,1);
+          z0Canvas_Pt->SetGrid(1,1);
+          pCanvas_Pt->SetGrid(1,1);
+          lCanvas_Pt->SetGrid(1,1);
+          betaCanvas_Pt->SetGrid(1,1);
+          omegaCanvas_Pt->SetGrid(1,1);
 
           gStyle->SetGridStyle(style_grid);
           gStyle->SetGridColor(color_hard_grid);
@@ -4511,10 +4511,10 @@ namespace insur {
               momentumProfile.SetMinimum(insur::vis_min_dPtOverPt); //4E-3*100);
               momentumProfile.SetMaximum(insur::vis_max_dPtOverPt); //.5*100*verticalScale);
             }
-            linMomCanvas_Pt.SetLogy(0);
-            logMomCanvas_Pt.SetLogy(1);
-            linMomCanvas_Pt.SetFillColor(color_plot_background);
-            logMomCanvas_Pt.SetFillColor(color_plot_background);
+            linMomCanvas_Pt->SetLogy(0);
+            logMomCanvas_Pt->SetLogy(1);
+            linMomCanvas_Pt->SetFillColor(color_plot_background);
+            logMomCanvas_Pt->SetFillColor(color_plot_background);
 
             momentumProfile.SetLineColor(momentumColor(myColor));
             momentumProfile.SetMarkerColor(momentumColor(myColor));
@@ -4524,9 +4524,9 @@ namespace insur {
             momentumProfile.SetMarkerSize(markerSize);
 
             if (momentumGraph.GetN()>0) {
-              linMomCanvas_Pt.cd();
+              linMomCanvas_Pt->cd();
               momentumProfile.Draw(plotOption.c_str());
-              logMomCanvas_Pt.cd();
+              logMomCanvas_Pt->cd();
               momentumProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -4546,8 +4546,8 @@ namespace insur {
               pProfile.SetMinimum(insur::vis_min_dPtOverPt); //4E-3*100);
               pProfile.SetMaximum(insur::vis_max_dPtOverPt); //.11*100*verticalScale);
             }
-            pCanvas_Pt.SetLogy();
-            pCanvas_Pt.SetFillColor(color_plot_background);
+            pCanvas_Pt->SetLogy();
+            pCanvas_Pt->SetFillColor(color_plot_background);
 
             pProfile.SetLineColor(momentumColor(myColor));
             pProfile.SetMarkerColor(momentumColor(myColor));
@@ -4557,7 +4557,7 @@ namespace insur {
             pProfile.SetMarkerSize(markerSize);
 
             if (pGraph.GetN() > 0) {
-              pCanvas_Pt.cd();
+              pCanvas_Pt->cd();
               pProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -4577,8 +4577,8 @@ namespace insur {
               distanceProfile.SetMinimum(vis_min_dD0);
               distanceProfile.SetMaximum(vis_max_dD0);//*verticalScale);
             }
-            d0Canvas_Pt.SetLogy();
-            d0Canvas_Pt.SetFillColor(color_plot_background);
+            d0Canvas_Pt->SetLogy();
+            d0Canvas_Pt->SetFillColor(color_plot_background);
 
             distanceProfile.SetLineColor(momentumColor(myColor));
             distanceProfile.SetMarkerColor(momentumColor(myColor));
@@ -4588,7 +4588,7 @@ namespace insur {
             distanceProfile.SetMarkerSize(markerSize);
 
             if (distanceGraph.GetN()>0) {
-              d0Canvas_Pt.cd();
+              d0Canvas_Pt->cd();
               distanceProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -4608,8 +4608,8 @@ namespace insur {
               angleProfile.SetMinimum(vis_min_dPhi);
               angleProfile.SetMaximum(vis_max_dPhi);//*verticalScale);
             }
-            phiCanvas_Pt.SetLogy();
-            phiCanvas_Pt.SetFillColor(color_plot_background);
+            phiCanvas_Pt->SetLogy();
+            phiCanvas_Pt->SetFillColor(color_plot_background);
 
             angleProfile.SetLineColor(momentumColor(myColor));
             angleProfile.SetMarkerColor(momentumColor(myColor));
@@ -4619,7 +4619,7 @@ namespace insur {
             angleProfile.SetMarkerSize(markerSize);
 
             if (angleGraph.GetN() > 0) {
-              phiCanvas_Pt.cd();
+              phiCanvas_Pt->cd();
               angleProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -4636,12 +4636,12 @@ namespace insur {
 
             ctgThetaProfile.SetMinimum(vis_min_dCtgTheta);
             ctgThetaProfile.SetMaximum(vis_max_dCtgTheta);
-            ctgThetaCanvas_Pt.SetLogy();
-            ctgThetaCanvas_Pt.SetFillColor(color_plot_background);
+            ctgThetaCanvas_Pt->SetLogy();
+            ctgThetaCanvas_Pt->SetFillColor(color_plot_background);
             etaProfile.SetMinimum(vis_min_dCtgTheta);
             etaProfile.SetMaximum(vis_max_dCtgTheta);
-            etaCanvas_Pt.SetLogy();
-            etaCanvas_Pt.SetFillColor(color_plot_background);
+            etaCanvas_Pt->SetLogy();
+            etaCanvas_Pt->SetFillColor(color_plot_background);
 
             ctgThetaProfile.SetLineColor(momentumColor(myColor));
             ctgThetaProfile.SetMarkerColor(momentumColor(myColor));
@@ -4656,9 +4656,9 @@ namespace insur {
             etaProfile.SetMarkerSize(markerSize);
 
             if (ctgThetaGraph.GetN() > 0) {
-              ctgThetaCanvas_Pt.cd();
+              ctgThetaCanvas_Pt->cd();
               ctgThetaProfile.Draw(plotOption.c_str());
-              etaCanvas_Pt.cd();
+              etaCanvas_Pt->cd();
               etaProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -4673,8 +4673,8 @@ namespace insur {
 
             z0Profile.SetMinimum(vis_min_dZ0);
             z0Profile.SetMaximum(vis_max_dZ0);//*verticalScale);
-            z0Canvas_Pt.SetLogy();
-            z0Canvas_Pt.SetFillColor(color_plot_background);
+            z0Canvas_Pt->SetLogy();
+            z0Canvas_Pt->SetFillColor(color_plot_background);
 
             z0Profile.SetLineColor(momentumColor(myColor));
             z0Profile.SetMarkerColor(momentumColor(myColor));
@@ -4682,10 +4682,10 @@ namespace insur {
             myColor++;
             z0Profile.SetMarkerStyle(markerStyle);
             z0Profile.SetMarkerSize(markerSize);
-            z0Canvas_Pt.SetFillColor(color_plot_background);
+            z0Canvas_Pt->SetFillColor(color_plot_background);
 
             if (z0Graph.GetN() > 0) {
-              z0Canvas_Pt.cd();
+              z0Canvas_Pt->cd();
               z0Profile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -4701,8 +4701,8 @@ namespace insur {
 
             lProfile.SetMinimum(vis_min_dL);
             lProfile.SetMaximum(vis_max_dL);//*verticalScale);
-            lCanvas_Pt.SetLogy();
-            lCanvas_Pt.SetFillColor(color_plot_background);
+            lCanvas_Pt->SetLogy();
+            lCanvas_Pt->SetFillColor(color_plot_background);
 
             lProfile.SetLineColor(momentumColor(myColor));
             lProfile.SetMarkerColor(momentumColor(myColor));
@@ -4710,10 +4710,10 @@ namespace insur {
             myColor++;
             lProfile.SetMarkerStyle(markerStyle);
             lProfile.SetMarkerSize(markerSize);
-            lCanvas_Pt.SetFillColor(color_plot_background);
+            lCanvas_Pt->SetFillColor(color_plot_background);
 
             if (LGraph.GetN() > 0) {
-              lCanvas_Pt.cd();
+              lCanvas_Pt->cd();
               lProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -4729,8 +4729,8 @@ namespace insur {
 
             betaProfile.SetMinimum(vis_min_beta);
             betaProfile.SetMaximum(vis_max_beta);
-            betaCanvas_Pt.SetLogy(0);
-            betaCanvas_Pt.SetFillColor(color_plot_background);
+            betaCanvas_Pt->SetLogy(0);
+            betaCanvas_Pt->SetFillColor(color_plot_background);
 
             betaProfile.SetLineColor(momentumColor(myColor));
             betaProfile.SetMarkerColor(momentumColor(myColor));
@@ -4738,10 +4738,10 @@ namespace insur {
             myColor++;
             betaProfile.SetMarkerStyle(markerStyle);
             betaProfile.SetMarkerSize(markerSize);
-            betaCanvas_Pt.SetFillColor(color_plot_background);
+            betaCanvas_Pt->SetFillColor(color_plot_background);
 
             if (BetaGraph.GetN() > 0) {
-              betaCanvas_Pt.cd();
+              betaCanvas_Pt->cd();
               betaProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -4757,8 +4757,8 @@ namespace insur {
 
             omegaProfile.SetMinimum(vis_min_omega);
             omegaProfile.SetMaximum(vis_max_omega);
-            omegaCanvas_Pt.SetLogy(0);
-            omegaCanvas_Pt.SetFillColor(color_plot_background);
+            omegaCanvas_Pt->SetLogy(0);
+            omegaCanvas_Pt->SetFillColor(color_plot_background);
 
             omegaProfile.SetLineColor(momentumColor(myColor));
             omegaProfile.SetMarkerColor(momentumColor(myColor));
@@ -4766,10 +4766,10 @@ namespace insur {
             myColor++;
             omegaProfile.SetMarkerStyle(markerStyle);
             omegaProfile.SetMarkerSize(markerSize);
-            omegaCanvas_Pt.SetFillColor(color_plot_background);
+            omegaCanvas_Pt->SetFillColor(color_plot_background);
 
             if (OmegaGraph.GetN() > 0) {
-              omegaCanvas_Pt.cd();
+              omegaCanvas_Pt->cd();
               omegaProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -4842,17 +4842,17 @@ namespace insur {
             scenarioStr = "noMS_P";
           }
 
-          TCanvas linMomCanvas_P;
-          TCanvas logMomCanvas_P;
-          TCanvas d0Canvas_P;
-          TCanvas phiCanvas_P;
-          TCanvas ctgThetaCanvas_P;
-          TCanvas etaCanvas_P;
-          TCanvas z0Canvas_P;
-          TCanvas pCanvas_P;
-          TCanvas lCanvas_P;
-          TCanvas betaCanvas_P;
-          TCanvas omegaCanvas_P;
+          TCanvas* linMomCanvas_P = new TCanvas();
+          TCanvas* logMomCanvas_P = new TCanvas();
+          TCanvas* d0Canvas_P = new TCanvas();
+          TCanvas* phiCanvas_P = new TCanvas();
+          TCanvas* ctgThetaCanvas_P = new TCanvas();
+          TCanvas* etaCanvas_P = new TCanvas();
+          TCanvas* z0Canvas_P = new TCanvas();
+          TCanvas* pCanvas_P = new TCanvas();
+          TCanvas* lCanvas_P = new TCanvas();
+          TCanvas* betaCanvas_P = new TCanvas();
+          TCanvas* omegaCanvas_P = new TCanvas();
 
           // Default attributes
           int myColor            = 0;
@@ -4862,17 +4862,17 @@ namespace insur {
           double lineWidth       = 2.;
           std::string plotOption = "";
 
-          linMomCanvas_P.SetGrid(1,1);
-          logMomCanvas_P.SetGrid(1,1);
-          d0Canvas_P.SetGrid(1,1);
-          phiCanvas_P.SetGrid(1,1);
-          ctgThetaCanvas_P.SetGrid(1,1);
-          etaCanvas_P.SetGrid(1,1);
-          z0Canvas_P.SetGrid(1,1);
-          pCanvas_P.SetGrid(1,1);
-          lCanvas_P.SetGrid(1,1);
-          betaCanvas_P.SetGrid(1,1);
-          omegaCanvas_P.SetGrid(1,1);
+          linMomCanvas_P->SetGrid(1,1);
+          logMomCanvas_P->SetGrid(1,1);
+          d0Canvas_P->SetGrid(1,1);
+          phiCanvas_P->SetGrid(1,1);
+          ctgThetaCanvas_P->SetGrid(1,1);
+          etaCanvas_P->SetGrid(1,1);
+          z0Canvas_P->SetGrid(1,1);
+          pCanvas_P->SetGrid(1,1);
+          lCanvas_P->SetGrid(1,1);
+          betaCanvas_P->SetGrid(1,1);
+          omegaCanvas_P->SetGrid(1,1);
 
           gStyle->SetGridStyle(style_grid);
           gStyle->SetGridColor(color_hard_grid);
@@ -4892,10 +4892,10 @@ namespace insur {
               momentumProfile.SetMinimum(insur::vis_min_dPtOverPt); //4E-3*100);
               momentumProfile.SetMaximum(insur::vis_max_dPtOverPt); //.5*100*verticalScale);
             }
-            linMomCanvas_P.SetLogy(0);
-            logMomCanvas_P.SetLogy(1);
-            linMomCanvas_P.SetFillColor(color_plot_background);
-            logMomCanvas_P.SetFillColor(color_plot_background);
+            linMomCanvas_P->SetLogy(0);
+            logMomCanvas_P->SetLogy(1);
+            linMomCanvas_P->SetFillColor(color_plot_background);
+            logMomCanvas_P->SetFillColor(color_plot_background);
 
             momentumProfile.SetLineColor(momentumColor(myColor));
             momentumProfile.SetMarkerColor(momentumColor(myColor));
@@ -4905,9 +4905,9 @@ namespace insur {
             momentumProfile.SetMarkerSize(markerSize);
 
             if (momentumGraph.GetN()>0) {
-              linMomCanvas_P.cd();
+              linMomCanvas_P->cd();
               momentumProfile.Draw(plotOption.c_str());
-              logMomCanvas_P.cd();
+              logMomCanvas_P->cd();
               momentumProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -4927,8 +4927,8 @@ namespace insur {
               pProfile.SetMinimum(insur::vis_min_dPtOverPt); //4E-3*100);
               pProfile.SetMaximum(insur::vis_max_dPtOverPt); //.11*100*verticalScale);
             }
-            pCanvas_P.SetLogy();
-            pCanvas_P.SetFillColor(color_plot_background);
+            pCanvas_P->SetLogy();
+            pCanvas_P->SetFillColor(color_plot_background);
 
             pProfile.SetLineColor(momentumColor(myColor));
             pProfile.SetMarkerColor(momentumColor(myColor));
@@ -4938,7 +4938,7 @@ namespace insur {
             pProfile.SetMarkerSize(markerSize);
 
             if (pGraph.GetN() > 0) {
-              pCanvas_P.cd();
+              pCanvas_P->cd();
               pProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -4958,8 +4958,8 @@ namespace insur {
                 distanceProfile.SetMinimum(vis_min_dD0);
                 distanceProfile.SetMaximum(vis_max_dD0);//*verticalScale);
             }
-            d0Canvas_P.SetLogy();
-            d0Canvas_P.SetFillColor(color_plot_background);
+            d0Canvas_P->SetLogy();
+            d0Canvas_P->SetFillColor(color_plot_background);
 
             distanceProfile.SetLineColor(momentumColor(myColor));
             distanceProfile.SetMarkerColor(momentumColor(myColor));
@@ -4969,7 +4969,7 @@ namespace insur {
             distanceProfile.SetMarkerSize(markerSize);
 
             if (distanceGraph.GetN()>0) {
-              d0Canvas_P.cd();
+              d0Canvas_P->cd();
               distanceProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -4989,8 +4989,8 @@ namespace insur {
               angleProfile.SetMinimum(vis_min_dPhi);
               angleProfile.SetMaximum(vis_max_dPhi);//*verticalScale);
             }
-            phiCanvas_P.SetLogy();
-            phiCanvas_P.SetFillColor(color_plot_background);
+            phiCanvas_P->SetLogy();
+            phiCanvas_P->SetFillColor(color_plot_background);
 
             angleProfile.SetLineColor(momentumColor(myColor));
             angleProfile.SetMarkerColor(momentumColor(myColor));
@@ -5000,7 +5000,7 @@ namespace insur {
             angleProfile.SetMarkerSize(markerSize);
 
             if (angleGraph.GetN() > 0) {
-              phiCanvas_P.cd();
+              phiCanvas_P->cd();
               angleProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -5017,12 +5017,12 @@ namespace insur {
 
             ctgThetaProfile.SetMinimum(vis_min_dCtgTheta);
             ctgThetaProfile.SetMaximum(vis_max_dCtgTheta);
-            ctgThetaCanvas_P.SetLogy();
-            ctgThetaCanvas_P.SetFillColor(color_plot_background);
+            ctgThetaCanvas_P->SetLogy();
+            ctgThetaCanvas_P->SetFillColor(color_plot_background);
             etaProfile.SetMinimum(vis_min_dCtgTheta);
             etaProfile.SetMaximum(vis_max_dCtgTheta);
-            etaCanvas_P.SetLogy();
-            etaCanvas_P.SetFillColor(color_plot_background);
+            etaCanvas_P->SetLogy();
+            etaCanvas_P->SetFillColor(color_plot_background);
 
             ctgThetaProfile.SetLineColor(momentumColor(myColor));
             ctgThetaProfile.SetMarkerColor(momentumColor(myColor));
@@ -5037,9 +5037,9 @@ namespace insur {
             etaProfile.SetMarkerSize(markerSize);
 
             if (ctgThetaGraph.GetN() > 0) {
-              ctgThetaCanvas_P.cd();
+              ctgThetaCanvas_P->cd();
               ctgThetaProfile.Draw(plotOption.c_str());
-              etaCanvas_P.cd();
+              etaCanvas_P->cd();
               etaProfile.Draw(plotOption.c_str());
               plotOption = "same";
             }
@@ -5054,8 +5054,8 @@ namespace insur {
 
             z0Profile.SetMinimum(vis_min_dZ0);
             z0Profile.SetMaximum(vis_max_dZ0);//*verticalScale);
-            z0Canvas_P.SetLogy();
-            z0Canvas_P.SetFillColor(color_plot_background);
+            z0Canvas_P->SetLogy();
+            z0Canvas_P->SetFillColor(color_plot_background);
 
             z0Profile.SetLineColor(momentumColor(myColor));
             z0Profile.SetMarkerColor(momentumColor(myColor));
@@ -5063,10 +5063,10 @@ namespace insur {
             myColor++;
             z0Profile.SetMarkerStyle(markerStyle);
             z0Profile.SetMarkerSize(markerSize);
-            z0Canvas_P.SetFillColor(color_plot_background);
+            z0Canvas_P->SetFillColor(color_plot_background);
 
             if (z0Graph.GetN() > 0) {
-              z0Canvas_P.cd();
+              z0Canvas_P->cd();
               z0Profile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -5084,8 +5084,8 @@ namespace insur {
 
             lProfile.SetMinimum(vis_min_dL);
             lProfile.SetMaximum(vis_max_dL);//*verticalScale);
-            lCanvas_P.SetLogy();
-            lCanvas_P.SetFillColor(color_plot_background);
+            lCanvas_P->SetLogy();
+            lCanvas_P->SetFillColor(color_plot_background);
 
             lProfile.SetLineColor(momentumColor(myColor));
             lProfile.SetMarkerColor(momentumColor(myColor));
@@ -5093,10 +5093,10 @@ namespace insur {
             myColor++;
             lProfile.SetMarkerStyle(markerStyle);
             lProfile.SetMarkerSize(markerSize);
-            lCanvas_P.SetFillColor(color_plot_background);
+            lCanvas_P->SetFillColor(color_plot_background);
 
             if (LGraph.GetN() > 0) {
-              lCanvas_P.cd();
+              lCanvas_P->cd();
               lProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -5112,8 +5112,8 @@ namespace insur {
 
             betaProfile.SetMinimum(vis_min_beta);
             betaProfile.SetMaximum(vis_max_beta);
-            betaCanvas_P.SetLogy(0);
-            betaCanvas_P.SetFillColor(color_plot_background);
+            betaCanvas_P->SetLogy(0);
+            betaCanvas_P->SetFillColor(color_plot_background);
 
             betaProfile.SetLineColor(momentumColor(myColor));
             betaProfile.SetMarkerColor(momentumColor(myColor));
@@ -5121,10 +5121,10 @@ namespace insur {
             myColor++;
             betaProfile.SetMarkerStyle(markerStyle);
             betaProfile.SetMarkerSize(markerSize);
-            betaCanvas_P.SetFillColor(color_plot_background);
+            betaCanvas_P->SetFillColor(color_plot_background);
 
             if (BetaGraph.GetN() > 0) {
-              betaCanvas_P.cd();
+              betaCanvas_P->cd();
               betaProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -5140,8 +5140,8 @@ namespace insur {
 
             omegaProfile.SetMinimum(vis_min_omega);
             omegaProfile.SetMaximum(vis_max_omega);
-            omegaCanvas_P.SetLogy(0);
-            omegaCanvas_P.SetFillColor(color_plot_background);
+            omegaCanvas_P->SetLogy(0);
+            omegaCanvas_P->SetFillColor(color_plot_background);
 
             omegaProfile.SetLineColor(momentumColor(myColor));
             omegaProfile.SetMarkerColor(momentumColor(myColor));
@@ -5149,10 +5149,10 @@ namespace insur {
             myColor++;
             omegaProfile.SetMarkerStyle(markerStyle);
             omegaProfile.SetMarkerSize(markerSize);
-            omegaCanvas_P.SetFillColor(color_plot_background);
+            omegaCanvas_P->SetFillColor(color_plot_background);
 
             if (OmegaGraph.GetN() > 0) {
-              omegaCanvas_P.cd();
+              omegaCanvas_P->cd();
               omegaProfile.Draw(plotOption.c_str());
               plotOption = "p same";
             }
@@ -5466,11 +5466,11 @@ namespace insur {
     myInfoPt.setValue(SimParms::getInstance().numMinBiasEvents(), minimumBiasPrecision);
 
     // a) Bkg contamination probability -> In-Out approach
-    TCanvas canvasPtBkgContInOut("canvasPtBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-    canvasPtBkgContInOut.SetGrid(1,1);
-    canvasPtBkgContInOut.SetLogy(0);
-    canvasPtBkgContInOut.SetFillColor(color_plot_background);
-    canvasPtBkgContInOut.SetObjectStat(false);
+    TCanvas* canvasPtBkgContInOut = new TCanvas("canvasPtBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    canvasPtBkgContInOut->SetGrid(1,1);
+    canvasPtBkgContInOut->SetLogy(0);
+    canvasPtBkgContInOut->SetFillColor(color_plot_background);
+    canvasPtBkgContInOut->SetObjectStat(false);
 
     // For each momentum/transverse momentum compute
     int iMomentum = 0;
@@ -5502,11 +5502,11 @@ namespace insur {
     myImagePtBkgContInOut.setName("bkg_pt_pContam_inout");
 
     // b) Bkg contamination probability -> OutIn approach
-    TCanvas canvasPtBkgContOutIn("canvasPtBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-    canvasPtBkgContOutIn.SetGrid(1,1);
-    canvasPtBkgContOutIn.SetLogy(0);
-    canvasPtBkgContOutIn.SetFillColor(color_plot_background);
-    canvasPtBkgContOutIn.SetObjectStat(false);
+    TCanvas* canvasPtBkgContOutIn = new TCanvas("canvasPtBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    canvasPtBkgContOutIn->SetGrid(1,1);
+    canvasPtBkgContOutIn->SetLogy(0);
+    canvasPtBkgContOutIn->SetFillColor(color_plot_background);
+    canvasPtBkgContOutIn->SetObjectStat(false);
 
     // For each momentum/transverse momentum compute
     iMomentum = 0;
@@ -5550,11 +5550,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPtD0InOut(std::string("canvasPtD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPtD0InOut.SetGrid(1,1);
-      canvasPtD0InOut.SetLogy(0);
-      canvasPtD0InOut.SetFillColor(color_plot_background);
-      canvasPtD0InOut.SetObjectStat(false);
+      TCanvas* canvasPtD0InOut = new TCanvas(std::string("canvasPtD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPtD0InOut->SetGrid(1,1);
+      canvasPtD0InOut->SetLogy(0);
+      canvasPtD0InOut->SetFillColor(color_plot_background);
+      canvasPtD0InOut->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5593,11 +5593,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPtZ0InOut(std::string("canvasPtZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPtZ0InOut.SetGrid(1,1);
-      canvasPtZ0InOut.SetLogy(0);
-      canvasPtZ0InOut.SetFillColor(color_plot_background);
-      canvasPtZ0InOut.SetObjectStat(false);
+      TCanvas* canvasPtZ0InOut = new TCanvas(std::string("canvasPtZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPtZ0InOut->SetGrid(1,1);
+      canvasPtZ0InOut->SetLogy(0);
+      canvasPtZ0InOut->SetFillColor(color_plot_background);
+      canvasPtZ0InOut->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5633,11 +5633,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPtProbContamInOut(std::string("canvasPtProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPtProbContamInOut.SetGrid(1,1);
-      canvasPtProbContamInOut.SetLogy(0);
-      canvasPtProbContamInOut.SetFillColor(color_plot_background);
-      canvasPtProbContamInOut.SetObjectStat(false);
+      TCanvas* canvasPtProbContamInOut = new TCanvas(std::string("canvasPtProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPtProbContamInOut->SetGrid(1,1);
+      canvasPtProbContamInOut->SetLogy(0);
+      canvasPtProbContamInOut->SetFillColor(color_plot_background);
+      canvasPtProbContamInOut->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5678,11 +5678,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPtD0OutIn(std::string("canvasPtD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPtD0OutIn.SetGrid(1,1);
-      canvasPtD0OutIn.SetLogy(0);
-      canvasPtD0OutIn.SetFillColor(color_plot_background);
-      canvasPtD0OutIn.SetObjectStat(false);
+      TCanvas* canvasPtD0OutIn = new TCanvas(std::string("canvasPtD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPtD0OutIn->SetGrid(1,1);
+      canvasPtD0OutIn->SetLogy(0);
+      canvasPtD0OutIn->SetFillColor(color_plot_background);
+      canvasPtD0OutIn->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5721,11 +5721,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPtZ0OutIn(std::string("canvasPtZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPtZ0OutIn.SetGrid(1,1);
-      canvasPtZ0OutIn.SetLogy(0);
-      canvasPtZ0OutIn.SetFillColor(color_plot_background);
-      canvasPtZ0OutIn.SetObjectStat(false);
+      TCanvas* canvasPtZ0OutIn = new TCanvas(std::string("canvasPtZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPtZ0OutIn->SetGrid(1,1);
+      canvasPtZ0OutIn->SetLogy(0);
+      canvasPtZ0OutIn->SetFillColor(color_plot_background);
+      canvasPtZ0OutIn->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5761,11 +5761,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPtProbContamOutIn(std::string("canvasPtProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPtProbContamOutIn.SetGrid(1,1);
-      canvasPtProbContamOutIn.SetLogy(0);
-      canvasPtProbContamOutIn.SetFillColor(color_plot_background);
-      canvasPtProbContamOutIn.SetObjectStat(false);
+      TCanvas* canvasPtProbContamOutIn = new TCanvas(std::string("canvasPtProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPtProbContamOutIn->SetGrid(1,1);
+      canvasPtProbContamOutIn->SetLogy(0);
+      canvasPtProbContamOutIn->SetFillColor(color_plot_background);
+      canvasPtProbContamOutIn->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5802,11 +5802,11 @@ namespace insur {
     myInfoP.setValue(SimParms::getInstance().numMinBiasEvents(), minimumBiasPrecision);
 
     // a) Bkg contamination probability - In-Out approach
-    TCanvas canvasPBkgContInOut("canvasPBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-    canvasPBkgContInOut.SetGrid(1,1);
-    canvasPBkgContInOut.SetLogy(0);
-    canvasPBkgContInOut.SetFillColor(color_plot_background);
-    canvasPBkgContInOut.SetObjectStat(false);
+    TCanvas* canvasPBkgContInOut = new TCanvas("canvasPBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    canvasPBkgContInOut->SetGrid(1,1);
+    canvasPBkgContInOut->SetLogy(0);
+    canvasPBkgContInOut->SetFillColor(color_plot_background);
+    canvasPBkgContInOut->SetObjectStat(false);
 
     // For each momentum/transverse momentum compute
     iMomentum = 0;
@@ -5838,11 +5838,11 @@ namespace insur {
     myImagePBkgContInOut.setName("bkg_p_pContam_inout");
 
     // b) Bkg contamination probability - Out-In approach
-    TCanvas canvasPBkgContOutIn("canvasPBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-    canvasPBkgContOutIn.SetGrid(1,1);
-    canvasPBkgContOutIn.SetLogy(0);
-    canvasPBkgContOutIn.SetFillColor(color_plot_background);
-    canvasPBkgContOutIn.SetObjectStat(false);
+    TCanvas* canvasPBkgContOutIn = new TCanvas("canvasPBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    canvasPBkgContOutIn->SetGrid(1,1);
+    canvasPBkgContOutIn->SetLogy(0);
+    canvasPBkgContOutIn->SetFillColor(color_plot_background);
+    canvasPBkgContOutIn->SetObjectStat(false);
 
     // For each momentum/transverse momentum compute
     iMomentum = 0;
@@ -5886,11 +5886,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPD0InOut(std::string("canvasPD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPD0InOut.SetGrid(1,1);
-      canvasPD0InOut.SetLogy(0);
-      canvasPD0InOut.SetFillColor(color_plot_background);
-      canvasPD0InOut.SetObjectStat(false);
+      TCanvas* canvasPD0InOut = new TCanvas(std::string("canvasPD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPD0InOut->SetGrid(1,1);
+      canvasPD0InOut->SetLogy(0);
+      canvasPD0InOut->SetFillColor(color_plot_background);
+      canvasPD0InOut->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5929,11 +5929,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPZ0InOut(std::string("canvasPZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPZ0InOut.SetGrid(1,1);
-      canvasPZ0InOut.SetLogy(0);
-      canvasPZ0InOut.SetFillColor(color_plot_background);
-      canvasPZ0InOut.SetObjectStat(false);
+      TCanvas* canvasPZ0InOut = new TCanvas(std::string("canvasPZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPZ0InOut->SetGrid(1,1);
+      canvasPZ0InOut->SetLogy(0);
+      canvasPZ0InOut->SetFillColor(color_plot_background);
+      canvasPZ0InOut->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -5971,11 +5971,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPProbContamInOut(std::string("canvasPProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPProbContamInOut.SetGrid(1,1);
-      canvasPProbContamInOut.SetLogy(0);
-      canvasPProbContamInOut.SetFillColor(color_plot_background);
-      canvasPProbContamInOut.SetObjectStat(false);
+      TCanvas* canvasPProbContamInOut = new TCanvas(std::string("canvasPProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPProbContamInOut->SetGrid(1,1);
+      canvasPProbContamInOut->SetLogy(0);
+      canvasPProbContamInOut->SetFillColor(color_plot_background);
+      canvasPProbContamInOut->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -6015,11 +6015,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPD0OutIn(std::string("canvasPD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPD0OutIn.SetGrid(1,1);
-      canvasPD0OutIn.SetLogy(0);
-      canvasPD0OutIn.SetFillColor(color_plot_background);
-      canvasPD0OutIn.SetObjectStat(false);
+      TCanvas* canvasPD0OutIn = new TCanvas(std::string("canvasPD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPD0OutIn->SetGrid(1,1);
+      canvasPD0OutIn->SetLogy(0);
+      canvasPD0OutIn->SetFillColor(color_plot_background);
+      canvasPD0OutIn->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -6058,11 +6058,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPZ0OutIn(std::string("canvasPZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPZ0OutIn.SetGrid(1,1);
-      canvasPZ0OutIn.SetLogy(0);
-      canvasPZ0OutIn.SetFillColor(color_plot_background);
-      canvasPZ0OutIn.SetObjectStat(false);
+      TCanvas* canvasPZ0OutIn = new TCanvas(std::string("canvasPZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPZ0OutIn->SetGrid(1,1);
+      canvasPZ0OutIn->SetLogy(0);
+      canvasPZ0OutIn->SetFillColor(color_plot_background);
+      canvasPZ0OutIn->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -6100,11 +6100,11 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas canvasPProbContamOutIn(std::string("canvasPProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
-      canvasPProbContamOutIn.SetGrid(1,1);
-      canvasPProbContamOutIn.SetLogy(0);
-      canvasPProbContamOutIn.SetFillColor(color_plot_background);
-      canvasPProbContamOutIn.SetObjectStat(false);
+      TCanvas* canvasPProbContamOutIn = new TCanvas(std::string("canvasPProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      canvasPProbContamOutIn->SetGrid(1,1);
+      canvasPProbContamOutIn->SetLogy(0);
+      canvasPProbContamOutIn->SetFillColor(color_plot_background);
+      canvasPProbContamOutIn->SetObjectStat(false);
 
       for (const auto& pIter : mainConfig.getMomenta()) {
 
@@ -6178,8 +6178,8 @@ namespace insur {
 
       // Create the contents
       RootWContent& myContent = myPage.addContent("Overall trigger");
-      TCanvas pointsCanvas;
-      pointsCanvas.SetGrid(1,1);
+      TCanvas* pointsCanvas = new TCanvas();
+      pointsCanvas->SetGrid(1,1);
       plotOption = "E1"; // or "E6"
 
       // Strings according to the content
@@ -6216,9 +6216,9 @@ namespace insur {
         npointsProfile.SetFillColor(Palette::color(myColor));
         myColor++;
         npointsProfile.SetMarkerStyle(8);
-        pointsCanvas.SetFillColor(color_plot_background);
+        pointsCanvas->SetFillColor(color_plot_background);
 
-        pointsCanvas.cd();
+        pointsCanvas->cd();
         // std::cerr << "About to draw plot " << myPt << std::endl; // debug
         npointsProfile.Draw(plotOption.c_str());
         //plotOption = "E6 same";
@@ -6233,7 +6233,7 @@ namespace insur {
 
       // std::cerr << "now to log scale..." << std::endl; // debug
 
-      pointsCanvas.SetLogy();
+      pointsCanvas->SetLogy();
       RootWImage& npointsLogImage = myContent.addImage(pointsCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS << " (log scale)";
       npointsLogImage.setComment(tempSS.str().c_str());
@@ -6241,8 +6241,8 @@ namespace insur {
 
       // std::cerr << "done..." << std::endl; // debug
 
-      TCanvas fractionCanvas;
-      fractionCanvas.SetGrid(1,1);
+      TCanvas* fractionCanvas = new TCanvas();
+      fractionCanvas->SetGrid(1,1);
       plotOption = "E1";
 
       // Strings according to the content
@@ -6280,9 +6280,9 @@ namespace insur {
         fractionProfile.SetFillColor(Palette::color(myColor));
         myColor++;
         fractionProfile.SetMarkerStyle(8);
-        fractionCanvas.SetFillColor(color_plot_background);
+        fractionCanvas->SetFillColor(color_plot_background);
 
-        fractionCanvas.cd();
+        fractionCanvas->cd();
         // std::cerr << "About to draw fraction plot " << myPt << std::endl; // debug
         fractionProfile.Draw(plotOption.c_str());
         plotOption = "E1 same";
@@ -6297,15 +6297,15 @@ namespace insur {
       RootWImage& fractionImage = myContent.addImage(fractionCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       fractionImage.setComment(tempSS.str().c_str());
       fractionImage.setName("fractiontrigpoints");
-      fractionCanvas.SetLogy();
+      fractionCanvas->SetLogy();
       RootWImage& fractionLogImage = myContent.addImage(fractionCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS << " (log scale)";
       fractionLogImage.setComment(tempSS.str().c_str());
       fractionLogImage.setName("fractiontrigpointsLog");
 
 
-      TCanvas purityCanvas;
-      purityCanvas.SetGrid(1,1);
+      TCanvas* purityCanvas = new TCanvas();
+      purityCanvas->SetGrid(1,1);
       plotOption = "E1";
 
       // Strings according to the content
@@ -6343,9 +6343,9 @@ namespace insur {
         purityProfile.SetFillColor(Palette::color(myColor));
         myColor++;
         purityProfile.SetMarkerStyle(8);
-        purityCanvas.SetFillColor(color_plot_background);
+        purityCanvas->SetFillColor(color_plot_background);
 
-        purityCanvas.cd();
+        purityCanvas->cd();
         // std::cerr << "About to draw purity plot " << myPt << std::endl; // debug
         purityProfile.Draw(plotOption.c_str());
         plotOption = "E1 same";
@@ -6360,7 +6360,7 @@ namespace insur {
       RootWImage& purityImage = myContent.addImage(purityCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       purityImage.setComment(tempSS.str().c_str());
       purityImage.setName("puritytrigpoints");
-      purityCanvas.SetLogy();
+      purityCanvas->SetLogy();
       RootWImage& purityLogImage = myContent.addImage(purityCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS << " (log scale)";
       purityLogImage.setComment(tempSS.str().c_str());
@@ -6389,12 +6389,12 @@ namespace insur {
            it != efficiencyMaps.end(); ++it) {
 
         // One canvas per map
-        TCanvas myCanvas;
+        TCanvas* myCanvas = new TCanvas();
         double myPt = it->first;
         if (myPt>maxPt) maxPt=myPt;
         TH2D& myMap = it->second;
-        myCanvas.SetFillColor(color_plot_background);
-        myCanvas.cd();
+        myCanvas->SetFillColor(color_plot_background);
+        myCanvas->cd();
 
         // Actually plot the map
         myMap.SetMinimum(0);
@@ -6427,7 +6427,7 @@ namespace insur {
       RootWContent& myContent = myPage.addContent("Stub efficiency coverage", false);
       for (const auto& lmel : profiles) {
         TCanvas* myCanvas = new TCanvas(Form("StubEfficiencyCoverageCanvas%s", lmel.first.c_str()), "Stub efficiency eta coverage", vis_std_canvas_sizeX, vis_min_canvas_sizeY);
-        //myCanvas.SetFillColor(color_plot_background);
+        //myCanvas->SetFillColor(color_plot_background);
         myCanvas->cd();
         std::vector<std::string> momenta;
         int myColor = 1;
@@ -6467,11 +6467,11 @@ namespace insur {
            it != thresholdMaps.end(); ++it) {
 
         // One canvas per map
-        TCanvas myCanvas;
+        TCanvas* myCanvas = new TCanvas();
         double myEfficiency = it->first;
         TH2D& myMap = it->second;
-        myCanvas.SetFillColor(color_plot_background);
-        myCanvas.cd();
+        myCanvas->SetFillColor(color_plot_background);
+        myCanvas->cd();
 
         // Actually plot the map
         myMap.SetMinimum(0);
@@ -6506,47 +6506,47 @@ namespace insur {
     RootWContent& myContent = myPage.addContent("Module configuration maps", false);
 
     // One canvas per map
-    TCanvas thickCanvas;
-    TCanvas windowCanvas;
-    TCanvas suggestedSpacingCanvas;
-    TCanvas suggestedSpacingAWCanvas;
-    TCanvas nominalCutCanvas;
-    thickCanvas.SetFillColor(color_plot_background);
-    windowCanvas.SetFillColor(color_plot_background);
-    suggestedSpacingCanvas.SetFillColor(color_plot_background);
-    suggestedSpacingAWCanvas.SetFillColor(color_plot_background);
-    nominalCutCanvas.SetFillColor(color_plot_background);
+    TCanvas* thickCanvas = new TCanvas();
+    TCanvas* windowCanvas = new TCanvas();
+    TCanvas* suggestedSpacingCanvas = new TCanvas();
+    TCanvas* suggestedSpacingAWCanvas = new TCanvas();
+    TCanvas* nominalCutCanvas = new TCanvas();
+    thickCanvas->SetFillColor(color_plot_background);
+    windowCanvas->SetFillColor(color_plot_background);
+    suggestedSpacingCanvas->SetFillColor(color_plot_background);
+    suggestedSpacingAWCanvas->SetFillColor(color_plot_background);
+    nominalCutCanvas->SetFillColor(color_plot_background);
 
     struct Spacing { double operator()(const Module& m) { return m.dsDistance(); } };
     PlotDrawer<YZ, Spacing> thicknessDrawer;
     thicknessDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
-    thicknessDrawer.drawFrame<HistogramFrameStyle>(thickCanvas);
-    thicknessDrawer.drawModules<ContourStyle>(thickCanvas);
+    thicknessDrawer.drawFrame<HistogramFrameStyle>(*thickCanvas);
+    thicknessDrawer.drawModules<ContourStyle>(*thickCanvas);
 
     struct TriggerWindow { double operator()(const Module& m) { return m.triggerWindow(); } };
     PlotDrawer<YZ, TriggerWindow> windowDrawer;
     windowDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
-    windowDrawer.drawFrame<HistogramFrameStyle>(windowCanvas);
-    windowDrawer.drawModules<ContourStyle>(windowCanvas);
+    windowDrawer.drawFrame<HistogramFrameStyle>(*windowCanvas);
+    windowDrawer.drawModules<ContourStyle>(*windowCanvas);
 
 
     // Actually plot the maps
-    //thickCanvas.cd();
+    //thickCanvas->cd();
     //thicknessMap.Draw("colz");
-    //windowCanvas.cd();
+    //windowCanvas->cd();
     //windowMap.Draw("colz");
     if (extended) {
-      suggestedSpacingCanvas.cd();
+      suggestedSpacingCanvas->cd();
       suggestedSpacingMap.Draw("colz");
-      suggestedSpacingAWCanvas.cd();
+      suggestedSpacingAWCanvas->cd();
       suggestedSpacingMapAW.Draw("colz");
-      nominalCutCanvas.cd();
+      nominalCutCanvas->cd();
       //struct PtCut { double operator()(const Module& m) { return PtErrorAdapter(m).getPtCut(); } };
       //PlotDrawer<YZ, PtCut> cutDrawer;
       //cutDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
-      //cutDrawer.drawFrame<HistogramFrameStyle>(nominalCutCanvas);
-      //cutDrawer.drawModules<ContourStyle>(nominalCutCanvas);
-      nominalCutCanvas.SetLogz();
+      //cutDrawer.drawFrame<HistogramFrameStyle>(*nominalCutCanvas);
+      //cutDrawer.drawModules<ContourStyle>(*nominalCutCanvas);
+      nominalCutCanvas->SetLogz();
       nominalCutMap.Draw("colz");
     }
 
@@ -6627,10 +6627,10 @@ namespace insur {
         }
       }
 
-
-      TCanvas rangeCanvas;
-      rangeCanvas.SetFillColor(color_plot_background);
-      rangeCanvas.SetGrid(0,1);
+      TCanvas* rangeCanvas = new TCanvas();
+      rangeCanvas->cd();
+      rangeCanvas->SetFillColor(color_plot_background);
+      rangeCanvas->SetGrid(0,1);
       myFrame.Draw();
       rangeGraph.SetFillColor(Palette::color(1));
       rangeGraph.Draw("same 2");
@@ -6645,9 +6645,10 @@ namespace insur {
       tempSS.str(""); tempSS << "TriggerRangeTuning";
       RangeImage.setName(tempSS.str());
 
-      TCanvas tuningCanvas;
-      tuningCanvas.SetFillColor(color_plot_background);
-      tuningCanvas.SetGrid(0,1);
+      TCanvas* tuningCanvas = new TCanvas();
+      tuningCanvas->cd();
+      tuningCanvas->SetFillColor(color_plot_background);
+      tuningCanvas->SetGrid(0,1);
       //std::map<int, TGraphErrors>& spacingTuningGraphs = a.getSpacingTuningGraphs();
       std::map<int, TGraphErrors>& spacingTuningGraphsBad = a.getSpacingTuningGraphsBad();
       TH1D& spacingTuningFrame = a.getSpacingTuningFrame();
@@ -6682,18 +6683,18 @@ namespace insur {
       tuningImage.setName(tempSS.str());
 
       TH1D& spacingDistribution = a.getHistoOptimalSpacing(false);
-      TCanvas spacingCanvas;
-      spacingCanvas.SetFillColor(color_plot_background);
-      spacingCanvas.cd();
+      TCanvas* spacingCanvas = new TCanvas();
+      spacingCanvas->SetFillColor(color_plot_background);
+      spacingCanvas->cd();
       spacingDistribution.SetFillColor(Palette::color(1));
       spacingDistribution.Draw();
       RootWImage& spacingImage = spacingSummaryContent.addImage(spacingCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       spacingImage.setComment("Distribution of minimal spacing for low pT rejection @ standard window");
       spacingImage.setName("SpacingDistribution");
       TH1D& spacingDistributionAW = a.getHistoOptimalSpacing(true);
-      TCanvas spacingCanvasAW;
-      spacingCanvasAW.SetFillColor(color_plot_background);
-      spacingCanvasAW.cd();
+      TCanvas* spacingCanvasAW = new TCanvas();
+      spacingCanvasAW->SetFillColor(color_plot_background);
+      spacingCanvasAW->cd();
       spacingDistributionAW.SetFillColor(Palette::color(1));
       spacingDistributionAW.Draw();
       RootWImage& spacingImageAW = spacingSummaryContent.addImage(spacingCanvasAW, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
@@ -6715,9 +6716,9 @@ namespace insur {
         std::map<double, TProfile>& tuningProfiles = aProfileBag.getNamedProfiles(*itName);
 
         int myColor = 1;
-        TCanvas tuningCanvas;
-        tuningCanvas.SetFillColor(color_plot_background);
-        tuningCanvas.cd();
+        TCanvas* tuningCanvas = new TCanvas();
+        tuningCanvas->SetFillColor(color_plot_background);
+        tuningCanvas->cd();
 
         std::string plotOption = "E1";
         for (std::map<double, TProfile>::iterator itProfile = tuningProfiles.begin() ; itProfile!= tuningProfiles.end(); ++itProfile) {
@@ -6772,9 +6773,9 @@ namespace insur {
         std::map<double, TProfile>& turnonProfiles = aProfileBag.getNamedProfiles(*itName);
 
         int myColor = 1;
-        TCanvas turnonCanvas;
-        turnonCanvas.SetFillColor(color_plot_background);
-        turnonCanvas.cd();
+        TCanvas* turnonCanvas = new TCanvas();
+        turnonCanvas->SetFillColor(color_plot_background);
+        turnonCanvas->cd();
 
         std::string plotOption = "E1";
         tempSS.str("");

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6376,7 +6376,7 @@ namespace insur {
     //*   Trigger efficiency maps    *//
     //*                              *//
     //********************************//
-    mapBag myMapBag = a.getMapBag();
+    mapBag& myMapBag = a.getMapBag();
     std::map<double, TH2D>& efficiencyMaps = myMapBag.getMaps(mapBag::efficiencyMap);
     double maxPt = -1;
     // Check if the maps exist at all

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1144,8 +1144,8 @@ namespace insur {
     hadronAverageHitsGraph->Draw("same lp");
 
     // Number of hits
-    std::vector<TGraph> hadronGoodTracksFraction=a.getHadronGoodTracksFraction();
-    std::vector<double> hadronNeededHitsFraction=a.getHadronNeededHitsFraction();
+    std::vector<TGraph>& hadronGoodTracksFraction=a.getHadronGoodTracksFraction();
+    std::vector<double>& hadronNeededHitsFraction=a.getHadronNeededHitsFraction();
     myPad = myCanvas->GetPad(2);
     myPad->cd();
     TLegend* myLegend = new TLegend(0.75, 0.16, .95, .40);
@@ -2832,7 +2832,6 @@ namespace insur {
 	}
       }
     } // debugResolution
-    gStyle->SetOptStat(0);
 
 
     //********************************//
@@ -3638,24 +3637,33 @@ namespace insur {
     if (fullLayoutContent) fullLayoutContent->addItem(myImage);
 
     // Number of layers count
-    THStack* totalLayersEtaStack = new THStack();
-    if (totalEtaProfileLayers_) {
-      totalLayersEtaStack->Add(totalEtaProfileLayers_->ProjectionX());
-      totalEtaProfileLayers_->SetMarkerColor(kBlack);
-    }
-    if (totalEtaProfileLayersPixel_) {
-      totalLayersEtaStack->Add(totalEtaProfileLayersPixel_->ProjectionX());
-      totalEtaProfileLayersPixel_->SetMarkerColor(kBlack);
-    }
     std::unique_ptr<TCanvas> totalEtaProfileLayersFull(new TCanvas("totalEtaProfileLayersFull", "Full eta profile (Layers)", vis_std_canvas_sizeX, vis_std_canvas_sizeY));
     totalEtaProfileLayersFull->cd();
+    THStack* totalLayersEtaStack = new THStack();
+    TH1D* totalLayersCountOuter = (totalEtaProfileLayers_ ? (TH1D*)totalEtaProfileLayers_->ProjectionX()->Clone() : nullptr);
+    if (totalLayersCountOuter) {
+      totalLayersCountOuter->SetBit(1);
+      totalLayersEtaStack->Add(totalLayersCountOuter);
+      totalLayersCountOuter->SetMarkerStyle(8);
+      totalLayersCountOuter->SetMarkerSize(1);
+      totalLayersCountOuter->SetMarkerColor(Palette::color(1));
+    }
+    TH1D* totalLayersCountInner = (totalEtaProfileLayersPixel_ ? (TH1D*)totalEtaProfileLayersPixel_->ProjectionX()->Clone() : nullptr);
+    if (totalLayersCountInner) {   
+      totalLayersCountInner->SetBit(1);
+      totalLayersEtaStack->Add(totalLayersCountInner);
+      totalLayersCountInner->SetMarkerStyle(8);
+      totalLayersCountInner->SetMarkerSize(1);
+      totalLayersCountInner->SetMarkerColor(Palette::color(2));
+    }
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerStyle(8);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerSize(1);
+    ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerColor(kBlack);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMinimum(0.);
     totalLayersEtaStack->GetStack()->Last()->Draw();
     // Per detector here
-    if (totalEtaProfileLayers_) totalEtaProfileLayers_->Draw("same");
-    if (totalEtaProfileLayersPixel_) totalEtaProfileLayersPixel_->Draw("same");
+    if (totalLayersCountOuter) totalLayersCountOuter->Draw("same");
+    if (totalLayersCountInner) totalLayersCountInner->Draw("same");
     totalLayersEtaStack->GetStack()->Last()->Draw("same"); // To overwrite where total is the same as one of the two
     RootWImage* myImageLayers = new RootWImage(std::move(totalEtaProfileLayersFull), vis_std_canvas_sizeX, vis_std_canvas_sizeY);
     myImageLayers->setComment("Full layer coverage across eta (OT = blue, pixel = red)");

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1165,15 +1165,16 @@ namespace insur {
     for (unsigned int i=0;
          i<hadronGoodTracksFraction.size();
          ++i) {
-      TGraph& myGraph = hadronGoodTracksFraction.at(i);
-      //std::cerr << "Good Hadrons fractions at (" << i <<") has " << myGraph.GetN() << " points" << std::endl;
+      TGraph* myGraph = &hadronGoodTracksFraction.at(i);
+      //std::cerr << "Good Hadrons fractions at (" << i <<") has " << myGraph->GetN() << " points" << std::endl;
       //double xx, yy;
-      //myGraph.GetPoint(myGraph.GetN()-1, xx, yy);
+      //myGraph->GetPoint(myGraph->GetN()-1, xx, yy);
       //std::cerr << "Last point (x,y) = ("<< xx <<", " << yy <<")" << std::endl;
-      averages[i] = Analyzer::average(myGraph, geom_range_eta_regions);
-      closeGraph(myGraph);
-      myGraph.SetFillColor(Palette::color(i+1));
-      myGraph.Draw("same F");
+      averages[i] = Analyzer::average(*myGraph, geom_range_eta_regions);
+      closeGraph(*myGraph);
+      myGraph->SetFillColor(Palette::color(i+1));
+      myGraph->SetBit(1);
+      myGraph->Draw("same F");
       tempSS.str("");
       if (hadronNeededHitsFraction.at(i)!=Analyzer::ZeroHitsRequired) {
         if (hadronNeededHitsFraction.at(i)==Analyzer::OneHitRequired)
@@ -1182,7 +1183,7 @@ namespace insur {
           tempSS << int(hadronNeededHitsFraction.at(i)*100)
             << "%% hits required";
         fractionTitles[i]=tempSS.str();
-        myLegend->AddEntry(&myGraph, fractionTitles[i].c_str(), "F");
+        myLegend->AddEntry(myGraph, fractionTitles[i].c_str(), "F");
       }
     }
     ranger->Draw("sameaxis");

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -3654,6 +3654,7 @@ namespace insur {
       totalLayersCountOuter->SetMarkerStyle(8);
       totalLayersCountOuter->SetMarkerSize(1);
       totalLayersCountOuter->SetMarkerColor(Palette::color(1));
+      totalLayersCountOuter->SetStats(0);
     }
     TH1D* totalLayersCountInner = (totalEtaProfileLayersPixel_ ? (TH1D*)totalEtaProfileLayersPixel_->ProjectionX()->Clone() : nullptr);
     if (totalLayersCountInner) {   
@@ -3662,11 +3663,13 @@ namespace insur {
       totalLayersCountInner->SetMarkerStyle(8);
       totalLayersCountInner->SetMarkerSize(1);
       totalLayersCountInner->SetMarkerColor(Palette::color(2));
+      totalLayersCountInner->SetStats(0);
     }
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerStyle(8);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerSize(1);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerColor(kBlack);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMinimum(0.);
+    ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetStats(0);
     totalLayersEtaStack->GetStack()->Last()->Draw();
     // Per detector here
     if (totalLayersCountOuter) totalLayersCountOuter->Draw("same");

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -98,10 +98,10 @@ namespace insur {
    */
   void Vizard::buildVisualization(Tracker& am, InactiveSurfaces& is, bool simplified) {
 /*    int c = 0;
-    TGeoVolume* vol=NULL;
-    TGeoTranslation* trans=NULL;
-    TGeoCombiTrans* trafo=NULL;
-    Layer* current=NULL;
+    TGeoVolume* vol=nullptr;
+    TGeoTranslation* trans=nullptr;
+    TGeoCombiTrans* trafo=nullptr;
+    Layer* current=nullptr;
     std::vector<Module*> templates;
     // barrels
     if (simplified) {
@@ -520,7 +520,6 @@ namespace insur {
     RootWContent* myContentDetails;
     RootWTable* myTable;
     RootWImage* myImage;
-    TCanvas* myCanvas;
     TVirtualPad* myPad;
     std::string pageTitle="Material";
     if (name!="") pageTitle+=" (" +name+")";
@@ -548,16 +547,16 @@ namespace insur {
     std::map<int, std::vector<double> > averages;
 
     // Book histograms
-    TH1D *cr = NULL, *ci = NULL;
-    TH1D *acr = NULL, *aci = NULL, *ser = NULL, *sei = NULL, *sur = NULL, *sui = NULL;
+    TH1D *cr = nullptr, *ci = nullptr;
+    TH1D *acr = nullptr, *aci = nullptr, *ser = nullptr, *sei = nullptr, *sur = nullptr, *sui = nullptr;
 #ifdef MATERIAL_SHADOW
-    TH2D *ir = NULL, *ii = NULL;
+    TH2D *ir = nullptr, *ii = nullptr;
 #endif
-    TH2D *mapRad = NULL, *mapInt = NULL;
+    TH2D *mapRad = nullptr, *mapInt = nullptr;
     TProfile *crProf, *ciProf;
 
     // 1D OVERVIEW (FULL VOLUME)
-    myCanvas = new TCanvas(name_overviewMaterial.c_str());
+    std::unique_ptr<TCanvas> myCanvas(new TCanvas(name_overviewMaterial.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -581,7 +580,7 @@ namespace insur {
     ciProf->Draw("hist");
 
     // Put the full volume materials plots to the site
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Material in full volume");
     myImage->setName("matOverviewFull");
     myTable = new RootWTable();
@@ -641,7 +640,7 @@ namespace insur {
     myContent = new RootWContent("Categories details (Full volume)", false);
     myPage->addContent(myContent);
     // Work area re-init
-    myCanvas = new TCanvas(name_categoriesMaterial.c_str());
+    myCanvas.reset(new TCanvas(name_categoriesMaterial.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -693,7 +692,7 @@ namespace insur {
     //myCanvas->Modified();
 
     // Write asl category plots to web page
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Detailed");
     myImage->setName("matCategoriesFull");
     myTable = new RootWTable();
@@ -733,7 +732,7 @@ namespace insur {
 
     TLegend* compLegend = new TLegend(0.1,0.6,0.35,0.9);
 
-    myCanvas = new TCanvas(("componentsRI"+name).c_str());
+    myCanvas.reset(new TCanvas(("componentsRI"+name).c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -781,7 +780,7 @@ namespace insur {
 
     myContent->addItem(myTable);
 
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Material in full volume as a function of &eta; (excluding beam pipe and including services, supports and module material (split by component)");
     myImage->setName("matComponentsFull");
     myContent->addItem(myImage);
@@ -803,7 +802,7 @@ namespace insur {
 
     TLegend* servicesCompLegend = new TLegend(0.1,0.6,0.35,0.9);
 
-    myCanvas = new TCanvas(("ServicesComponentsRI"+name).c_str());
+    myCanvas.reset(new TCanvas(("ServicesComponentsRI"+name).c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -848,7 +847,7 @@ namespace insur {
     servicesCompLegend->Draw();
 
     myContent->addItem(myTable);
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation and interaction length distribution in eta by component type in services");
     myImage->setName("matServicesComponentsFull");
     myContent->addItem(myImage);
@@ -870,7 +869,7 @@ namespace insur {
 
     TLegend* compLegendTrackingVolume = new TLegend(0.1,0.6,0.35,0.9);
 
-    myCanvas = new TCanvas(("componentsTrackingVolumeRI"+name).c_str());
+    myCanvas.reset(new TCanvas(("componentsTrackingVolumeRI"+name).c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -924,7 +923,7 @@ namespace insur {
 
     myContentDetails->addItem(myTable);
 
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation and interaction length distribution in eta by component type in total tracking volume");
     myImage->setName("matComponentsTrackingVolume");
     myContentDetails->addItem(myImage);
@@ -933,12 +932,12 @@ namespace insur {
 
 
     // 1D OVERVIEW (TRACKING VOLUME)
-    TH1D *rTrackingVolume = NULL, *iTrackingVolume = NULL;
-    TProfile *rTrackingVolumeProf = NULL, *iTrackingVolumeProf = NULL;
+    TH1D *rTrackingVolume = nullptr, *iTrackingVolume = nullptr;
+    TProfile *rTrackingVolumeProf = nullptr, *iTrackingVolumeProf = nullptr;
     myContent = new RootWContent("1D Overview (Tracking volume)", false);
     myPage->addContent(myContent);
     // Work area re-init
-    myCanvas = new TCanvas(name_overviewMaterialTrackingVolume.c_str());
+    myCanvas.reset(new TCanvas(name_overviewMaterialTrackingVolume.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -964,7 +963,7 @@ namespace insur {
       iTrackingVolumeProf->Draw("hist");
     }
     // Write global tracking volume plots to web pag
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Material in tracking volume");
     myImage->setName("matOverviewTrackingVolume");
     myTable = new RootWTable();
@@ -996,7 +995,7 @@ namespace insur {
 
     TLegend* servicesTrackingVolumeLegend = new TLegend(0.1,0.6,0.35,0.9);
 
-    myCanvas = new TCanvas(("ServicesDetailsTrackingVolumeRI"+name).c_str());
+    myCanvas.reset(new TCanvas(("ServicesDetailsTrackingVolumeRI"+name).c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -1052,7 +1051,7 @@ namespace insur {
     servicesTrackingVolumeLegend->Draw();
 
     myContent->addItem(myTable);
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation and interaction length distribution in eta by component type in services");
     myImage->setName("matServicesDetailsTrackingVolume");
     myContent->addItem(myImage);
@@ -1060,7 +1059,7 @@ namespace insur {
 
 
     // Work area re-init
-    myCanvas = new TCanvas(name_countourMaterial.c_str());
+    myCanvas.reset(new TCanvas(name_countourMaterial.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -1075,7 +1074,7 @@ namespace insur {
     // radiation length in isolines
     ir = (TH2D*)a.getHistoIsoR().Clone();
     ir->SetNameTitle("isor", "Radiation Length Contours");
-    ir->SetContour(temperature_levels, NULL);
+    ir->SetContour(temperature_levels, nullptr);
     ir->SetXTitle("z");
     ir->SetYTitle("r");
     ir->Draw("COLZ");
@@ -1084,40 +1083,40 @@ namespace insur {
     // interaction length in isolines
     ii = (TH2D*)a.getHistoIsoI().Clone();
     ii->SetNameTitle("isoi", "Interaction Length Contours");
-    ii->SetContour(temperature_levels, NULL);
+    ii->SetContour(temperature_levels, nullptr);
     ii->SetXTitle("z");
     ii->SetYTitle("r");
     ii->Draw("COLZ");
     // Write isoline plots to web page
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Material 2D distributions");
     myImage->setName("matShadow");
     myContent->addItem(myImage);
 #endif // MATERIAL_SHADOW
 
     // Radiation length plot
-    myCanvas = new TCanvas(name_mapMaterialRadiation.c_str());
+    myCanvas.reset(new TCanvas(name_mapMaterialRadiation.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->cd();
     mapRad = (TH2D*)a.getHistoMapRadiation().Clone();
-    mapRad->SetContour(vis_temperature_levels, NULL);
+    mapRad->SetContour(vis_temperature_levels, nullptr);
     mapRad->GetZaxis()->SetLabelSize(0.02);  // palette font size
     //myCanvas->SetLogz();
     mapRad->Draw("COLZ");
-    myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation length material map");
     myImage->setName("matMapR");
     myContent->addItem(myImage);
 
     // Interaction length plot
-    myCanvas = new TCanvas(name_mapMaterialInteraction.c_str());
+    myCanvas.reset(new TCanvas(name_mapMaterialInteraction.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->cd();
     mapInt = (TH2D*)a.getHistoMapInteraction().Clone();
-    mapInt->SetContour(vis_temperature_levels, NULL);
+    mapInt->SetContour(vis_temperature_levels, nullptr);
     mapInt->GetZaxis()->SetLabelSize(0.02); // palette font size
     mapInt->Draw("COLZ");
-    myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Interaction length material map");
     myImage->setName("matMapI");
     myContent->addItem(myImage);
@@ -1127,7 +1126,7 @@ namespace insur {
     myPage->addContent(myContent);
 
     // Number of hits
-    myCanvas = new TCanvas(name_hadronsHitsNumber.c_str());
+    myCanvas.reset(new TCanvas(name_hadronsHitsNumber.c_str()));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -1188,7 +1187,7 @@ namespace insur {
     }
     ranger->Draw("sameaxis");
     myLegend->Draw();
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Hits occupancy & track efficiency for hadrons");
     myImage->setName("hadHitsTracks");
     myContent->addItem(myImage);
@@ -1361,13 +1360,13 @@ namespace insur {
       RootWImage* myImage;
 
       // Modules to Bundles
-      TCanvas *RZBundleCanvas = nullptr;
-      TCanvas *XYBundleNegCanvas = nullptr;
-      TCanvas *XYBundleCanvas = nullptr;   
-      std::vector<TCanvas*> XYPosBundlesDisks;
-      std::vector<TCanvas*> XYPosBundlesDiskSurfaces;
-      std::vector<TCanvas*> XYNegBundlesDisks;
-      std::vector<TCanvas*> XYNegBundlesDiskSurfaces;
+      std::unique_ptr<TCanvas> RZBundleCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYBundleNegCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYBundleCanvas = nullptr;   
+      std::vector<std::unique_ptr<TCanvas> > XYPosBundlesDisks;
+      std::vector<std::unique_ptr<TCanvas> > XYPosBundlesDiskSurfaces;
+      std::vector<std::unique_ptr<TCanvas> > XYNegBundlesDisks;
+      std::vector<std::unique_ptr<TCanvas> > XYNegBundlesDiskSurfaces;
    
       myContent = new RootWContent("Modules to Bundles");
       myPage->addContent(myContent);
@@ -1376,17 +1375,19 @@ namespace insur {
 					    XYPosBundlesDisks, XYPosBundlesDiskSurfaces, XYNegBundlesDisks, XYNegBundlesDiskSurfaces);
 
       if (RZBundleCanvas) {
-	myImage = new RootWImage(RZBundleCanvas, RZBundleCanvas->GetWindowWidth(), RZBundleCanvas->GetWindowHeight() );
+	const int windowWidth = RZBundleCanvas->GetWindowWidth();
+	const int windowHeight = RZBundleCanvas->GetWindowHeight();
+	myImage = new RootWImage(std::move(RZBundleCanvas), windowWidth, windowHeight);
 	myImage->setComment("(RZ) View : Tracker modules colored by their connections to Bundles. Different colors = different bundles.");
 	myContent->addItem(myImage);
       }
       if (XYBundleNegCanvas) {
-	myImage = new RootWImage(XYBundleNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYBundleNegCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYBundleCanvas) {
-	myImage = new RootWImage(XYBundleCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYBundleCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
@@ -1396,15 +1397,17 @@ namespace insur {
       RootWTable* positiveSideName = new RootWTable();
       positiveSideName->setContent(0, 0, "Positive cabling side:");
       myContent->addItem(positiveSideName);
-      for (const auto& XYPosDisk : XYPosBundlesDisks) {
-	  myImage = new RootWImage(XYPosDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYPosDisk->GetTitle());
-	  myContent->addItem(myImage);
+      for (auto& XYPosDisk : XYPosBundlesDisks) {
+	const std::string comment = XYPosDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYPosDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
+	myContent->addItem(myImage);
       }
-      for (const auto& XYPosSurface : XYPosBundlesDiskSurfaces) {
-	  myImage = new RootWImage(XYPosSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYPosSurface->GetTitle());
-	  myContent->addItem(myImage);
+      for (auto& XYPosSurface : XYPosBundlesDiskSurfaces) {
+	const std::string comment = XYPosSurface->GetTitle();
+	myImage = new RootWImage(std::move(XYPosSurface), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
+	myContent->addItem(myImage);
       }
       // NEGATIVE CABLING SIDE
       myContent = new RootWContent("");
@@ -1412,25 +1415,27 @@ namespace insur {
       RootWTable* negativeSideName = new RootWTable();
       negativeSideName->setContent(0, 0, "Negative cabling side:");
       myContent->addItem(negativeSideName);
-      for (const auto& XYNegDisk : XYNegBundlesDisks) {
-	  myImage = new RootWImage(XYNegDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYNegDisk->GetTitle());
-	  myContent->addItem(myImage);
+      for (auto& XYNegDisk : XYNegBundlesDisks) {
+	const std::string comment = XYNegDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYNegDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
+	myContent->addItem(myImage);
       }
-      for (const auto& XYNegSurface : XYNegBundlesDiskSurfaces) {
-	  myImage = new RootWImage(XYNegSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYNegSurface->GetTitle());
-	  myContent->addItem(myImage);
+      for (auto& XYNegSurface : XYNegBundlesDiskSurfaces) {
+	const std::string comment = XYNegSurface->GetTitle();
+	myImage = new RootWImage(std::move(XYNegSurface), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
+	myContent->addItem(myImage);
       }
 
 
       // Modules to DTCs
-      TCanvas *RZDTCCanvas = nullptr;
-      TCanvas *XYDTCNegCanvas = nullptr;
-      TCanvas *XYDTCNegFlatCanvas = nullptr;
-      TCanvas *XYDTCCanvas = nullptr; 
-      TCanvas *XYDTCFlatCanvas = nullptr; 
-      std::vector<TCanvas*> XYDTCCanvasesDisk;
+      std::unique_ptr<TCanvas> RZDTCCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYDTCNegCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYDTCNegFlatCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYDTCCanvas = nullptr; 
+      std::unique_ptr<TCanvas> XYDTCFlatCanvas = nullptr; 
+      std::vector<std::unique_ptr<TCanvas> > XYDTCCanvasesDisk;
        
       myContent = new RootWContent("Modules to DTCs");
       myPage->addContent(myContent);
@@ -1438,34 +1443,37 @@ namespace insur {
       createOuterCablingPlotsDTCs(tracker, RZDTCCanvas, XYDTCNegCanvas, XYDTCNegFlatCanvas, XYDTCCanvas, XYDTCFlatCanvas, XYDTCCanvasesDisk);
 
       if (RZDTCCanvas) {
-	myImage = new RootWImage(RZDTCCanvas, RZDTCCanvas->GetWindowWidth(), RZDTCCanvas->GetWindowHeight() );
+	const int windowWidth = RZDTCCanvas->GetWindowWidth();
+	const int windowHeight = RZDTCCanvas->GetWindowHeight();
+	myImage = new RootWImage(std::move(RZDTCCanvas), windowWidth,  windowHeight);
 	myImage->setComment("(RZ) View : Tracker modules colored by their connections to DTCs. 1 color = 1 DTC.");
 	myContent->addItem(myImage);
       }
       if (XYDTCNegCanvas) {
-	myImage = new RootWImage(XYDTCNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYDTCNegCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYDTCNegFlatCanvas) {
-	myImage = new RootWImage(XYDTCNegFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYDTCNegFlatCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYDTCCanvas) {
-	myImage = new RootWImage(XYDTCCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYDTCCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYDTCFlatCanvas) {
-	myImage = new RootWImage(XYDTCFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYDTCFlatCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYDTCCanvasDisk : XYDTCCanvasesDisk ) {
-	  myImage = new RootWImage(XYDTCCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	  myImage->setComment(XYDTCCanvasDisk->GetTitle());
-	  myContent->addItem(myImage);
+      for (auto& XYDTCCanvasDisk : XYDTCCanvasesDisk ) {
+	const std::string comment = XYDTCCanvasDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYDTCCanvasDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
+	myContent->addItem(myImage);
       }
       
       
@@ -1555,7 +1563,7 @@ namespace insur {
       RootWContent* dtcMapContent = new RootWContent("DTCs per track", false);
       myPage->addContent(dtcMapContent);
       
-      TCanvas* hitMapDTCCanvas = new TCanvas("hitmapDTCcanvas", "Hit Map DTC", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> hitMapDTCCanvas(new TCanvas("hitmapDTCcanvas", "Hit Map DTC", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
       hitMapDTCCanvas->cd();
       hitMapDTCCanvas->SetFillColor(color_plot_background);
       hitMapDTCCanvas->SetBorderMode(0);
@@ -1563,17 +1571,17 @@ namespace insur {
       analyzer.getMapPhiEtaDTC().Draw("colz");
       analyzer.getMapPhiEtaDTC().SetStats(0);
       hitMapDTCCanvas->Modified();
-      myImage = new RootWImage(hitMapDTCCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      myImage = new RootWImage(std::move(hitMapDTCCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       myImage->setComment("Number of distinct DTCs per track");
       dtcMapContent->addItem(myImage);
 
 
       // Modules to Services Channels (optical)
-      TCanvas *XYChannelOpticalNegCanvas = nullptr;
-      TCanvas *XYChannelOpticalNegFlatCanvas = nullptr;
-      TCanvas *XYChannelOpticalCanvas = nullptr; 
-      TCanvas *XYChannelOpticalFlatCanvas = nullptr; 
-      std::vector<TCanvas*> XYChannelOpticalCanvasesDisk;
+      std::unique_ptr<TCanvas> XYChannelOpticalNegCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYChannelOpticalNegFlatCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYChannelOpticalCanvas = nullptr; 
+      std::unique_ptr<TCanvas> XYChannelOpticalFlatCanvas = nullptr; 
+      std::vector<std::unique_ptr<TCanvas> > XYChannelOpticalCanvasesDisk;
        
       myContent = new RootWContent("Modules to Services Channels (optical)");
       myPage->addContent(myContent);
@@ -1581,39 +1589,40 @@ namespace insur {
       createOuterCablingPlotsServicesChannelsOptical(tracker, myCablingMap, XYChannelOpticalNegCanvas, XYChannelOpticalNegFlatCanvas, XYChannelOpticalCanvas, XYChannelOpticalFlatCanvas, XYChannelOpticalCanvasesDisk);
 
       if (XYChannelOpticalNegCanvas) {
-	myImage = new RootWImage(XYChannelOpticalNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelOpticalNegCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYChannelOpticalNegFlatCanvas) {
-	myImage = new RootWImage(XYChannelOpticalNegFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelOpticalNegFlatCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Negative cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYChannelOpticalCanvas) {
-	myImage = new RootWImage(XYChannelOpticalCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelOpticalCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYChannelOpticalFlatCanvas) {
-	myImage = new RootWImage(XYChannelOpticalFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelOpticalFlatCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYChannelOpticalCanvasDisk : XYChannelOpticalCanvasesDisk ) {
-	myImage = new RootWImage(XYChannelOpticalCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYChannelOpticalCanvasDisk->GetTitle());
+      for (auto& XYChannelOpticalCanvasDisk : XYChannelOpticalCanvasesDisk ) {
+	const std::string comment = XYChannelOpticalCanvasDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYChannelOpticalCanvasDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
 
 
       // Modules to Services Channels (powering)
-      TCanvas *XYChannelPowerNegCanvas = nullptr;
-      TCanvas *XYChannelPowerNegFlatCanvas = nullptr;
-      TCanvas *XYChannelPowerCanvas = nullptr; 
-      TCanvas *XYChannelPowerFlatCanvas = nullptr; 
-      std::vector<TCanvas*> XYChannelPowerCanvasesDisk;
-      std::vector<TCanvas*> XYNegChannelPowerCanvasesDisk;
+      std::unique_ptr<TCanvas> XYChannelPowerNegCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYChannelPowerNegFlatCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYChannelPowerCanvas = nullptr; 
+      std::unique_ptr<TCanvas> XYChannelPowerFlatCanvas = nullptr; 
+      std::vector<std::unique_ptr<TCanvas> > XYChannelPowerCanvasesDisk;
+      std::vector<std::unique_ptr<TCanvas> > XYNegChannelPowerCanvasesDisk;
        
       myContent = new RootWContent("Modules to Services Channels (powering)");
       myPage->addContent(myContent);
@@ -1623,18 +1632,19 @@ namespace insur {
       // POSITIVE CABLING SIDE
       myContent->addItem(positiveSideName);
       if (XYChannelPowerCanvas) {
-	myImage = new RootWImage(XYChannelPowerCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelPowerCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYChannelPowerFlatCanvas) {
-	myImage = new RootWImage(XYChannelPowerFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelPowerFlatCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Positive cabling side. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYChannelPowerCanvasDisk : XYChannelPowerCanvasesDisk ) {
-	myImage = new RootWImage(XYChannelPowerCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYChannelPowerCanvasDisk->GetTitle());
+      for (auto& XYChannelPowerCanvasDisk : XYChannelPowerCanvasesDisk ) {
+	const std::string comment = XYChannelPowerCanvasDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYChannelPowerCanvasDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
      
@@ -1643,18 +1653,19 @@ namespace insur {
       // NEGATIVE CABLING SIDE
       myContent->addItem(negativeSideName);
       if (XYChannelPowerNegCanvas) {
-	myImage = new RootWImage(XYChannelPowerNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelPowerNegCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel. Negative cabling side. (CMS +Z points towards the depth of the screen)");
 	myContent->addItem(myImage);
       }
       if (XYChannelPowerNegFlatCanvas) {
-	myImage = new RootWImage(XYChannelPowerNegFlatCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYChannelPowerNegFlatCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : Tracker barrel, untilted modules. Negative cabling side. (CMS +Z points towards the depth of the screen)");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYNegChannelPowerCanvasDisk : XYNegChannelPowerCanvasesDisk ) {
-	myImage = new RootWImage(XYNegChannelPowerCanvasDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYNegChannelPowerCanvasDisk->GetTitle());
+      for (auto& XYNegChannelPowerCanvasDisk : XYNegChannelPowerCanvasesDisk ) {
+	const std::string comment = XYNegChannelPowerCanvasDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYNegChannelPowerCanvasDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
 
@@ -1738,11 +1749,11 @@ namespace insur {
 
 
       // MODULES TO POWER CHAINS
-      std::vector<TCanvas*> ZPhiPowerChainLayerPlots;
-      TCanvas *XYPowerChainNegCanvas = nullptr;
-      TCanvas *XYPowerChainCentralCanvas = nullptr;
-      TCanvas *XYPowerChainCanvas = nullptr;
-      std::vector<TCanvas*> XYPosPowerChainsDiskSurfaces;
+      std::vector<std::unique_ptr<TCanvas> > ZPhiPowerChainLayerPlots;
+      std::unique_ptr<TCanvas> XYPowerChainNegCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYPowerChainCentralCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYPowerChainCanvas = nullptr;
+      std::vector<std::unique_ptr<TCanvas> > XYPosPowerChainsDiskSurfaces;
    
       myContent = new RootWContent("Modules to Serial Power Chains");
       myPage->addContent(myContent);  
@@ -1754,23 +1765,24 @@ namespace insur {
 
       // bpix
       myContent->addItem(barrelName);
-      for (const auto& ZPhiPlot : ZPhiPowerChainLayerPlots) {
-	myImage = new RootWImage(ZPhiPlot, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(ZPhiPlot->GetTitle());
+      for (auto& ZPhiPlot : ZPhiPowerChainLayerPlots) {
+	const std::string comment = ZPhiPlot->GetTitle();
+	myImage = new RootWImage(std::move(ZPhiPlot), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
       if (XYPowerChainNegCanvas) {
-	myImage = new RootWImage(XYPowerChainNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYPowerChainNegCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : BPIX, (-Z) end. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYPowerChainCentralCanvas) {
-	myImage = new RootWImage(XYPowerChainCentralCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYPowerChainCentralCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : BPIX, sensors at Z = 0 only. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYPowerChainCanvas) {
-	myImage = new RootWImage(XYPowerChainCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYPowerChainCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : BPIX, (+Z) end. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
@@ -1778,16 +1790,17 @@ namespace insur {
       myContent = new RootWContent("");
       myPage->addContent(myContent);
       myContent->addItem(forwardName);
-      for (const auto& XYPosSurface : XYPosPowerChainsDiskSurfaces) {
-	myImage = new RootWImage(XYPosSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYPosSurface->GetTitle());
+      for (auto& XYPosSurface : XYPosPowerChainsDiskSurfaces) {
+	const std::string comment = XYPosSurface->GetTitle();
+	myImage = new RootWImage(std::move(XYPosSurface), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
  
 
       // MODULES TO GBTS
-      std::vector<TCanvas*> ZPhiGBTLayerPlots;
-      std::vector<TCanvas*> XYPosGBTsDiskSurfaces;
+      std::vector<std::unique_ptr<TCanvas> > ZPhiGBTLayerPlots;
+      std::vector<std::unique_ptr<TCanvas> > XYPosGBTsDiskSurfaces;
    
       myContent = new RootWContent("Modules to LP GBTs");
       myPage->addContent(myContent);
@@ -1797,26 +1810,28 @@ namespace insur {
 				  XYPosGBTsDiskSurfaces);
       // bpix
       myContent->addItem(barrelName);
-      for (const auto& ZPhiPlot : ZPhiGBTLayerPlots) {
-	myImage = new RootWImage(ZPhiPlot, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(ZPhiPlot->GetTitle());
+      for (auto& ZPhiPlot : ZPhiGBTLayerPlots) {
+	const std::string comment = ZPhiPlot->GetTitle();
+	myImage = new RootWImage(std::move(ZPhiPlot), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
       // fpix and epix, (+z) end
       myContent = new RootWContent("");
       myPage->addContent(myContent);
       myContent->addItem(forwardName);
-      for (const auto& XYPosSurface : XYPosGBTsDiskSurfaces) {
-	myImage = new RootWImage(XYPosSurface, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYPosSurface->GetTitle());
+      for (auto& XYPosSurface : XYPosGBTsDiskSurfaces) {
+	const std::string comment = XYPosSurface->GetTitle();
+	myImage = new RootWImage(std::move(XYPosSurface), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
 
 
       // MODULES TO BUNDLES
-      TCanvas *XYBundleNegCanvas = nullptr;
-      TCanvas *XYBundlePosCanvas = nullptr;   
-      std::vector<TCanvas*> XYPosBundlesDisks;
+      std::unique_ptr<TCanvas> XYBundleNegCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYBundlePosCanvas = nullptr;   
+      std::vector<std::unique_ptr<TCanvas> > XYPosBundlesDisks;
    
       myContent = new RootWContent("Modules to Fiber Bundles");
       myPage->addContent(myContent);  
@@ -1827,12 +1842,12 @@ namespace insur {
       // bpix
       myContent->addItem(barrelName);
       if (XYBundleNegCanvas) {
-	myImage = new RootWImage(XYBundleNegCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYBundleNegCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : BPIX, (-Z) end. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
       if (XYBundlePosCanvas) {
-	myImage = new RootWImage(XYBundlePosCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYBundlePosCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : BPIX, (+Z) end. (CMS +Z points towards you)");
 	myContent->addItem(myImage);
       }
@@ -1840,17 +1855,18 @@ namespace insur {
       myContent = new RootWContent("");
       myPage->addContent(myContent);
       myContent->addItem(forwardName);
-      for (const auto& XYPosDisk : XYPosBundlesDisks) {
-	myImage = new RootWImage(XYPosDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYPosDisk->GetTitle());
+      for (auto& XYPosDisk : XYPosBundlesDisks) {
+	const std::string comment = XYPosDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYPosDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
 
 
       // MODULES TO DTCs
-      TCanvas *RZDTCCanvas = nullptr;
-      TCanvas *XYDTCPosCanvas = nullptr;   
-      std::vector<TCanvas*> XYPosDTCsDisks;
+      std::unique_ptr<TCanvas> RZDTCCanvas = nullptr;
+      std::unique_ptr<TCanvas> XYDTCPosCanvas = nullptr;   
+      std::vector<std::unique_ptr<TCanvas> > XYPosDTCsDisks;
        
       myContent = new RootWContent("Modules to DTCs");
       myPage->addContent(myContent);
@@ -1858,18 +1874,21 @@ namespace insur {
       createInnerCablingPlotsDTCs(tracker, RZDTCCanvas, XYDTCPosCanvas, XYPosDTCsDisks);
 
       if (RZDTCCanvas) {
-	myImage = new RootWImage(RZDTCCanvas, RZDTCCanvas->GetWindowWidth(), RZDTCCanvas->GetWindowHeight() );
+	const int windowWidth = RZDTCCanvas->GetWindowWidth();
+	const int windowHeight = RZDTCCanvas->GetWindowHeight();
+	myImage = new RootWImage(std::move(RZDTCCanvas), windowWidth, windowHeight);
 	myImage->setComment("(RZ) View : Inner Tracker modules colored by their connections to DTCs. 1 color <=> 1 DTC.");
 	myContent->addItem(myImage);
       }
       if (XYDTCPosCanvas) {
-	myImage = new RootWImage(XYDTCPosCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage = new RootWImage(std::move(XYDTCPosCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
 	myImage->setComment("(XY) Section : BPIX, (+Z) end. (CMS +Z points towards you). 1 color <=> 1 DTC.");
 	myContent->addItem(myImage);
       }
-      for (const auto& XYPosDisk : XYPosDTCsDisks) {
-	myImage = new RootWImage(XYPosDisk, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-	myImage->setComment(XYPosDisk->GetTitle());
+      for (auto& XYPosDisk : XYPosDTCsDisks) {
+	const std::string comment = XYPosDisk->GetTitle();
+	myImage = new RootWImage(std::move(XYPosDisk), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+	myImage->setComment(comment);
 	myContent->addItem(myImage);
       }
 
@@ -2683,7 +2702,7 @@ namespace insur {
 	gStyle->SetTitleW(1);
 	gStyle->SetOptStat("emr");
 	if (parametrizedResolutionLocalXBarrelMap[tag].GetEntries() != 0) {
-	  TCanvas* resoXBarCanvas = new TCanvas();
+	  std::unique_ptr<TCanvas> resoXBarCanvas(new TCanvas());
 	  resoXBarCanvas->SetFillColor(color_plot_background);
 	  resoXBarCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
@@ -2710,12 +2729,12 @@ namespace insur {
 	  const double normC = 1. / trackPhiBarrelDistribution[tag].Integral();
 	  trackPhiBarrelDistribution[tag].Scale(normC, "width");
 	  trackPhiBarrelDistribution[tag].Draw();
-	  RootWImage& resoXBarImage = parametrizedResolutionContent.addImage(resoXBarCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+	  RootWImage& resoXBarImage = parametrizedResolutionContent.addImage(std::move(resoXBarCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
 	  resoXBarImage.setComment(Form("Resolution on local X coordinate for %s barrel modules", tag.c_str()));
 	  resoXBarImage.setName(Form("Resolution on local X coordinate for %s barrel modules", tag.c_str()));
 	}
 	if (parametrizedResolutionLocalYBarrelMap[tag].GetEntries() != 0) {
-	  TCanvas* resoYBarCanvas = new TCanvas();
+	  std::unique_ptr<TCanvas> resoYBarCanvas(new TCanvas());
 	  resoYBarCanvas->SetFillColor(color_plot_background);
 	  resoYBarCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
@@ -2742,12 +2761,12 @@ namespace insur {
 	  const double normC = 1. / trackEtaBarrelDistribution[tag].Integral();
 	  trackEtaBarrelDistribution[tag].Scale(normC, "width");
 	  trackEtaBarrelDistribution[tag].Draw();
-	  RootWImage& resoYBarImage = parametrizedResolutionContent.addImage(resoYBarCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+	  RootWImage& resoYBarImage = parametrizedResolutionContent.addImage(std::move(resoYBarCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
 	  resoYBarImage.setComment(Form("Resolution on local Y coordinate for %s barrel modules", tag.c_str()));
 	  resoYBarImage.setName(Form("Resolution on local Y coordinate for %s barrel modules", tag.c_str()));
 	}
 	if (parametrizedResolutionLocalXEndcapsMap[tag].GetEntries() != 0) {
-	  TCanvas* resoXEndCanvas = new TCanvas();
+	  std::unique_ptr<TCanvas> resoXEndCanvas(new TCanvas());
 	  resoXEndCanvas->SetFillColor(color_plot_background);
 	  resoXEndCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
@@ -2774,12 +2793,12 @@ namespace insur {
 	  const double normC = 1. / trackPhiEndcapsDistribution[tag].Integral();
 	  trackPhiEndcapsDistribution[tag].Scale(normC, "width");
 	  trackPhiEndcapsDistribution[tag].Draw();
-	  RootWImage& resoXEndImage = parametrizedResolutionContent.addImage(resoXEndCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+	  RootWImage& resoXEndImage = parametrizedResolutionContent.addImage(std::move(resoXEndCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
 	  resoXEndImage.setComment(Form("Resolution on local X coordinate for %s endcaps modules", tag.c_str()));
 	  resoXEndImage.setName(Form("Resolution on local X coordinate for %s endcaps modules", tag.c_str()));
 	}
 	if (parametrizedResolutionLocalYEndcapsMap[tag].GetEntries() != 0) {
-	  TCanvas* resoYEndCanvas = new TCanvas();
+	  std::unique_ptr<TCanvas> resoYEndCanvas(new TCanvas());
 	  resoYEndCanvas->SetFillColor(color_plot_background);
 	  resoYEndCanvas->Divide(2,2);
 	  TVirtualPad* myPad;
@@ -2806,7 +2825,7 @@ namespace insur {
 	  const double normC = 1. / trackEtaEndcapsDistribution[tag].Integral();
 	  trackEtaEndcapsDistribution[tag].Scale(normC, "width");
 	  trackEtaEndcapsDistribution[tag].Draw();
-	  RootWImage& resoYEndImage = parametrizedResolutionContent.addImage(resoYEndCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+	  RootWImage& resoYEndImage = parametrizedResolutionContent.addImage(std::move(resoYEndCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
 	  resoYEndImage.setComment(Form("Resolution on local Y coordinate for %s endcaps modules", tag.c_str()));
 	  resoYEndImage.setName(Form("Resolution on local Y coordinate for %s endcaps modules", tag.c_str()));
 	}
@@ -2821,12 +2840,12 @@ namespace insur {
     //*                              *//
     //********************************//
     RootWImage* myImage;
-    TCanvas *summaryCanvas = NULL;
-    TCanvas *RZCanvas = NULL;
-    TCanvas *RZCanvasBarrel = NULL;
-    TCanvas *XYCanvas = NULL;
-    std::vector<TCanvas*> XYCanvasesEC;
-    TCanvas *myCanvas = NULL;
+    std::unique_ptr<TCanvas> summaryCanvas = nullptr;
+    std::unique_ptr<TCanvas> RZCanvas = nullptr;
+    std::unique_ptr<TCanvas> RZCanvasBarrel = nullptr;
+    std::unique_ptr<TCanvas> XYCanvas = nullptr;
+    std::vector<std::unique_ptr<TCanvas>> XYCanvasesEC;
+    std::unique_ptr<TCanvas> myCanvas = nullptr;
     createSummaryCanvasNicer(tracker, RZCanvas, RZCanvasBarrel, XYCanvas, XYCanvasesEC);
     if (isPixelTracker) {
       logINFO("PIXEL HACK for beam pipe");
@@ -2835,7 +2854,7 @@ namespace insur {
       beampipe->SetPoint(1, 2915/2., 45/2.);
       beampipe->SetPoint(2, 3804/2., 56.6/2.);
       beampipe->SetPoint(3, 3804/2.+1164, 91/2.);
-      for (auto XYCanvasEC : XYCanvasesEC) {
+      for (auto& XYCanvasEC : XYCanvasesEC) {
 	XYCanvasEC->cd();
 	drawCircle(22.5, true, 18); // "grey18"
       }
@@ -2860,60 +2879,63 @@ namespace insur {
     myPage->addContent(myContent);
 
     if (summaryCanvas) {
-      myImage = new RootWImage(summaryCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      myImage = new RootWImage(std::move(summaryCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       myImage->setComment("Tracker summary: modules position in XY (endcap and barrel), YZ and number of hits vs. eta.");
       myContent->addItem(myImage);
     }
-
+ 
     if (RZCanvas) {
-      myImage = new RootWImage(RZCanvas, RZCanvas->GetWindowWidth(), RZCanvas->GetWindowHeight() );
+      const int windowWidth = RZCanvas->GetWindowWidth();
+      const int windowHeight = RZCanvas->GetWindowHeight();
+      myImage = new RootWImage(std::move(RZCanvas), windowWidth, windowHeight);
       myImage->setComment("RZ positions of the modules.");
       myContent->addItem(myImage);
     }
     if ((RZCanvasBarrel) && isPixelTracker) {
-      myImage = new RootWImage(RZCanvasBarrel, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      myImage = new RootWImage(std::move(RZCanvasBarrel), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       myImage->setComment("RZ positions of the barrel modules.");
       myContent->addItem(myImage);
     }
     if (XYCanvas) {
-      myImage = new RootWImage(XYCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      myImage = new RootWImage(std::move(XYCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       myImage->setComment("XY Section of the tracker barrel.");
       myContent->addItem(myImage);
     }
-    for (auto XYCanvasEC : XYCanvasesEC ) {
-      myImage = new RootWImage(XYCanvasEC, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-      myImage->setComment(XYCanvasEC->GetTitle());
+    for (auto& XYCanvasEC : XYCanvasesEC ) {
+      const std::string comment = XYCanvasEC->GetTitle();
+      myImage = new RootWImage(std::move(XYCanvasEC), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      myImage->setComment(comment);
       myContent->addItem(myImage);
     }
 
     // Eta profile big plot
-    myCanvas = new TCanvas("EtaProfileHits", "Eta profile (Hit Modules)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    drawEtaProfiles(*myCanvas, analyzer);
-    myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myCanvas.reset(new TCanvas("EtaProfileHits", "Eta profile (Hit Modules)", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
+    drawEtaProfiles(*myCanvas.get(), analyzer);
+    myImage = new RootWImage(std::move(myCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Hit modules across eta.");
     myContent->addItem(myImage);
 
-    myCanvas = new TCanvas("EtaProfileSensors", "Eta profile (Hits)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    drawEtaProfilesSensors(*myCanvas, analyzer);
-    myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myCanvas.reset(new TCanvas("EtaProfileSensors", "Eta profile (Hits)", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
+    drawEtaProfilesSensors(*myCanvas.get(), analyzer);
+    myImage = new RootWImage(std::move(myCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Hit coverage across eta.");
     myContent->addItem(myImage);
 
-    myCanvas = new TCanvas("EtaProfileStubs", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    drawEtaProfilesStubs(*myCanvas, analyzer);
-    myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myCanvas.reset(new TCanvas("EtaProfileStubs", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
+    drawEtaProfilesStubs(*myCanvas.get(), analyzer);
+    myImage = new RootWImage(std::move(myCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Stub coverage across eta.");
     myContent->addItem(myImage);
 
-    myCanvas = new TCanvas("EtaProfileNumberOfStubsRatios", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    if (myCanvas) drawTracksDistributionPerNumberOfStubs(*myCanvas, analyzer, isPixelTracker);
-    myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myCanvas.reset(new TCanvas("EtaProfileNumberOfStubsRatios", "Eta profile (Stubs)", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
+    if (myCanvas) drawTracksDistributionPerNumberOfStubs(*myCanvas.get(), analyzer, isPixelTracker);
+    myImage = new RootWImage(std::move(myCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Stub coverage across eta.");
     myContent->addItem(myImage);
 
-    myCanvas = new TCanvas("EtaProfileLayers", "Eta profile (Layers)", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    drawEtaProfilesLayers(*myCanvas, analyzer);
-    myImage = new RootWImage(myCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myCanvas.reset(new TCanvas("EtaProfileLayers", "Eta profile (Layers)", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
+    drawEtaProfilesLayers(*myCanvas.get(), analyzer);
+    myImage = new RootWImage(std::move(myCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Layer coverage across eta.");
     myContent->addItem(myImage);
 
@@ -2926,7 +2948,7 @@ namespace insur {
       totalEtaProfileLayersPixel_ = &analyzer.getTotalEtaProfileLayers();
     }
 
-    TCanvas* hitMapCanvas = new TCanvas("hitmapcanvas", "Hit Map", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> hitMapCanvas(new TCanvas("hitmapcanvas", "Hit Map", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
     hitMapCanvas->cd();
     //gStyle->SetPalette(1);
     hitMapCanvas->SetFillColor(color_plot_background);
@@ -2935,7 +2957,7 @@ namespace insur {
     analyzer.getMapPhiEta().Draw("colz");
     analyzer.getMapPhiEta().SetStats(0);
     hitMapCanvas->Modified();
-    myImage = new RootWImage(hitMapCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(hitMapCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Hit coverage in eta, phi");
     myContent->addItem(myImage);
 
@@ -3125,7 +3147,7 @@ namespace insur {
     for (auto& layerIt : coveragePerLayer) {
       const std::string layerName = layerIt.first;
 
-      TCanvas* myCanvas = new TCanvas(Form("LayerCoverage%s%s", layerName.c_str(), type.c_str()), ("Layer eta coverage (" + type + ")").c_str(), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> myCanvas(new TCanvas(Form("LayerCoverage%s%s", layerName.c_str(), type.c_str()), ("Layer eta coverage (" + type + ")").c_str(), vis_std_canvas_sizeX, vis_min_canvas_sizeY));
       myCanvas->cd();
 
       // Distribution of tracks with at least 1 hit / stub.
@@ -3202,7 +3224,7 @@ namespace insur {
 	zoomedLegend->Draw();
       }
 
-      RootWImage* myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage* myImage = new RootWImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       const std::string title = (type.find("stub") != std::string::npos ? "stub" : type);
       myImage->setComment("Layer coverage in eta for " + title + "s.");
       myContent->addItem(myImage);
@@ -3210,7 +3232,7 @@ namespace insur {
 
     // IT only: add tables with detailed 3-hit stubs counts, per ring transition.
     if (is3HitsStubStudy && !stubWith3HitsCountPerDiskAndRing.empty()) {
-      for (const auto& diskIt : stubWith3HitsCountPerDiskAndRing) {
+      for (auto& diskIt : stubWith3HitsCountPerDiskAndRing) {
 	RootWTable* stubWith3HitsCountTable = new RootWTable();
 	const std::string diskName = diskIt.first;
 	const std::map<int, double>& stubWith3HitsCountPerRing = diskIt.second;
@@ -3218,7 +3240,7 @@ namespace insur {
 	stubWith3HitsCountTable->setContent(1, 0, "Ring transition (Ring i & i+1):");
 	stubWith3HitsCountTable->setContent(2, 0, "Fraction of tracks (‰)");
 
-	for (const auto& ringTransitionIt : stubWith3HitsCountPerRing) {
+	for (auto& ringTransitionIt : stubWith3HitsCountPerRing) {
 	  const int ringTransition = ringTransitionIt.first;
 	  const double stubWith3HitsCount = ringTransitionIt.second;
 	  stubWith3HitsCountTable->setContent(1, ringTransition, ringTransition);
@@ -3266,8 +3288,8 @@ namespace insur {
 
   static int nLayoutCanvases = 0;
   
-  TCanvas* Vizard::drawFullLayoutRZ() {
-    TCanvas* result = nullptr;
+  std::unique_ptr<TCanvas> Vizard::drawFullLayoutRZ() {
+    std::unique_ptr<TCanvas> result = nullptr;
     PlotDrawer<YZ, Type> yzDrawer;
 
     for (unsigned int i=0; i< trackers_.size(); ++i) {
@@ -3277,16 +3299,16 @@ namespace insur {
 
     int rzCanvasX = vis_max_canvas_sizeX;
     int rzCanvasY = vis_min_canvas_sizeY;
-    result = new TCanvas(Form("FullRZCanvas%d", nLayoutCanvases++), "RZView Canvas (full layout)", rzCanvasX, rzCanvasY );
+    result.reset(new TCanvas(Form("FullRZCanvas%d", nLayoutCanvases++), "RZView Canvas (full layout)", rzCanvasX, rzCanvasY ));
     result->cd();
-    yzDrawer.drawFrame<SummaryFrameStyle>(*result);
-    yzDrawer.drawModules<ContourStyle>(*result);
+    yzDrawer.drawFrame<SummaryFrameStyle>(*result.get());
+    yzDrawer.drawModules<ContourStyle>(*result.get());
 
     return result;
   }
 
-  TCanvas* Vizard::drawFullLayoutServicesRZ() {
-    TCanvas* result = drawFullLayoutRZ();
+  std::unique_ptr<TCanvas> Vizard::drawFullLayoutServicesRZ() {
+    std::unique_ptr<TCanvas> result = drawFullLayoutRZ();
     result->cd();
     for (auto& matBud : materialBudgets_ ) {
       std::vector<InactiveElement> allServices = matBud->getAllServices();
@@ -3310,8 +3332,8 @@ namespace insur {
   }
 
   
-  TCanvas* Vizard::drawFullLayoutBarrelXY() {
-    TCanvas* result = nullptr;
+  std::unique_ptr<TCanvas> Vizard::drawFullLayoutBarrelXY() {
+    std::unique_ptr<TCanvas> result = nullptr;
     PlotDrawer<XY, Type> xyDrawer;
 
     for (unsigned int i=0; i< trackers_.size(); ++i) {
@@ -3321,10 +3343,10 @@ namespace insur {
 
     int xyCanvasX = vis_min_canvas_sizeX;
     int xyCanvasY = vis_min_canvas_sizeY;
-    result = new TCanvas("FullXYCanvas", "XYView Canvas (full layout)", xyCanvasX, xyCanvasY );
+    result.reset(new TCanvas("FullXYCanvas", "XYView Canvas (full layout)", xyCanvasX, xyCanvasY ));
     result->cd();
-    xyDrawer.drawFrame<SummaryFrameStyle>(*result);
-    xyDrawer.drawModules<ContourStyle>(*result);
+    xyDrawer.drawFrame<SummaryFrameStyle>(*result.get());
+    xyDrawer.drawModules<ContourStyle>(*result.get());
 
     return result;
   }
@@ -3403,7 +3425,7 @@ namespace insur {
 
     TLegend* compLegend = new TLegend(0.1,0.6,0.35,0.9);
 
-    TCanvas* myCanvas = new TCanvas("FullLayoutMaterialComponentsTrackingVolumeRI");
+    std::unique_ptr<TCanvas> myCanvas(new TCanvas("FullLayoutMaterialComponentsTrackingVolumeRI"));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     TVirtualPad* myPad = myCanvas->GetPad(0);
@@ -3434,7 +3456,7 @@ namespace insur {
     compLegend->Draw();
 
     materialComponentsContent->addItem(myTable);
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation and interaction length distribution in eta by component type in total tracking volume");
     myImage->setName("fullLayoutMatComponentsTrackingVolume");
     materialComponentsContent->addItem(myImage);
@@ -3462,7 +3484,7 @@ namespace insur {
     THStack* iCompCategoryTrackingVolumeStack = new THStack("icompcategorytrackingvolumestack", "Interaction Length by Category in tracking volume");
     THStack* dummy = new THStack("dummy", "dummy");
 
-    myCanvas = new TCanvas("FullLayoutMaterialCategoriesTrackingVolumeRI");
+    myCanvas.reset(new TCanvas("FullLayoutMaterialCategoriesTrackingVolumeRI"));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -3485,16 +3507,16 @@ namespace insur {
     compLegend->Draw();
 
     materialCategoriesContent->addItem(myTable);
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Radiation and interaction length distribution in eta by category in total tracking volume");
     myImage->setName("fullLayoutMatCategoriesTrackingVolume");
     materialCategoriesContent->addItem(myImage);
    
     // 1D OVERVIEW (TRACKING VOLUME)
-    TH1D *cr = NULL, *ci = NULL;
+    TH1D *cr = nullptr, *ci = nullptr;
     TProfile *crProf, *ciProf;
     // Work area re-init
-    myCanvas = new TCanvas("FullLayoutMaterialOverviewTrackingVolumeRI");
+    myCanvas.reset(new TCanvas("FullLayoutMaterialOverviewTrackingVolumeRI"));
     myCanvas->SetFillColor(color_plot_background);
     myCanvas->Divide(2, 1);
     myPad = myCanvas->GetPad(0);
@@ -3520,7 +3542,7 @@ namespace insur {
       ciProf->Draw("hist");
     }
     // Write global tracking volume plots to web pag
-    myImage = new RootWImage(myCanvas, 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(myCanvas), 2*vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Material in total tracking volume");
     myImage->setName("fullLayoutMatOverviewTrackingVolume");
     myTable = new RootWTable();
@@ -3556,26 +3578,32 @@ namespace insur {
     //********************************//
 
     // Detector full layout
-    TCanvas* aLayout = drawFullLayoutRZ();
-    TCanvas* aLayoutServices = drawFullLayoutServicesRZ();
-    TCanvas* aLayoutXY = drawFullLayoutBarrelXY();
+    std::unique_ptr<TCanvas> aLayout = drawFullLayoutRZ();
+    std::unique_ptr<TCanvas> aLayoutServices = drawFullLayoutServicesRZ();
+    std::unique_ptr<TCanvas> aLayoutXY = drawFullLayoutBarrelXY();
     if (aLayout||aLayoutXY) {
       fullLayoutContent = new RootWContent("Full layout Geometry", true);
       myPage->addContent(fullLayoutContent);
       if (aLayout) {
-	RootWImage* anImage = new RootWImage(aLayout, aLayout->GetWindowWidth(), aLayout->GetWindowHeight() );
+	const int windowWidth = aLayout->GetWindowWidth();
+	const int windowHeight = aLayout->GetWindowHeight();
+	RootWImage* anImage = new RootWImage(std::move(aLayout), windowWidth, windowHeight);
 	anImage->setComment("RZ position of the modules (full layout)");
 	anImage->setName("fullLayout");
 	fullLayoutContent->addItem(anImage);
       }
       if (aLayoutXY) {
-	RootWImage* anImage = new RootWImage(aLayoutXY, aLayoutXY->GetWindowWidth(), aLayoutXY->GetWindowHeight() );
+	const int windowWidth = aLayoutXY->GetWindowWidth();
+	const int windowHeight = aLayoutXY->GetWindowHeight();
+	RootWImage* anImage = new RootWImage(std::move(aLayoutXY), windowWidth, windowHeight);
 	anImage->setComment("XY position of the barrel modules (full layout)");
 	anImage->setName("fullLayoutBarrelXY");
 	fullLayoutContent->addItem(anImage);
       }
       if (aLayoutServices) {
-	RootWImage* anImage = new RootWImage(aLayoutServices, aLayoutServices->GetWindowWidth(), aLayoutServices->GetWindowHeight() );
+	const int windowWidth = aLayoutServices->GetWindowWidth();
+	const int windowHeight = aLayoutServices->GetWindowHeight();
+	RootWImage* anImage = new RootWImage(std::move(aLayoutServices), windowWidth, windowHeight);
 	anImage->setComment("RZ position of the modules (full layout with services)");
 	anImage->setName("fullLayout");
 	fullLayoutContent->addItem(anImage);
@@ -3594,7 +3622,7 @@ namespace insur {
     THStack* totalEtaStack = new THStack();
     if (totalEtaProfileSensors_) totalEtaStack->Add(totalEtaProfileSensors_->ProjectionX());
     if (totalEtaProfileSensorsPixel_) totalEtaStack->Add(totalEtaProfileSensorsPixel_->ProjectionX());
-    TCanvas* totalEtaProfileFull = new TCanvas("TotalEtaProfileFull", "Full eta profile (Hits)", vis_std_canvas_sizeX, vis_std_canvas_sizeY);
+    std::unique_ptr<TCanvas> totalEtaProfileFull(new TCanvas("TotalEtaProfileFull", "Full eta profile (Hits)", vis_std_canvas_sizeX, vis_std_canvas_sizeY));
     totalEtaProfileFull->cd();
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerStyle(8);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerSize(1);
@@ -3604,7 +3632,7 @@ namespace insur {
     drawEtaProfilesSensors(*totalEtaProfileFull, analyzer, false);
     drawEtaProfilesSensors(*totalEtaProfileFull, pixelAnalyzer, false);
     totalEtaStack->GetStack()->Last()->Draw("same");
-    RootWImage* myImage = new RootWImage(totalEtaProfileFull, vis_std_canvas_sizeX, vis_std_canvas_sizeY);
+    RootWImage* myImage = new RootWImage(std::move(totalEtaProfileFull), vis_std_canvas_sizeX, vis_std_canvas_sizeY);
     myImage->setComment("Full hit coverage across eta");
     if (fullLayoutContent) fullLayoutContent->addItem(myImage);
 
@@ -3612,13 +3640,13 @@ namespace insur {
     THStack* totalLayersEtaStack = new THStack();
     if (totalEtaProfileLayers_) {
       totalLayersEtaStack->Add(totalEtaProfileLayers_->ProjectionX());
-      totalEtaProfileLayers_->SetMarkerColor(Palette::color(1));
+      totalEtaProfileLayers_->SetMarkerColor(kBlack);
     }
     if (totalEtaProfileLayersPixel_) {
       totalLayersEtaStack->Add(totalEtaProfileLayersPixel_->ProjectionX());
-      totalEtaProfileLayersPixel_->SetMarkerColor(Palette::color(2));
+      totalEtaProfileLayersPixel_->SetMarkerColor(kBlack);
     }
-    TCanvas* totalEtaProfileLayersFull = new TCanvas("totalEtaProfileLayersFull", "Full eta profile (Layers)", vis_std_canvas_sizeX, vis_std_canvas_sizeY);
+    std::unique_ptr<TCanvas> totalEtaProfileLayersFull(new TCanvas("totalEtaProfileLayersFull", "Full eta profile (Layers)", vis_std_canvas_sizeX, vis_std_canvas_sizeY));
     totalEtaProfileLayersFull->cd();
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerStyle(8);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerSize(1);
@@ -3628,7 +3656,7 @@ namespace insur {
     if (totalEtaProfileLayers_) totalEtaProfileLayers_->Draw("same");
     if (totalEtaProfileLayersPixel_) totalEtaProfileLayersPixel_->Draw("same");
     totalLayersEtaStack->GetStack()->Last()->Draw("same"); // To overwrite where total is the same as one of the two
-    RootWImage* myImageLayers = new RootWImage(totalEtaProfileLayersFull, vis_std_canvas_sizeX, vis_std_canvas_sizeY);
+    RootWImage* myImageLayers = new RootWImage(std::move(totalEtaProfileLayersFull), vis_std_canvas_sizeX, vis_std_canvas_sizeY);
     myImageLayers->setComment("Full layer coverage across eta (OT = blue, pixel = red)");
     if (fullLayoutContent) fullLayoutContent->addItem(myImageLayers);
     
@@ -3735,8 +3763,8 @@ namespace insur {
     // (also todo: handle this properly: with a not-hardcoded model)
     myContent = new RootWContent("Distributions and models");
     myPage->addContent(myContent);
-    TCanvas* bandWidthCanvas = new TCanvas("ModuleBandwidthC", "Modules needed bandwidthC", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
-    TCanvas* moduleHitCanvas = new TCanvas("ModuleHitC", "Module hit countC", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> bandWidthCanvas(new TCanvas("ModuleBandwidthC", "Modules needed bandwidthC", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
+    std::unique_ptr<TCanvas> moduleHitCanvas(new TCanvas("ModuleHitC", "Module hit countC", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
     bandWidthCanvas->SetLogy(1);
     moduleHitCanvas->SetLogy(1);
 
@@ -3749,14 +3777,14 @@ namespace insur {
     myLegend->AddEntry(&bandwidthDistribution, "Unsparsified", "l");
     myLegend->AddEntry(&bandwidthDistributionSparsified, "Sparsified", "l");
     myLegend->Draw();
-    RootWImage* myImage = new RootWImage(bandWidthCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage* myImage = new RootWImage(std::move(bandWidthCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Module bandwidth distribution in the sparsified and unsparsified model");
     myContent->addItem(myImage);
 
     moduleHitCanvas->cd();
     TH1D& chanHitDistribution = analyzer.getChanHitDistribution();
     chanHitDistribution.Draw();
-    myImage = new RootWImage(moduleHitCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    myImage = new RootWImage(std::move(moduleHitCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage->setComment("Distribution of number of hits per bunch crossing (each sensor is counted separately)");
     myContent->addItem(myImage);
 
@@ -3820,8 +3848,8 @@ namespace insur {
 
     myContent = &myPage->addContent("Trigger bandwidth and frequency maps", true);
 
-    TCanvas* triggerDataBandwidthCanvas = new TCanvas();
-    TCanvas* triggerFrequencyPerEventCanvas = new TCanvas();
+    std::unique_ptr<TCanvas> triggerDataBandwidthCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> triggerFrequencyPerEventCanvas(new TCanvas());
 
     PlotDrawer<YZ, Type, Max> yzbwDrawer(0, 0); // we take the MAX because the Analyzer only sweeps across the first quadrant (up to PI/2),
     PlotDrawer<YZ, Type, Max> yztfDrawer(0, 0); // so there's plenty modules in Phi which don't have their property set, but Max disregards all the 0's
@@ -3829,17 +3857,17 @@ namespace insur {
     yzbwDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL | ENDCAP);
     yztfDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end(), BARREL | ENDCAP);
 
-    yzbwDrawer.drawFrame<HistogramFrameStyle>(*triggerDataBandwidthCanvas);
-    yztfDrawer.drawFrame<HistogramFrameStyle>(*triggerFrequencyPerEventCanvas);
+    yzbwDrawer.drawFrame<HistogramFrameStyle>(*triggerDataBandwidthCanvas.get());
+    yztfDrawer.drawFrame<HistogramFrameStyle>(*triggerFrequencyPerEventCanvas.get());
 
-    yzbwDrawer.drawModules<ContourStyle>(*triggerDataBandwidthCanvas);
-    yztfDrawer.drawModules<ContourStyle>(*triggerFrequencyPerEventCanvas);
+    yzbwDrawer.drawModules<ContourStyle>(*triggerDataBandwidthCanvas.get());
+    yztfDrawer.drawModules<ContourStyle>(*triggerFrequencyPerEventCanvas.get());
 
-    RootWImage& triggerDataBandwidthImage = myContent->addImage(triggerDataBandwidthCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& triggerDataBandwidthImage = myContent->addImage(std::move(triggerDataBandwidthCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     triggerDataBandwidthImage.setComment("Map of the bandwidth for trigger data in Gbps");
     triggerDataBandwidthImage.setName("triggerDataBandwidthMap");
 
-    RootWImage& triggerFrequencyPerEventImage = myContent->addImage(triggerFrequencyPerEventCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& triggerFrequencyPerEventImage = myContent->addImage(std::move(triggerFrequencyPerEventCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     triggerFrequencyPerEventImage.setComment("Map of the trigger frequency per event (a.k.a. stubs per event)");
     triggerFrequencyPerEventImage.setName("triggerFrequencyPerEventMap");
 
@@ -3858,14 +3886,14 @@ namespace insur {
         myContent = &myPage->addContent(std::string("Stub rate plots (") + layer.first + ")", false);
         currCntName = layer.first;
       }
-      TCanvas* graphCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> graphCanvas(new TCanvas());
       graphCanvas->cd();
       totalHisto->SetLineColor(1);
       totalHisto->SetMinimum(trueHisto->GetMinimum()*.9 < 0.1 ? 0 : trueHisto->GetMinimum()*.9);
       totalHisto->Draw();
       trueHisto->SetLineColor(2);
       trueHisto->Draw("SAME");
-      RootWImage& graphImage = myContent->addImage(graphCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& graphImage = myContent->addImage(std::move(graphCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       graphImage.setComment("Stub rate for layer " + any2str(layer.second) + " (MHz/cm^2)");
       graphImage.setName("stubRate" + layer.first + any2str(layer.second));
 
@@ -3899,14 +3927,14 @@ namespace insur {
     
     myPage->addContent("Processor inbound connections").addTable().setContent(processorSummary.getContent());
     RootWContent& sharedConnContent = myPage->addContent("Processor shared inbound connections", false);
-    TCanvas* sharedConnCanvas = new TCanvas();
+    std::unique_ptr<TCanvas> sharedConnCanvas(new TCanvas());
     sharedConnCanvas->cd();
     TH2I& sharedConnMap = analyzer.getProcessorCommonConnectionMap();
     sharedConnMap.GetXaxis()->LabelsOption("v");
     sharedConnMap.GetXaxis()->SetLabelSize(0.03);
     sharedConnMap.GetYaxis()->SetLabelSize(0.03);
     sharedConnMap.Draw("colz");
-    RootWImage& sharedConnImage = sharedConnContent.addImage(sharedConnCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& sharedConnImage = sharedConnContent.addImage(std::move(sharedConnCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     sharedConnImage.setComment("Map of the shared processor connections (on the diagonal unshared connections are reported)");
     sharedConnImage.setName("sharedConnMap");
 
@@ -3924,9 +3952,9 @@ namespace insur {
 
     RootWContent& myContent = myPage->addContent("Module outbound connection maps", true);
 
-    TCanvas* moduleConnectionEtaCanvas = new TCanvas();
-    TCanvas* moduleConnectionPhiCanvas = new TCanvas();
-    TCanvas* moduleConnectionEndcapPhiCanvas = new TCanvas();
+    std::unique_ptr<TCanvas> moduleConnectionEtaCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> moduleConnectionPhiCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> moduleConnectionEndcapPhiCanvas(new TCanvas());
 
     struct EtaConnections {
       const ModuleConnectionMap& mm_;
@@ -3947,8 +3975,8 @@ namespace insur {
     xyDrawer.addModules<CheckType<BARREL>>(tracker.modules().begin(), tracker.modules().end());
     xyecDrawer.addModules<CheckType<ENDCAP>>(tracker.modules().begin(), tracker.modules().end());
 
-    yzDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEtaCanvas);
-    xyDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionPhiCanvas);
+    yzDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEtaCanvas.get());
+    xyDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionPhiCanvas.get());
     std::pair<Circle, Circle> petal = analyzer.getSampleTriggerPetal();
     TArc a1(petal.first.x0, petal.first.y0, petal.first.r, (XYPoint(petal.first.x0, petal.first.y0)).Phi()*180./M_PI + 180.);
     TArc a2(petal.second.x0, petal.second.y0, petal.second.r, 0., (XYPoint(petal.second.x0, petal.second.y0)).Phi()*180./M_PI + 180.);
@@ -3958,14 +3986,14 @@ namespace insur {
     a1.Draw("only");
     a2.Draw("only");
 
-    xyecDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEndcapPhiCanvas);
+    xyecDrawer.drawFrame<HistogramFrameStyle>(*moduleConnectionEndcapPhiCanvas.get());
     moduleConnectionEndcapPhiCanvas->cd();
     a1.Draw("only");
     a2.Draw("only");
 
-    yzDrawer.drawModules<ContourStyle>(*moduleConnectionEtaCanvas);
-    xyDrawer.drawModules<ContourStyle>(*moduleConnectionPhiCanvas);
-    xyecDrawer.drawModules<ContourStyle>(*moduleConnectionEndcapPhiCanvas);
+    yzDrawer.drawModules<ContourStyle>(*moduleConnectionEtaCanvas.get());
+    xyDrawer.drawModules<ContourStyle>(*moduleConnectionPhiCanvas.get());
+    xyecDrawer.drawModules<ContourStyle>(*moduleConnectionEndcapPhiCanvas.get());
 
 
 
@@ -3977,32 +4005,32 @@ namespace insur {
     moduleConnectionEtaCanvas->cd();
     moduleConnectionEtaMap.Draw("colz");
     */
-    RootWImage& moduleConnectionEtaImage = myContent.addImage(moduleConnectionEtaCanvas, vis_max_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& moduleConnectionEtaImage = myContent.addImage(std::move(moduleConnectionEtaCanvas), vis_max_canvas_sizeX, vis_min_canvas_sizeY);
     moduleConnectionEtaImage.setComment("Map of the number of connections to trigger processors per module (eta section)");
     moduleConnectionEtaImage.setName("moduleConnectionEtaMap");
     /*
        moduleConnectionPhiCanvas->cd();
        moduleConnectionPhiMap.Draw("colz");
        */
-    RootWImage& moduleConnectionPhiImage = myContent.addImage(moduleConnectionPhiCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& moduleConnectionPhiImage = myContent.addImage(std::move(moduleConnectionPhiCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     moduleConnectionPhiImage.setComment("Map of the number of connections to trigger processors per barrel module (phi section)");
     moduleConnectionPhiImage.setName("moduleConnectionPhiMap");
 
     // moduleConnectionEndcapPhiCanvas->cd();
     // moduleConnectionEndcapPhiMap.Draw("colz");
 
-    RootWImage& moduleConnectionEndcapPhiImage = myContent.addImage(moduleConnectionEndcapPhiCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& moduleConnectionEndcapPhiImage = myContent.addImage(std::move(moduleConnectionEndcapPhiCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     moduleConnectionEndcapPhiImage.setComment("Map of the number of connections to trigger processors per endcap module (phi section)");
     moduleConnectionEndcapPhiImage.setName("moduleConnectionEndcapPhiMap");
 
     //    myContent = myPage->addContent("Module Connections distribution", true);
 
-    TCanvas* moduleConnectionsCanvas = new TCanvas("ModuleConnectionsC", "Modules connectionsC", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> moduleConnectionsCanvas(new TCanvas("ModuleConnectionsC", "Modules connectionsC", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
     moduleConnectionsCanvas->cd();
     TH1I& moduleConnectionsDistribution = analyzer.getModuleConnectionsDistribution();
     moduleConnectionsDistribution.SetFillColor(Palette::color(2));
     moduleConnectionsDistribution.Draw();
-    RootWImage& myImage = myContent.addImage(moduleConnectionsCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& myImage = myContent.addImage(std::move(moduleConnectionsCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
     myImage.setComment("Module connections distribution");
 
     return true;
@@ -4052,14 +4080,14 @@ namespace insur {
           scenarioStr = "noMS";
         }
 
-        TCanvas* linearMomentumCanvas = new TCanvas();
-        TCanvas* momentumCanvas = new TCanvas();
-        TCanvas* distanceCanvas = new TCanvas();
-        TCanvas* angleCanvas = new TCanvas();
-        TCanvas* ctgThetaCanvas = new TCanvas();
-        TCanvas* etaCanvas = new TCanvas();
-        TCanvas* z0Canvas = new TCanvas();
-        TCanvas* pCanvas = new TCanvas();
+        std::unique_ptr<TCanvas> linearMomentumCanvas(new TCanvas());
+        std::unique_ptr<TCanvas> momentumCanvas(new TCanvas());
+        std::unique_ptr<TCanvas> distanceCanvas(new TCanvas());
+        std::unique_ptr<TCanvas> angleCanvas(new TCanvas());
+        std::unique_ptr<TCanvas> ctgThetaCanvas(new TCanvas());
+        std::unique_ptr<TCanvas> etaCanvas(new TCanvas());
+        std::unique_ptr<TCanvas> z0Canvas(new TCanvas());
+        std::unique_ptr<TCanvas> pCanvas(new TCanvas());
 
         int myColor=0;
         int nRebin = 2;
@@ -4249,28 +4277,28 @@ namespace insur {
             plotOption = "p same";
           }
         }
-        RootWImage& linearMomentumImage = myContent->addImage(linearMomentumCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& linearMomentumImage = myContent->addImage(std::move(linearMomentumCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         linearMomentumImage.setComment("Transverse momentum resolution vs. eta (linear scale)");
         linearMomentumImage.setName(Form("linptres_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-        RootWImage& momentumImage = myContent->addImage(momentumCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& momentumImage = myContent->addImage(std::move(momentumCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         momentumImage.setComment("Transverse momentum resolution vs. eta");
         momentumImage.setName(Form("ptres_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-        RootWImage& distanceImage = myContent->addImage(distanceCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& distanceImage = myContent->addImage(std::move(distanceCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         distanceImage.setComment("Distance of closest approach resolution vs. eta");
         distanceImage.setName(Form("dxyres_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-        RootWImage& angleImage = myContent->addImage(angleCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& angleImage = myContent->addImage(std::move(angleCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         angleImage.setComment("Angle resolution vs. eta");
         angleImage.setName(Form("phires_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-        RootWImage& ctgThetaImage = myContent->addImage(ctgThetaCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& ctgThetaImage = myContent->addImage(std::move(ctgThetaCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         ctgThetaImage.setComment("CtgTheta resolution vs. eta");
         ctgThetaImage.setName(Form("cotThetares_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-        RootWImage& etaImage = myContent->addImage(etaCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& etaImage = myContent->addImage(std::move(etaCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         etaImage.setComment("Eta resolution vs. eta");
         etaImage.setName(Form("etares_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-	RootWImage& z0Image = myContent->addImage(z0Canvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+	RootWImage& z0Image = myContent->addImage(std::move(z0Canvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         z0Image.setComment("z0 resolution vs. eta");
         z0Image.setName(Form("dzres_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
-        RootWImage& pImage = myContent->addImage(pCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& pImage = myContent->addImage(std::move(pCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         pImage.setComment("Momentum resolution vs. eta");
         pImage.setName(Form("pres_%s_%s",additionalTag.c_str(), scenarioStr.c_str()));
       }
@@ -4461,17 +4489,17 @@ namespace insur {
             scenarioStr = "noMS_Pt";
           }
 
-          TCanvas* linMomCanvas_Pt = new TCanvas();
-          TCanvas* logMomCanvas_Pt = new TCanvas();
-          TCanvas* d0Canvas_Pt = new TCanvas();
-          TCanvas* phiCanvas_Pt = new TCanvas();
-          TCanvas* ctgThetaCanvas_Pt = new TCanvas();
-          TCanvas* etaCanvas_Pt = new TCanvas();
-          TCanvas* z0Canvas_Pt = new TCanvas();
-          TCanvas* pCanvas_Pt = new TCanvas();
-          TCanvas* lCanvas_Pt = new TCanvas();
-          TCanvas* betaCanvas_Pt = new TCanvas();
-          TCanvas* omegaCanvas_Pt = new TCanvas();
+          std::unique_ptr<TCanvas> linMomCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> logMomCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> d0Canvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> phiCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> ctgThetaCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> etaCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> z0Canvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> pCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> lCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> betaCanvas_Pt(new TCanvas());
+          std::unique_ptr<TCanvas> omegaCanvas_Pt(new TCanvas());
 
           // Default attributes
           int myColor            = 0;
@@ -4775,47 +4803,47 @@ namespace insur {
             }
           }
 
-          RootWImage& linMomImage_Pt = myContent->addImage(linMomCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& linMomImage_Pt = myContent->addImage(std::move(linMomCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           linMomImage_Pt.setComment("Transverse momentum resolution vs. "+etaLetter+" (linear scale) - const Pt across "+etaLetter);
           linMomImage_Pt.setName(Form("linptres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& logMomImage_Pt = myContent->addImage(logMomCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& logMomImage_Pt = myContent->addImage(std::move(logMomCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           logMomImage_Pt.setComment("Transverse momentum resolution vs. "+etaLetter+" (log scale) - const Pt across "+etaLetter);
           logMomImage_Pt.setName(Form("ptres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& pImage_Pt = myContent->addImage(pCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& pImage_Pt = myContent->addImage(std::move(pCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           pImage_Pt.setComment("Momentum resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           pImage_Pt.setName(Form("pres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& d0Image_Pt = myContent->addImage(d0Canvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& d0Image_Pt = myContent->addImage(std::move(d0Canvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           d0Image_Pt.setComment("d0 resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           d0Image_Pt.setName(Form("dxyres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& z0Image_Pt = myContent->addImage(z0Canvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& z0Image_Pt = myContent->addImage(std::move(z0Canvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           z0Image_Pt.setComment("z0 resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           z0Image_Pt.setName(Form("dzres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& lImage_Pt = myContent->addImage(lCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& lImage_Pt = myContent->addImage(std::move(lCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           lImage_Pt.setComment("L resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           lImage_Pt.setName(Form("lres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& betaImage_Pt = myContent->addImage(betaCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& betaImage_Pt = myContent->addImage(std::move(betaCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           betaImage_Pt.setComment("Relative influence of #sigma_{d0} (max for #beta=#pi/2) and #sigma_{z0} (max for #beta=0) - const Pt across "+etaLetter);
           betaImage_Pt.setName(Form("beta_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& omegaImage_Pt = myContent->addImage(omegaCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& omegaImage_Pt = myContent->addImage(std::move(omegaCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           omegaImage_Pt.setComment("Pixel aspect ratio optimzation (for fixed pixel area). #Omega=#pi/2 means you need longer pixels - const Pt across "+etaLetter);
           omegaImage_Pt.setName(Form("omega_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& phiImage_Pt = myContent->addImage(phiCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& phiImage_Pt = myContent->addImage(std::move(phiCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           phiImage_Pt.setComment("Angle resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           phiImage_Pt.setName(Form("phires_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& ctgThetaImage_Pt = myContent->addImage(ctgThetaCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& ctgThetaImage_Pt = myContent->addImage(std::move(ctgThetaCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           ctgThetaImage_Pt.setComment("Ctg("+thetaLetter+") resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           ctgThetaImage_Pt.setName(Form("cotThetares_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& etaImage_Pt = myContent->addImage(etaCanvas_Pt, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& etaImage_Pt = myContent->addImage(std::move(etaCanvas_Pt), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           etaImage_Pt.setComment(etaLetter+" resolution vs. "+etaLetter+" - const Pt across "+etaLetter);
           etaImage_Pt.setName(Form("etares_%s_%s", tag.c_str(), scenarioStr.c_str()));
         }
@@ -4842,17 +4870,17 @@ namespace insur {
             scenarioStr = "noMS_P";
           }
 
-          TCanvas* linMomCanvas_P = new TCanvas();
-          TCanvas* logMomCanvas_P = new TCanvas();
-          TCanvas* d0Canvas_P = new TCanvas();
-          TCanvas* phiCanvas_P = new TCanvas();
-          TCanvas* ctgThetaCanvas_P = new TCanvas();
-          TCanvas* etaCanvas_P = new TCanvas();
-          TCanvas* z0Canvas_P = new TCanvas();
-          TCanvas* pCanvas_P = new TCanvas();
-          TCanvas* lCanvas_P = new TCanvas();
-          TCanvas* betaCanvas_P = new TCanvas();
-          TCanvas* omegaCanvas_P = new TCanvas();
+          std::unique_ptr<TCanvas> linMomCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> logMomCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> d0Canvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> phiCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> ctgThetaCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> etaCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> z0Canvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> pCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> lCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> betaCanvas_P(new TCanvas());
+          std::unique_ptr<TCanvas> omegaCanvas_P(new TCanvas());
 
           // Default attributes
           int myColor            = 0;
@@ -5158,47 +5186,47 @@ namespace insur {
             }
           }
 
-          RootWImage& linMomImage_P = myContent->addImage(linMomCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& linMomImage_P = myContent->addImage(std::move(linMomCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           linMomImage_P.setComment("Transverse momentum resolution vs. "+etaLetter+" (linear scale) - const P across "+etaLetter);
           linMomImage_P.setName(Form("linptres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& logMomImage_P = myContent->addImage(logMomCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& logMomImage_P = myContent->addImage(std::move(logMomCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           logMomImage_P.setComment("Transverse momentum resolution vs. "+etaLetter+" (log scale) - const P across "+etaLetter);
           logMomImage_P.setName(Form("ptres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& pImage_P = myContent->addImage(pCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& pImage_P = myContent->addImage(std::move(pCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           pImage_P.setComment("Momentum resolution vs. "+etaLetter+" - const P across "+etaLetter);
           pImage_P.setName(Form("pres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& d0Image_P = myContent->addImage(d0Canvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& d0Image_P = myContent->addImage(std::move(d0Canvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           d0Image_P.setComment("d0 resolution vs. "+etaLetter+" - const P across "+etaLetter);
           d0Image_P.setName(Form("dxyres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& z0Image_P = myContent->addImage(z0Canvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& z0Image_P = myContent->addImage(std::move(z0Canvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           z0Image_P.setComment("z0 resolution vs. "+etaLetter+" - const P across "+etaLetter);
           z0Image_P.setName(Form("dzres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& lImage_P = myContent->addImage(lCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& lImage_P = myContent->addImage(std::move(lCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           lImage_P.setComment("L resolution vs. "+etaLetter+" - const P across "+etaLetter);
           lImage_P.setName(Form("lres_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& betaImage_P = myContent->addImage(betaCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& betaImage_P = myContent->addImage(std::move(betaCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           betaImage_P.setComment("Relative influence of #sigma_{d0} (max for #beta=#pi/2) and #sigma_{z0} (max for #beta=0) - const P across "+etaLetter);
           betaImage_P.setName(Form("beta_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& omegaImage_P = myContent->addImage(omegaCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& omegaImage_P = myContent->addImage(std::move(omegaCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           omegaImage_P.setComment("Pixel aspect ratio optimzation (for fixed pixel area). #Omega=#pi/2 means you need longer pixels - const P across "+etaLetter);
           omegaImage_P.setName(Form("omega_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& phiImage_P = myContent->addImage(phiCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& phiImage_P = myContent->addImage(std::move(phiCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           phiImage_P.setComment("Angle resolution vs. "+etaLetter+" - const P across "+etaLetter);
           phiImage_P.setName(Form("phires_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& ctgThetaImage_P = myContent->addImage(ctgThetaCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& ctgThetaImage_P = myContent->addImage(std::move(ctgThetaCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           ctgThetaImage_P.setComment("Ctg("+thetaLetter+") resolution vs. "+etaLetter+" - const P across "+etaLetter);
           ctgThetaImage_P.setName(Form("cotThetares_%s_%s", tag.c_str(), scenarioStr.c_str()));
 
-          RootWImage& etaImage_P = myContent->addImage(etaCanvas_P, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+          RootWImage& etaImage_P = myContent->addImage(std::move(etaCanvas_P), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
           etaImage_P.setComment(etaLetter+") resolution vs. "+etaLetter+" - const P across "+etaLetter);
           etaImage_P.setName(Form("etares_%s_%s", tag.c_str(), scenarioStr.c_str()));
         }
@@ -5466,7 +5494,7 @@ namespace insur {
     myInfoPt.setValue(SimParms::getInstance().numMinBiasEvents(), minimumBiasPrecision);
 
     // a) Bkg contamination probability -> In-Out approach
-    TCanvas* canvasPtBkgContInOut = new TCanvas("canvasPtBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> canvasPtBkgContInOut(new TCanvas("canvasPtBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
     canvasPtBkgContInOut->SetGrid(1,1);
     canvasPtBkgContInOut->SetLogy(0);
     canvasPtBkgContInOut->SetFillColor(color_plot_background);
@@ -5497,12 +5525,12 @@ namespace insur {
     }
     legendPtInOut->Draw("SAME");
 
-    RootWImage& myImagePtBkgContInOut = myContentPlotsPt.addImage(canvasPtBkgContInOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& myImagePtBkgContInOut = myContentPlotsPt.addImage(std::move(canvasPtBkgContInOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImagePtBkgContInOut.setComment("In-Out approach for pT: Bkg contamination prob. in 95% area of 2D error ellipse accumulated across N layers");
     myImagePtBkgContInOut.setName("bkg_pt_pContam_inout");
 
     // b) Bkg contamination probability -> OutIn approach
-    TCanvas* canvasPtBkgContOutIn = new TCanvas("canvasPtBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> canvasPtBkgContOutIn(new TCanvas("canvasPtBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
     canvasPtBkgContOutIn->SetGrid(1,1);
     canvasPtBkgContOutIn->SetLogy(0);
     canvasPtBkgContOutIn->SetFillColor(color_plot_background);
@@ -5533,7 +5561,7 @@ namespace insur {
     }
     legendPtOutIn->Draw("SAME");
 
-    RootWImage& myImagePtBkgContOutIn = myContentPlotsPt.addImage(canvasPtBkgContOutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& myImagePtBkgContOutIn = myContentPlotsPt.addImage(std::move(canvasPtBkgContOutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImagePtBkgContOutIn.setComment("Out-In approach for pT: Bkg contamination prob. in 95% area of 2D error ellipse accumulated across N layers");
     myImagePtBkgContOutIn.setName("bkg_pt_pContam_outin");
 
@@ -5550,7 +5578,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPtD0InOut = new TCanvas(std::string("canvasPtD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPtD0InOut(new TCanvas(std::string("canvasPtD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPtD0InOut->SetGrid(1,1);
       canvasPtD0InOut->SetLogy(0);
       canvasPtD0InOut->SetFillColor(color_plot_background);
@@ -5578,7 +5606,7 @@ namespace insur {
       legendPtInOut->SetEntryLabel("p_{T} options (InOut+IP, full TRK):");
       legendPtInOut->Draw("SAME");
 
-      RootWImage& myImagePtD0InOut = myContentPlotsPtD0InOut.addImage(canvasPtD0InOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePtD0InOut = myContentPlotsPtD0InOut.addImage(std::move(canvasPtD0InOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePtD0InOut.setComment(std::string("Detector: "+name+" - an extrapolated sigma in R-Phi from previous layers/discs in in-out approach.").c_str());
       myImagePtD0InOut.setName(std::string("bkg_pt_d0_inout_"+name).c_str());
     }
@@ -5593,7 +5621,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPtZ0InOut = new TCanvas(std::string("canvasPtZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPtZ0InOut(new TCanvas(std::string("canvasPtZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPtZ0InOut->SetGrid(1,1);
       canvasPtZ0InOut->SetLogy(0);
       canvasPtZ0InOut->SetFillColor(color_plot_background);
@@ -5618,7 +5646,7 @@ namespace insur {
       }
       legendPtInOut->Draw("SAME");
 
-      RootWImage& myImagePtZ0InOut = myContentPlotsPtZ0InOut.addImage(canvasPtZ0InOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePtZ0InOut = myContentPlotsPtZ0InOut.addImage(std::move(canvasPtZ0InOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePtZ0InOut.setComment(std::string("Detector: "+name+" - an extrapolated sigma in Z from previous layers/discs in in-out approach.").c_str());
       myImagePtZ0InOut.setName(std::string("bkg_pt_z0_inout_"+name).c_str());
     }
@@ -5633,7 +5661,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPtProbContamInOut = new TCanvas(std::string("canvasPtProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPtProbContamInOut(new TCanvas(std::string("canvasPtProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPtProbContamInOut->SetGrid(1,1);
       canvasPtProbContamInOut->SetLogy(0);
       canvasPtProbContamInOut->SetFillColor(color_plot_background);
@@ -5660,7 +5688,7 @@ namespace insur {
       legendPtInOut->SetX2(0.36);
       legendPtInOut->Draw("SAME");
 
-      RootWImage& myImagePtProbContamInOut = myContentPlotsPtProbContamInOut.addImage(canvasPtProbContamInOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePtProbContamInOut = myContentPlotsPtProbContamInOut.addImage(std::move(canvasPtProbContamInOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePtProbContamInOut.setComment(std::string("Detector: "+name+" - bkg contamination prob. as error ellipse extrap. from previous layers/discs in in-out approach.").c_str());
       myImagePtProbContamInOut.setName(std::string("bkg_pt_pContam_inout_"+name).c_str());
     }
@@ -5678,7 +5706,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPtD0OutIn = new TCanvas(std::string("canvasPtD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPtD0OutIn(new TCanvas(std::string("canvasPtD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPtD0OutIn->SetGrid(1,1);
       canvasPtD0OutIn->SetLogy(0);
       canvasPtD0OutIn->SetFillColor(color_plot_background);
@@ -5706,7 +5734,7 @@ namespace insur {
       legendPtOutIn->SetEntryLabel("p_{T} options (OutIn, full TRK):");
       legendPtOutIn->Draw("SAME");
 
-      RootWImage& myImagePtD0OutIn = myContentPlotsPtD0OutIn.addImage(canvasPtD0OutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePtD0OutIn = myContentPlotsPtD0OutIn.addImage(std::move(canvasPtD0OutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePtD0OutIn.setComment(std::string("Detector: "+name+" - an extrapolated sigma in R-Phi from previous layers/discs in out-in approach.").c_str());
       myImagePtD0OutIn.setName(std::string("bkg_pt_d0_outin_"+name).c_str());
     }
@@ -5721,7 +5749,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPtZ0OutIn = new TCanvas(std::string("canvasPtZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPtZ0OutIn(new TCanvas(std::string("canvasPtZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPtZ0OutIn->SetGrid(1,1);
       canvasPtZ0OutIn->SetLogy(0);
       canvasPtZ0OutIn->SetFillColor(color_plot_background);
@@ -5746,7 +5774,7 @@ namespace insur {
       }
       legendPtOutIn->Draw("SAME");
 
-      RootWImage& myImagePtZ0OutIn = myContentPlotsPtZ0OutIn.addImage(canvasPtZ0OutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePtZ0OutIn = myContentPlotsPtZ0OutIn.addImage(std::move(canvasPtZ0OutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePtZ0OutIn.setComment(std::string("Detector: "+name+" - an extrapolated sigma in Z from previous layers/discs in out-in approach.").c_str());
       myImagePtZ0OutIn.setName(std::string("bkg_pt_z0_outin_"+name).c_str());
     }
@@ -5761,7 +5789,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPtProbContamOutIn = new TCanvas(std::string("canvasPtProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPtProbContamOutIn(new TCanvas(std::string("canvasPtProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPtProbContamOutIn->SetGrid(1,1);
       canvasPtProbContamOutIn->SetLogy(0);
       canvasPtProbContamOutIn->SetFillColor(color_plot_background);
@@ -5788,7 +5816,7 @@ namespace insur {
       legendPtOutIn->SetX2(0.36);
       legendPtOutIn->Draw("SAME");
 
-      RootWImage& myImagePtProbContamOutIn = myContentPlotsPtProbContamOutIn.addImage(canvasPtProbContamOutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePtProbContamOutIn = myContentPlotsPtProbContamOutIn.addImage(std::move(canvasPtProbContamOutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePtProbContamOutIn.setComment(std::string("Detector: "+name+" - bkg contamination prob. as error ellipse extrap. from previous layers/discs in out-in approach.").c_str());
       myImagePtProbContamOutIn.setName(std::string("bkg_pt_pContam_outin_"+name).c_str());
     }
@@ -5802,7 +5830,7 @@ namespace insur {
     myInfoP.setValue(SimParms::getInstance().numMinBiasEvents(), minimumBiasPrecision);
 
     // a) Bkg contamination probability - In-Out approach
-    TCanvas* canvasPBkgContInOut = new TCanvas("canvasPBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> canvasPBkgContInOut(new TCanvas("canvasPBkgContInOut","",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
     canvasPBkgContInOut->SetGrid(1,1);
     canvasPBkgContInOut->SetLogy(0);
     canvasPBkgContInOut->SetFillColor(color_plot_background);
@@ -5833,12 +5861,12 @@ namespace insur {
     }
     legendPInOut->Draw("SAME");
 
-    RootWImage& myImagePBkgContInOut = myContentPlotsP.addImage(canvasPBkgContInOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& myImagePBkgContInOut = myContentPlotsP.addImage(std::move(canvasPBkgContInOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImagePBkgContInOut.setComment("In-Out approach for p: Bkg contamination prob. in 95% area of 2D error ellipse accumulated across N layers");
     myImagePBkgContInOut.setName("bkg_p_pContam_inout");
 
     // b) Bkg contamination probability - Out-In approach
-    TCanvas* canvasPBkgContOutIn = new TCanvas("canvasPBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+    std::unique_ptr<TCanvas> canvasPBkgContOutIn(new TCanvas("canvasPBkgContOutIn","",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
     canvasPBkgContOutIn->SetGrid(1,1);
     canvasPBkgContOutIn->SetLogy(0);
     canvasPBkgContOutIn->SetFillColor(color_plot_background);
@@ -5869,7 +5897,7 @@ namespace insur {
     }
     legendPOutIn->Draw("SAME");
 
-    RootWImage& myImagePBkgContOutIn = myContentPlotsP.addImage(canvasPBkgContOutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& myImagePBkgContOutIn = myContentPlotsP.addImage(std::move(canvasPBkgContOutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     myImagePBkgContOutIn.setComment("Out-In approach for p: Bkg contamination prob. in 95% area of 2D error ellipse accumulated across N layers");
     myImagePBkgContOutIn.setName("bkg_p_pContam_outin");
 
@@ -5886,7 +5914,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPD0InOut = new TCanvas(std::string("canvasPD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPD0InOut(new TCanvas(std::string("canvasPD0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPD0InOut->SetGrid(1,1);
       canvasPD0InOut->SetLogy(0);
       canvasPD0InOut->SetFillColor(color_plot_background);
@@ -5914,7 +5942,7 @@ namespace insur {
       legendPInOut->SetEntryLabel("p options (InOut+IP, full TRK):");
       legendPInOut->Draw("SAME");
 
-      RootWImage& myImagePD0InOut = myContentPlotsPD0InOut.addImage(canvasPD0InOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePD0InOut = myContentPlotsPD0InOut.addImage(std::move(canvasPD0InOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePD0InOut.setComment(std::string("Detector: "+name+" - an extrapolated sigma in R-Phi from previous layers/discs in in-out approach.").c_str());
       myImagePD0InOut.setName(std::string("bkg_p_d0_inout_"+name).c_str());
     }
@@ -5929,7 +5957,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPZ0InOut = new TCanvas(std::string("canvasPZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPZ0InOut(new TCanvas(std::string("canvasPZ0InOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPZ0InOut->SetGrid(1,1);
       canvasPZ0InOut->SetLogy(0);
       canvasPZ0InOut->SetFillColor(color_plot_background);
@@ -5956,7 +5984,7 @@ namespace insur {
       legendPInOut->SetX2(0.89);
       legendPInOut->Draw("SAME");
 
-      RootWImage& myImagePZ0InOut = myContentPlotsPZ0InOut.addImage(canvasPZ0InOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePZ0InOut = myContentPlotsPZ0InOut.addImage(std::move(canvasPZ0InOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePZ0InOut.setComment(std::string("Detector: "+name+" - an extrapolated sigma in Z from previous layers/discs in in-out approach.").c_str());
       myImagePZ0InOut.setName(std::string("bkg_p_z0_inout_"+name).c_str());
     }
@@ -5971,7 +5999,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPProbContamInOut = new TCanvas(std::string("canvasPProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPProbContamInOut(new TCanvas(std::string("canvasPProbContamInOut"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPProbContamInOut->SetGrid(1,1);
       canvasPProbContamInOut->SetLogy(0);
       canvasPProbContamInOut->SetFillColor(color_plot_background);
@@ -5998,7 +6026,7 @@ namespace insur {
       legendPInOut->SetX2(0.36);
       legendPInOut->Draw("SAME");
 
-      RootWImage& myImagePProbContamInOut = myContentPlotsPProbContamInOut.addImage(canvasPProbContamInOut, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePProbContamInOut = myContentPlotsPProbContamInOut.addImage(std::move(canvasPProbContamInOut), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePProbContamInOut.setComment(std::string("Detector: "+name+" - bkg contamination prob. as error ellipse extrap. from previous layers/discs in in-out approach.").c_str());
       myImagePProbContamInOut.setName(std::string("bkg_p_pContam_inout_"+name).c_str());
     }
@@ -6015,7 +6043,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPD0OutIn = new TCanvas(std::string("canvasPD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPD0OutIn(new TCanvas(std::string("canvasPD0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPD0OutIn->SetGrid(1,1);
       canvasPD0OutIn->SetLogy(0);
       canvasPD0OutIn->SetFillColor(color_plot_background);
@@ -6043,7 +6071,7 @@ namespace insur {
       legendPOutIn->SetEntryLabel("p options (OutIn+IP, full TRK):");
       legendPOutIn->Draw("SAME");
 
-      RootWImage& myImagePD0OutIn = myContentPlotsPD0OutIn.addImage(canvasPD0OutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePD0OutIn = myContentPlotsPD0OutIn.addImage(std::move(canvasPD0OutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePD0OutIn.setComment(std::string("Detector: "+name+" - an extrapolated sigma in R-Phi from previous layers/discs in out-in approach.").c_str());
       myImagePD0OutIn.setName(std::string("bkg_p_d0_outin_"+name).c_str());
     }
@@ -6058,7 +6086,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPZ0OutIn = new TCanvas(std::string("canvasPZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPZ0OutIn(new TCanvas(std::string("canvasPZ0OutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPZ0OutIn->SetGrid(1,1);
       canvasPZ0OutIn->SetLogy(0);
       canvasPZ0OutIn->SetFillColor(color_plot_background);
@@ -6085,7 +6113,7 @@ namespace insur {
       legendPOutIn->SetX2(0.89);
       legendPOutIn->Draw("SAME");
 
-      RootWImage& myImagePZ0OutIn = myContentPlotsPZ0OutIn.addImage(canvasPZ0OutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePZ0OutIn = myContentPlotsPZ0OutIn.addImage(std::move(canvasPZ0OutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePZ0OutIn.setComment(std::string("Detector: "+name+" - an extrapolated sigma in Z from previous layers/discs in out-in approach.").c_str());
       myImagePZ0OutIn.setName(std::string("bkg_p_z0_outin_"+name).c_str());
     }
@@ -6100,7 +6128,7 @@ namespace insur {
 
       int         iMomentum = 0;
 
-      TCanvas* canvasPProbContamOutIn = new TCanvas(std::string("canvasPProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> canvasPProbContamOutIn(new TCanvas(std::string("canvasPProbContamOutIn"+name).c_str(),"",vis_std_canvas_sizeY,vis_min_canvas_sizeY));
       canvasPProbContamOutIn->SetGrid(1,1);
       canvasPProbContamOutIn->SetLogy(0);
       canvasPProbContamOutIn->SetFillColor(color_plot_background);
@@ -6127,7 +6155,7 @@ namespace insur {
       legendPOutIn->SetX2(0.36);
       legendPOutIn->Draw("SAME");
 
-      RootWImage& myImagePProbContamOutIn = myContentPlotsPProbContamOutIn.addImage(canvasPProbContamOutIn, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& myImagePProbContamOutIn = myContentPlotsPProbContamOutIn.addImage(std::move(canvasPProbContamOutIn), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       myImagePProbContamOutIn.setComment(std::string("Detector: "+name+" - bkg contamination prob. as error ellipse extrap. from previous layers/discs in out-in approach.").c_str());
       myImagePProbContamOutIn.setName(std::string("bkg_p_pContam_outin_"+name).c_str());
     }
@@ -6178,7 +6206,7 @@ namespace insur {
 
       // Create the contents
       RootWContent& myContent = myPage.addContent("Overall trigger");
-      TCanvas* pointsCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> pointsCanvas(new TCanvas());
       pointsCanvas->SetGrid(1,1);
       plotOption = "E1"; // or "E6"
 
@@ -6226,22 +6254,20 @@ namespace insur {
         //plotOption = "same";
       }
       tempSS << " GeV";
-      
-      RootWImage& npointsImage = myContent.addImage(pointsCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+
+      std::unique_ptr<TCanvas> pointsLogCanvas((TCanvas*)pointsCanvas->DrawClone());
+      pointsLogCanvas->SetLogy();
+           
+      RootWImage& npointsImage = myContent.addImage(std::move(pointsCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       npointsImage.setComment(tempSS.str().c_str());
       npointsImage.setName("ntrigpoints");
 
-      // std::cerr << "now to log scale..." << std::endl; // debug
-
-      pointsCanvas->SetLogy();
-      RootWImage& npointsLogImage = myContent.addImage(pointsCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& npointsLogImage = myContent.addImage(std::move(pointsLogCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS << " (log scale)";
       npointsLogImage.setComment(tempSS.str().c_str());
       npointsLogImage.setName("ntrigpointsLog");
 
-      // std::cerr << "done..." << std::endl; // debug
-
-      TCanvas* fractionCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> fractionCanvas(new TCanvas());
       fractionCanvas->SetGrid(1,1);
       plotOption = "E1";
 
@@ -6294,17 +6320,20 @@ namespace insur {
       }
       tempSS << " GeV";
 
-      RootWImage& fractionImage = myContent.addImage(fractionCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> fractionLogCanvas((TCanvas*)fractionCanvas->DrawClone());
+      fractionLogCanvas->SetLogy();
+
+      RootWImage& fractionImage = myContent.addImage(std::move(fractionCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       fractionImage.setComment(tempSS.str().c_str());
       fractionImage.setName("fractiontrigpoints");
-      fractionCanvas->SetLogy();
-      RootWImage& fractionLogImage = myContent.addImage(fractionCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      
+      RootWImage& fractionLogImage = myContent.addImage(std::move(fractionLogCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS << " (log scale)";
       fractionLogImage.setComment(tempSS.str().c_str());
       fractionLogImage.setName("fractiontrigpointsLog");
 
 
-      TCanvas* purityCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> purityCanvas(new TCanvas());
       purityCanvas->SetGrid(1,1);
       plotOption = "E1";
 
@@ -6357,11 +6386,14 @@ namespace insur {
       }
       tempSS << " GeV";
 
-      RootWImage& purityImage = myContent.addImage(purityCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      std::unique_ptr<TCanvas> purityLogCanvas((TCanvas*)purityCanvas->DrawClone());
+      purityLogCanvas->SetLogy();
+
+      RootWImage& purityImage = myContent.addImage(std::move(purityCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       purityImage.setComment(tempSS.str().c_str());
       purityImage.setName("puritytrigpoints");
-      purityCanvas->SetLogy();
-      RootWImage& purityLogImage = myContent.addImage(purityCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      
+      RootWImage& purityLogImage = myContent.addImage(std::move(purityLogCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS << " (log scale)";
       purityLogImage.setComment(tempSS.str().c_str());
       purityLogImage.setName("puritytrigpointsLog");
@@ -6389,7 +6421,7 @@ namespace insur {
            it != efficiencyMaps.end(); ++it) {
 
         // One canvas per map
-        TCanvas* myCanvas = new TCanvas();
+        std::unique_ptr<TCanvas> myCanvas(new TCanvas());
         double myPt = it->first;
         if (myPt>maxPt) maxPt=myPt;
         TH2D& myMap = it->second;
@@ -6406,7 +6438,7 @@ namespace insur {
         myMap.Draw("colz");
 
         // Create the image object
-        RootWImage& myImage = myContent.addImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& myImage = myContent.addImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         tempSS.str(""); tempSS << "Trigger efficiency map for pT = " << myPt << " GeV/c"; tempString = tempSS.str();
         myImage.setComment(tempString.c_str());
         tempSS.str(""); tempSS << "TriggerEfficiency_" << myPt; tempString = tempSS.str();
@@ -6426,7 +6458,7 @@ namespace insur {
     if (!profiles.empty()) {
       RootWContent& myContent = myPage.addContent("Stub efficiency coverage", false);
       for (const auto& lmel : profiles) {
-        TCanvas* myCanvas = new TCanvas(Form("StubEfficiencyCoverageCanvas%s", lmel.first.c_str()), "Stub efficiency eta coverage", vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        std::unique_ptr<TCanvas> myCanvas(new TCanvas(Form("StubEfficiencyCoverageCanvas%s", lmel.first.c_str()), "Stub efficiency eta coverage", vis_std_canvas_sizeX, vis_min_canvas_sizeY));
         //myCanvas->SetFillColor(color_plot_background);
         myCanvas->cd();
         std::vector<std::string> momenta;
@@ -6444,7 +6476,7 @@ namespace insur {
           drawOpts = "same";
           break;
         }
-        RootWImage* myImage = new RootWImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage* myImage = new RootWImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         myImage->setComment("Stub efficiency coverage in eta for pT = " + join(momenta, ","));
         myContent.addItem(myImage);
       }
@@ -6467,7 +6499,7 @@ namespace insur {
            it != thresholdMaps.end(); ++it) {
 
         // One canvas per map
-        TCanvas* myCanvas = new TCanvas();
+        std::unique_ptr<TCanvas> myCanvas(new TCanvas());
         double myEfficiency = it->first;
         TH2D& myMap = it->second;
         myCanvas->SetFillColor(color_plot_background);
@@ -6480,7 +6512,7 @@ namespace insur {
         myMap.Draw("colz");
 
         // Create the image object
-        RootWImage& myImage = myContent.addImage(myCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& myImage = myContent.addImage(std::move(myCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         tempSS.str(""); tempSS << "Trigger threshold map for eff = " << myEfficiency * 100 << " %";
         tempString = tempSS.str();
         myImage.setComment(tempString.c_str());
@@ -6506,11 +6538,11 @@ namespace insur {
     RootWContent& myContent = myPage.addContent("Module configuration maps", false);
 
     // One canvas per map
-    TCanvas* thickCanvas = new TCanvas();
-    TCanvas* windowCanvas = new TCanvas();
-    TCanvas* suggestedSpacingCanvas = new TCanvas();
-    TCanvas* suggestedSpacingAWCanvas = new TCanvas();
-    TCanvas* nominalCutCanvas = new TCanvas();
+    std::unique_ptr<TCanvas> thickCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> windowCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> suggestedSpacingCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> suggestedSpacingAWCanvas(new TCanvas());
+    std::unique_ptr<TCanvas> nominalCutCanvas(new TCanvas());
     thickCanvas->SetFillColor(color_plot_background);
     windowCanvas->SetFillColor(color_plot_background);
     suggestedSpacingCanvas->SetFillColor(color_plot_background);
@@ -6520,14 +6552,14 @@ namespace insur {
     struct Spacing { double operator()(const Module& m) { return m.dsDistance(); } };
     PlotDrawer<YZ, Spacing> thicknessDrawer;
     thicknessDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
-    thicknessDrawer.drawFrame<HistogramFrameStyle>(*thickCanvas);
-    thicknessDrawer.drawModules<ContourStyle>(*thickCanvas);
+    thicknessDrawer.drawFrame<HistogramFrameStyle>(*thickCanvas.get());
+    thicknessDrawer.drawModules<ContourStyle>(*thickCanvas.get());
 
     struct TriggerWindow { double operator()(const Module& m) { return m.triggerWindow(); } };
     PlotDrawer<YZ, TriggerWindow> windowDrawer;
     windowDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
-    windowDrawer.drawFrame<HistogramFrameStyle>(*windowCanvas);
-    windowDrawer.drawModules<ContourStyle>(*windowCanvas);
+    windowDrawer.drawFrame<HistogramFrameStyle>(*windowCanvas.get());
+    windowDrawer.drawModules<ContourStyle>(*windowCanvas.get());
 
 
     // Actually plot the maps
@@ -6544,27 +6576,27 @@ namespace insur {
       //struct PtCut { double operator()(const Module& m) { return PtErrorAdapter(m).getPtCut(); } };
       //PlotDrawer<YZ, PtCut> cutDrawer;
       //cutDrawer.addModulesType(tracker.modules().begin(), tracker.modules().end());
-      //cutDrawer.drawFrame<HistogramFrameStyle>(*nominalCutCanvas);
-      //cutDrawer.drawModules<ContourStyle>(*nominalCutCanvas);
+      //cutDrawer.drawFrame<HistogramFrameStyle>(*nominalCutCanvas.get());
+      //cutDrawer.drawModules<ContourStyle>(*nominalCutCanvas.get());
       nominalCutCanvas->SetLogz();
       nominalCutMap.Draw("colz");
     }
 
     // Create the image objects
-    RootWImage& thicknessImage = myContent.addImage(thickCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& thicknessImage = myContent.addImage(std::move(thickCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     thicknessImage.setComment("Map of sensor distances");
     thicknessImage.setName("ThicknessMap");
-    RootWImage& windowImage = myContent.addImage(windowCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& windowImage = myContent.addImage(std::move(windowCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
     windowImage.setComment("Map of selection windows");
     windowImage.setName("WindowMap");
     if (extended) {
-      RootWImage& suggestedSpacingImage = myContent.addImage(suggestedSpacingCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& suggestedSpacingImage = myContent.addImage(std::move(suggestedSpacingCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       suggestedSpacingImage.setComment("Map of selection suggestedSpacings [default window]");
       suggestedSpacingImage.setName("SuggestedSpacingMap");
-      RootWImage& suggestedSpacingAWImage = myContent.addImage(suggestedSpacingAWCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& suggestedSpacingAWImage = myContent.addImage(std::move(suggestedSpacingAWCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       suggestedSpacingAWImage.setComment("Map of selection suggestedSpacings [selected windows]");
       suggestedSpacingAWImage.setName("SuggestedSpacingMapAW");
-      RootWImage& nominalCutImage = myContent.addImage(nominalCutCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& nominalCutImage = myContent.addImage(std::move(nominalCutCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       nominalCutImage.setComment("Map of nominal pT cut");
       nominalCutImage.setName("NominalCutMap");
     }
@@ -6626,7 +6658,7 @@ namespace insur {
 	}
       }
 
-      TCanvas* rangeCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> rangeCanvas(new TCanvas());
       rangeCanvas->cd();
       rangeCanvas->SetFillColor(color_plot_background);
       rangeCanvas->SetGrid(0,1);
@@ -6642,13 +6674,13 @@ namespace insur {
       availableSpacings.SetBit(0);
       availableSpacings.Draw("p same");
 
-      RootWImage& RangeImage = spacingSummaryContent.addImage(rangeCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& RangeImage = spacingSummaryContent.addImage(std::move(rangeCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS.str(""); tempSS << "Sensor distance range tuning";
       RangeImage.setComment(tempSS.str());
       tempSS.str(""); tempSS << "TriggerRangeTuning";
       RangeImage.setName(tempSS.str());
 
-      TCanvas* tuningCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> tuningCanvas(new TCanvas());
       tuningCanvas->cd();
       tuningCanvas->SetFillColor(color_plot_background);
       tuningCanvas->SetGrid(0,1);
@@ -6679,28 +6711,28 @@ namespace insur {
         tuningGraph.Draw("same 2");
       }
 
-      RootWImage& tuningImage = spacingSummaryContent.addImage(tuningCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& tuningImage = spacingSummaryContent.addImage(std::move(tuningCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
       tempSS.str(""); tempSS << "Sensor distance range tuning for different windows";
       tuningImage.setComment(tempSS.str());
       tempSS.str(""); tempSS << "TriggerRangeTuningWindows";
       tuningImage.setName(tempSS.str());
 
       TH1D& spacingDistribution = a.getHistoOptimalSpacing(false);
-      TCanvas* spacingCanvas = new TCanvas();
+      std::unique_ptr<TCanvas> spacingCanvas(new TCanvas());
       spacingCanvas->SetFillColor(color_plot_background);
       spacingCanvas->cd();
       spacingDistribution.SetFillColor(Palette::color(1));
       spacingDistribution.Draw();
-      RootWImage& spacingImage = spacingSummaryContent.addImage(spacingCanvas, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& spacingImage = spacingSummaryContent.addImage(std::move(spacingCanvas), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       spacingImage.setComment("Distribution of minimal spacing for low pT rejection @ standard window");
       spacingImage.setName("SpacingDistribution");
       TH1D& spacingDistributionAW = a.getHistoOptimalSpacing(true);
-      TCanvas* spacingCanvasAW = new TCanvas();
+      std::unique_ptr<TCanvas> spacingCanvasAW(new TCanvas());
       spacingCanvasAW->SetFillColor(color_plot_background);
       spacingCanvasAW->cd();
       spacingDistributionAW.SetFillColor(Palette::color(1));
       spacingDistributionAW.Draw();
-      RootWImage& spacingImageAW = spacingSummaryContent.addImage(spacingCanvasAW, vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+      RootWImage& spacingImageAW = spacingSummaryContent.addImage(std::move(spacingCanvasAW), vis_min_canvas_sizeX, vis_min_canvas_sizeY);
       spacingImageAW.setComment("Distribution of minimal spacing for low pT rejection @ selected window");
       spacingImageAW.setName("SpacingDistributionAW");
 
@@ -6719,7 +6751,7 @@ namespace insur {
         std::map<double, TProfile>& tuningProfiles = aProfileBag.getNamedProfiles(*itName);
 
         int myColor = 1;
-        TCanvas* tuningCanvas = new TCanvas();
+        std::unique_ptr<TCanvas> tuningCanvas(new TCanvas());
         tuningCanvas->SetFillColor(color_plot_background);
         tuningCanvas->cd();
 
@@ -6739,7 +6771,7 @@ namespace insur {
           plotOption = "same E1";
         }
 
-        RootWImage& tuningImage = spacingDetailedContent.addImage(tuningCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& tuningImage = spacingDetailedContent.addImage(std::move(tuningCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         tempString = (*itName);
         tempString = tempString.substr(profileBag::TriggerProfileName.size(), tempString.size()-profileBag::TriggerProfileName.size());
         tempSS.str(""); tempSS << "Sensor distance tuning for " << tempString.c_str();
@@ -6776,7 +6808,7 @@ namespace insur {
         std::map<double, TProfile>& turnonProfiles = aProfileBag.getNamedProfiles(*itName);
 
         int myColor = 1;
-        TCanvas* turnonCanvas = new TCanvas();
+        std::unique_ptr<TCanvas> turnonCanvas(new TCanvas());
         turnonCanvas->SetFillColor(color_plot_background);
         turnonCanvas->cd();
 
@@ -6800,7 +6832,7 @@ namespace insur {
 
         tempString = (*itName);
         tempString = tempString.substr(profileBag::TurnOnCurveName.size(), tempString.size()-profileBag::TurnOnCurveName.size());
-        RootWImage& turnonImage = turnOnDetailedContent.addImage(turnonCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);
+        RootWImage& turnonImage = turnOnDetailedContent.addImage(std::move(turnonCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
         tempSS.str(""); tempSS << "Sensor turnon curve for " << tempString.c_str() << " with windows of " << windowList;
         turnonImage.setComment(tempSS.str());
         tempSS.str(""); tempSS << "TriggerTurnon" << tempString.c_str();
@@ -7158,14 +7190,14 @@ namespace insur {
   // @param analyzer A reference to the analysing class that examined the material budget and filled the histograms
   // @return a pointer to the new TCanvas
   void Vizard::createSummaryCanvas(double maxZ, double maxRho, Analyzer& analyzer,
-                                   TCanvas *&YZCanvas, TCanvas *&XYCanvas,
-                                   TCanvas *&XYCanvasEC) {
+                                   std::unique_ptr<TCanvas> &YZCanvas, std::unique_ptr<TCanvas> &XYCanvas,
+                                   std::unique_ptr<TCanvas> &XYCanvasEC) {
     Int_t irep;
     TVirtualPad* myPad;
 
-    YZCanvas = new TCanvas("YZCanvas", "YZView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
-    XYCanvasEC = new TCanvas("XYCanvasEC", "XYView Canvas (Endcap)", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    YZCanvas.reset(new TCanvas("YZCanvas", "YZView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
+    XYCanvasEC.reset(new TCanvas("XYCanvasEC", "XYView Canvas (Endcap)", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
 
     // YZView
     if (analyzer.getGeomLiteYZ()) {
@@ -7210,41 +7242,41 @@ namespace insur {
 
 
   void Vizard::createSummaryCanvasNicer(Tracker& tracker,
-                                        TCanvas *&RZCanvas, TCanvas *&RZCanvasBarrel, TCanvas *&XYCanvas,
-                                        std::vector<TCanvas*> &XYCanvasesEC) {
+                                        std::unique_ptr<TCanvas> &RZCanvas, std::unique_ptr<TCanvas> &RZCanvasBarrel, std::unique_ptr<TCanvas> &XYCanvas,
+                                        std::vector<std::unique_ptr<TCanvas> > &XYCanvasesEC) {
 
-    RZCanvas = new TCanvas("RZCanvas", "RZView Canvas",  insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY);
+    RZCanvas.reset(new TCanvas("RZCanvas", "RZView Canvas",  insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY));
     RZCanvas->cd();
     PlotDrawer<YZ, Type> yzDrawer;
     yzDrawer.addModules(tracker);
-    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
-    yzDrawer.drawModules<ContourStyle>(*RZCanvas);
+    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas.get());
+    yzDrawer.drawModules<ContourStyle>(*RZCanvas.get());
 
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
-    RZCanvasBarrel = new TCanvas("RZCanvasBarrel", "RZView CanvasBarrel", vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+    RZCanvasBarrel.reset(new TCanvas("RZCanvasBarrel", "RZView CanvasBarrel", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
     RZCanvasBarrel->cd();
     PlotDrawer<YZ, Type> yzDrawerBarrel(viewPortMax, viewPortMax);
     yzDrawerBarrel.addModulesType(tracker, BARREL);
-    yzDrawerBarrel.drawFrame<SummaryFrameStyle>(*RZCanvasBarrel);
-    yzDrawerBarrel.drawModules<ContourStyle>(*RZCanvasBarrel);
+    yzDrawerBarrel.drawFrame<SummaryFrameStyle>(*RZCanvasBarrel.get());
+    yzDrawerBarrel.drawModules<ContourStyle>(*RZCanvasBarrel.get());
 
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCanvas->cd();
     PlotDrawer<XY, Type> xyBarrelDrawer;
     xyBarrelDrawer.addModulesType(tracker, BARREL);
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas.get());
 
     for (auto& anEndcap : tracker.endcaps() ) {
-      TCanvas* XYCanvasEC = new TCanvas(Form("XYCanvasEC_%s", anEndcap.myid().c_str()),
+      std::unique_ptr<TCanvas> XYCanvasEC(new TCanvas(Form("XYCanvasEC_%s", anEndcap.myid().c_str()),
 					Form("XY projection of Endcap %s", anEndcap.myid().c_str()),
-					vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						      vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
       XYCanvasEC->cd();
       PlotDrawer<XY, Type> xyEndcapDrawer;
       xyEndcapDrawer.addModules(anEndcap);
-      xyEndcapDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasEC);
-      xyEndcapDrawer.drawModules<ContourStyle>(*XYCanvasEC);
-      XYCanvasesEC.push_back(XYCanvasEC);
+      xyEndcapDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasEC.get());
+      xyEndcapDrawer.drawModules<ContourStyle>(*XYCanvasEC.get());
+      XYCanvasesEC.push_back(std::move(XYCanvasEC));
     }
 
     // And now one per disk surface
@@ -7257,17 +7289,17 @@ namespace insur {
 	  auto found = allSurfaceModules.find(surfaceIndex);
 	  if (found != allSurfaceModules.end()) {
 	    const std::vector<const Module*>& surfaceModules = found->second;
-	    TCanvas* XYCanvasEC = new TCanvas(Form("XYCanvasEC_%s_%d", anEndcap.myid().c_str(), surfaceIndex),
+	    std::unique_ptr<TCanvas> XYCanvasEC(new TCanvas(Form("XYCanvasEC_%s_%d", anEndcap.myid().c_str(), surfaceIndex),
 					      Form("XY section of Endcap %s -- surface %d", anEndcap.myid().c_str(), surfaceIndex),
-					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	    XYCanvasEC->cd();
 	    PlotDrawer<XY, Type> xyEndcapDrawer;
 
 	    xyEndcapDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	    xyEndcapDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasEC);
-	    xyEndcapDrawer.drawModules<ContourStyle>(*XYCanvasEC);
-	    xyEndcapDrawer.drawModuleContours<ContourStyle>(*XYCanvasEC);
-	    XYCanvasesEC.push_back(XYCanvasEC);
+	    xyEndcapDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasEC.get());
+	    xyEndcapDrawer.drawModules<ContourStyle>(*XYCanvasEC.get());
+	    xyEndcapDrawer.drawModuleContours<ContourStyle>(*XYCanvasEC.get());
+	    XYCanvasesEC.push_back(std::move(XYCanvasEC));
 	  }
 	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
 	}
@@ -7283,33 +7315,33 @@ namespace insur {
    * Bundle cabling plots.
    */
   void Vizard::createOuterCablingPlotsBundles(const Tracker& tracker,
-					      TCanvas *&RZCanvas, TCanvas *&XYCanvas, TCanvas *&XYNegCanvas,
-					      std::vector<TCanvas*> &XYPosBundlesDisks, std::vector<TCanvas*> &XYPosBundlesDiskSurfaces,
-					      std::vector<TCanvas*> &XYNegBundlesDisks, std::vector<TCanvas*> &XYNegBundlesDiskSurfaces) {
+					      std::unique_ptr<TCanvas> &RZCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYNegCanvas,
+					      std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDisks, std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDiskSurfaces,
+					      std::vector<std::unique_ptr<TCanvas> > &XYNegBundlesDisks, std::vector<std::unique_ptr<TCanvas> > &XYNegBundlesDiskSurfaces) {
     
-    RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY);
+    RZCanvas.reset(new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY));
     RZCanvas->cd();
     PlotDrawer<YZFull, TypeBundleTransparentColor> yzDrawer;
     yzDrawer.addModules(tracker);
-    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
-    yzDrawer.drawModules<ContourStyle>(*RZCanvas);
+    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas.get());
+    yzDrawer.drawModules<ContourStyle>(*RZCanvas.get());
    
     // NEGATIVE CABLING SIDE. BARREL.
-    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas.reset(new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegCanvas->cd();
     PlotDrawer<XYNeg, TypeBundleColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveCablingSide() < 0); } );
-    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
-    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas.get());
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 
     // POSITIVE CABLING SIDE. BARREL.
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCanvas->cd();
     PlotDrawer<XY, TypeBundleColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveCablingSide() > 0); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 
     // POSITIVE CABLING SIDE.
@@ -7317,16 +7349,16 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       if (anEndcap.disks().size() > 0) {
 	const Disk& lastDisk = anEndcap.disks().back();
-	TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
+	std::unique_ptr<TCanvas> XYCanvasDisk(new TCanvas(Form("XYPosBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
 					    Form("(XY) Projection : Endcap %s, any Disk. (CMS +Z points towards you)", anEndcap.myid().c_str()),
-					    vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					    vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	XYCanvasDisk->cd();
 	PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
 	xyDiskDrawer.addModules(lastDisk);
-	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
-	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
+	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
+	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
 	drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
-	XYPosBundlesDisks.push_back(XYCanvasDisk);
+	XYPosBundlesDisks.push_back(std::move(XYCanvasDisk));
       }
     }
 
@@ -7341,31 +7373,31 @@ namespace insur {
 	    // Surface seen rotated: (+Z) towards the depth of the screen
 	    if ((surfaceIndex % 2) == 1) {
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosRotateY180BundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosRotateY180BundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      PlotDrawer<XYRotateY180, TypeBundleColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
 	      const bool isRotatedY180 = true;
 	      drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
-	      XYPosBundlesDiskSurfaces.push_back(XYSurfaceDisk);
+	      XYPosBundlesDiskSurfaces.push_back(std::move(XYSurfaceDisk));
 	    }
 	    // (+Z) towards you
 	    else {
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
 	      drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
-	      XYPosBundlesDiskSurfaces.push_back(XYSurfaceDisk);
+	      XYPosBundlesDiskSurfaces.push_back(std::move(XYSurfaceDisk));
 	    }
 	  }
 	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
@@ -7378,18 +7410,18 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       if (anEndcap.disks().size() > 0) {
 	const Disk& firstDisk = anEndcap.disks().front();
-	TCanvas* XYNegCanvasDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
+	std::unique_ptr<TCanvas> XYNegCanvasDisk(new TCanvas(Form("XYNegBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
 					       Form("(XY) Projection : Endcap %s, any Disk. (CMS +Z points towards the depth of the screen)", 
 						    anEndcap.myid().c_str()),
-					       vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					       vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	XYNegCanvasDisk->cd();
 	PlotDrawer<XYNegRotateY180, TypeBundleColor> xyDiskDrawer;
 	xyDiskDrawer.addModules(firstDisk);
-	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvasDisk);
-	xyDiskDrawer.drawModules<ContourStyle>(*XYNegCanvasDisk);
+	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvasDisk.get());
+	xyDiskDrawer.drawModules<ContourStyle>(*XYNegCanvasDisk.get());
 	const bool isRotatedY180 = true;
 	drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
-	XYNegBundlesDisks.push_back(XYNegCanvasDisk);
+	XYNegBundlesDisks.push_back(std::move(XYNegCanvasDisk));
       }
     }
 
@@ -7404,33 +7436,33 @@ namespace insur {
 	    // (+Z) towards you
 	    if ((surfaceIndex % 2) == 1) {
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYNegSurfaceDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYNegSurfaceDisk(new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						      Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", 
 							   anEndcap.myid().c_str(), surfaceIndex),
-						      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYNegSurfaceDisk->cd();
 	      PlotDrawer<XYNeg, TypeBundleColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk);
-	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk);
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk.get());
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk.get());
 	      drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
-	      XYNegBundlesDiskSurfaces.push_back(XYNegSurfaceDisk);
+	      XYNegBundlesDiskSurfaces.push_back(std::move(XYNegSurfaceDisk));
 	    }
 	    // Surface seen rotated: (+Z) towards the depth of the screen
 	    else {
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYNegSurfaceDisk = new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYNegSurfaceDisk(new TCanvas(Form("XYNegBundleEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						      Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", 
 							   anEndcap.myid().c_str(), surfaceIndex),
-						      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYNegSurfaceDisk->cd();
 	      PlotDrawer<XYNegRotateY180, TypeBundleColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk);
-	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk);
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk.get());
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk.get());
 	      const bool isRotatedY180 = true;
 	      drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
-	      XYNegBundlesDiskSurfaces.push_back(XYNegSurfaceDisk);
+	      XYNegBundlesDiskSurfaces.push_back(std::move(XYNegSurfaceDisk));
 	    }
 	  }
 	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
@@ -7445,69 +7477,69 @@ namespace insur {
    * DTC cabling plots.
    */
   void Vizard::createOuterCablingPlotsDTCs(Tracker& tracker,
-					   TCanvas *&RZCanvas, 
-					   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
-					   std::vector<TCanvas*> &XYCanvasesDisk) {
+					   std::unique_ptr<TCanvas> &RZCanvas, 
+					   std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYNegFlatCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYFlatCanvas, 
+					   std::vector<std::unique_ptr<TCanvas> > &XYCanvasesDisk) {
 
     const std::set<Module*>& trackerModules = tracker.modules();
-    RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY);
+    RZCanvas.reset(new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY));
     RZCanvas->cd();
     PlotDrawer<YZFull, TypeDTCTransparentColor> yzDrawer;
     yzDrawer.addModules(trackerModules.begin(), trackerModules.end(), [] (const Module& m ) { 
 	return ( (m.isPositiveCablingSide() > 0 && m.dtcPhiSectorRef() == 1) || (m.isPositiveCablingSide() < 0 && m.dtcPhiSectorRef() == 2) ); 
       } );
-    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
-    yzDrawer.drawModules<ContourStyle>(*RZCanvas);
+    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas.get());
+    yzDrawer.drawModules<ContourStyle>(*RZCanvas.get());
 
     // NEGATIVE CABLING SIDE. BARREL.
-    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas.reset(new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegCanvas->cd();
     PlotDrawer<XYNeg, TypeDTCColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0)); } );
-    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
-    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas.get());
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
-    XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegFlatCanvas.reset(new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegFlatCanvas->cd();
     PlotDrawer<XYNeg, TypeDTCColor> xyNegFlatBarrelDrawer;
     xyNegFlatBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0) && !m.isTilted()); } );
-    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
-    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
+    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas.get());
+    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 
     // POSITIVE CABLING SIDE. BARREL.
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCanvas->cd();
     PlotDrawer<XY, TypeDTCColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0)); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
-    XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYFlatCanvas.reset(new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYFlatCanvas->cd();
     PlotDrawer<XY, TypeDTCColor> xyBarrelFlatDrawer;
     xyBarrelFlatDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0) && !m.isTilted()); } );
-    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
-    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
+    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas.get());
+    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     
     // ENDCAPS DISK.
     for (auto& anEndcap : tracker.endcaps() ) {
       for (auto& aDisk : anEndcap.disks() ) {
 	if (aDisk.side()) {
-	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosDTCEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  std::unique_ptr<TCanvas> XYCanvasDisk(new TCanvas(Form("XYPosDTCEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
-					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	  XYCanvasDisk->cd();
 	  PlotDrawer<XY, TypeDTCColor> xyDiskDrawer;
 	  xyDiskDrawer.addModules(aDisk);
-	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
-	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
-	  XYCanvasesDisk.push_back(XYCanvasDisk);
+	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
+	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
+	  XYCanvasesDisk.push_back(std::move(XYCanvasDisk));
 	  drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 	}
       }
@@ -7519,8 +7551,8 @@ namespace insur {
    * Optical cables channels assignments plots.
    */
   void Vizard::createOuterCablingPlotsServicesChannelsOptical(Tracker& tracker, const OuterCablingMap* myCablingMap,
-							   TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
-							   std::vector<TCanvas*> &XYCanvasesDisk) {
+							   std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYNegFlatCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYFlatCanvas, 
+							   std::vector<std::unique_ptr<TCanvas> > &XYCanvasesDisk) {
     bool isPowerCabling = false;
     bool isPositiveCablingSide = true;
     TLegend* channelsLegendPos = new TLegend(0.905,0.3,1.0,0.8);
@@ -7530,42 +7562,42 @@ namespace insur {
     computeServicesChannelsLegend(channelsLegendNeg, myCablingMap, isPositiveCablingSide, isPowerCabling);
 
     // NEGATIVE CABLING SIDE. BARREL.
-    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas.reset(new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegCanvas->cd();
     PlotDrawer<XYNeg, TypeOpticalChannelColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0)); } );
-    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
-    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas.get());
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     channelsLegendNeg->Draw("same"); 
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
-    XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegFlatCanvas.reset(new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegFlatCanvas->cd();
     PlotDrawer<XYNeg, TypeOpticalChannelColor> xyNegFlatBarrelDrawer;
     xyNegFlatBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0) && !m.isTilted()); } );
-    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
-    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
+    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas.get());
+    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     channelsLegendNeg->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCanvas->cd();
     PlotDrawer<XY, TypeOpticalChannelColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0)); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     channelsLegendPos->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
-    XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYFlatCanvas.reset(new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYFlatCanvas->cd();
     PlotDrawer<XY, TypeOpticalChannelColor> xyBarrelFlatDrawer;
     xyBarrelFlatDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0) && !m.isTilted()); } );
-    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
-    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
+    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas.get());
+    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     channelsLegendPos->Draw("same");
     
@@ -7573,15 +7605,15 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       for (auto& aDisk : anEndcap.disks() ) {
 	if (aDisk.side()) {
-	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosOpticalChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  std::unique_ptr<TCanvas> XYCanvasDisk(new TCanvas(Form("XYPosOpticalChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
-					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	  XYCanvasDisk->cd();
 	  PlotDrawer<XY, TypeOpticalChannelColor> xyDiskDrawer;
 	  xyDiskDrawer.addModules(aDisk);
-	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
-	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
-	  XYCanvasesDisk.push_back(XYCanvasDisk);
+	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
+	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
+	  XYCanvasesDisk.push_back(std::move(XYCanvasDisk));
 	  drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
 	  channelsLegendPos->Draw("same");
 	}
@@ -7594,8 +7626,8 @@ namespace insur {
    * Power cables channels assignments plots.
    */
   void Vizard::createOuterCablingPlotsServicesChannelsPower(Tracker& tracker, const OuterCablingMap* myCablingMap,
-							    TCanvas *&XYNegCanvas, TCanvas *&XYNegFlatCanvas, TCanvas *&XYCanvas, TCanvas *&XYFlatCanvas, 
-							    std::vector<TCanvas*> &XYCanvasesDisk, std::vector<TCanvas*> &XYNegCanvasesDisk) {
+							    std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYNegFlatCanvas, std::unique_ptr<TCanvas> &XYCanvas, std::unique_ptr<TCanvas> &XYFlatCanvas, 
+							    std::vector<std::unique_ptr<TCanvas> > &XYCanvasesDisk, std::vector<std::unique_ptr<TCanvas> > &XYNegCanvasesDisk) {
     bool isPowerCabling = true;
 
     bool isPositiveCablingSide = true;
@@ -7607,44 +7639,44 @@ namespace insur {
 
     // NEGATIVE CABLING SIDE. BARREL.
     bool isRotatedY180 = true;
-    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas.reset(new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegCanvas->cd();
     PlotDrawer<XYNegRotateY180, TypePowerChannelColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0)); } );
-    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
-    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas.get());
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
     channelsLegendNeg->Draw("same");
 
     // NEGATIVE CABLING SIDE. BARREL FLAT PART.
     isRotatedY180 = true;
-    XYNegFlatCanvas = new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegFlatCanvas.reset(new TCanvas("XYNegFlatCanvas", "XYNegFlatView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegFlatCanvas->cd();
     PlotDrawer<XYNegRotateY180, TypePowerChannelColor> xyNegFlatBarrelDrawer;
     xyNegFlatBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() < 0) && !m.isTilted()); } );
-    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas);
-    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas);
+    xyNegFlatBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegFlatCanvas.get());
+    xyNegFlatBarrelDrawer.drawModules<ContourStyle>(*XYNegFlatCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
     channelsLegendNeg->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL.
     isRotatedY180 = false;
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCanvas->cd();
     PlotDrawer<XY, TypePowerChannelColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0)); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     channelsLegendPos->Draw("same");
 
     // POSITIVE CABLING SIDE. BARREL FLAT PART.
-    XYFlatCanvas = new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYFlatCanvas.reset(new TCanvas("XYFlatCanvas", "XYView FlatCanvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYFlatCanvas->cd();
     PlotDrawer<XY, TypePowerChannelColor> xyBarrelFlatDrawer;
     xyBarrelFlatDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return ((m.subdet() == BARREL) && (m.isPositiveCablingSide() > 0) && !m.isTilted()); } );
-    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas);
-    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas);
+    xyBarrelFlatDrawer.drawFrame<SummaryFrameStyle>(*XYFlatCanvas.get());
+    xyBarrelFlatDrawer.drawModules<ContourStyle>(*XYFlatCanvas.get());
     drawPhiSectorsBoundaries(outer_cabling_nonantWidth);  // Spider lines
     channelsLegendPos->Draw("same");
     
@@ -7653,30 +7685,30 @@ namespace insur {
 	// POSITIVE CABLING SIDE. ENDCAPS DISK.
 	if (aDisk.side()) {
 	  isRotatedY180 = false;
-	  TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosPowerChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  std::unique_ptr<TCanvas> XYCanvasDisk(new TCanvas(Form("XYPosPowerChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards you)", anEndcap.myid().c_str(), aDisk.myid()),
-					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	  XYCanvasDisk->cd();
 	  PlotDrawer<XY, TypePowerChannelColor> xyDiskDrawer;
 	  xyDiskDrawer.addModules(aDisk);
-	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
-	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
-	  XYCanvasesDisk.push_back(XYCanvasDisk);
+	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
+	  xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
+	  XYCanvasesDisk.push_back(std::move(XYCanvasDisk));
 	  drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
 	  channelsLegendPos->Draw("same");
 	}
 	// NEGATIVE CABLING SIDE. ENDCAPS DISK.
 	else {
 	  isRotatedY180 = true;
-	  TCanvas* XYNegCanvasDisk = new TCanvas(Form("XYNegPowerChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
+	  std::unique_ptr<TCanvas> XYNegCanvasDisk(new TCanvas(Form("XYNegPowerChannelsEndcap_%sDisk_%d", anEndcap.myid().c_str(), aDisk.myid()),
 					      Form("(XY) Projection : Endcap %s Disk %d. (CMS +Z points towards the depth of the screen)", anEndcap.myid().c_str(), aDisk.myid()),
-					      vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+					      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	  XYNegCanvasDisk->cd();
 	  PlotDrawer<XYNegRotateY180, TypePowerChannelColor> xyDiskDrawer;
 	  xyDiskDrawer.addModules(aDisk);
-	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvasDisk);
-	  xyDiskDrawer.drawModules<ContourStyle>(*XYNegCanvasDisk);
-	  XYNegCanvasesDisk.push_back(XYNegCanvasDisk);
+	  xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvasDisk.get());
+	  xyDiskDrawer.drawModules<ContourStyle>(*XYNegCanvasDisk.get());
+	  XYNegCanvasesDisk.push_back(std::move(XYNegCanvasDisk));
 	  drawPhiSectorsBoundaries(outer_cabling_nonantWidth, isRotatedY180);  // Spider lines
 	  channelsLegendNeg->Draw("same");
 	}
@@ -7909,9 +7941,9 @@ namespace insur {
    * Power chains plots
    */
   void Vizard::createInnerCablingPlotsPowerChains(const Tracker& tracker,
-						  std::vector<TCanvas*> &ZPhiLayerPlots,
-						  TCanvas *&XYNegCanvas, TCanvas *&XYCentralCanvas, TCanvas *&XYCanvas,
-						  std::vector<TCanvas*> &XYPosPowerChainsDiskSurfaces) {
+						  std::vector<std::unique_ptr<TCanvas> > &ZPhiLayerPlots,
+						  std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYCentralCanvas, std::unique_ptr<TCanvas> &XYCanvas,
+						  std::vector<std::unique_ptr<TCanvas> > &XYPosPowerChainsDiskSurfaces) {
 
     const std::pair<double, double> maxRadii = computeInnerCablingPlotsMaxRadii(tracker);
     const double forwardViewPort = maxRadii.second;
@@ -7924,8 +7956,8 @@ namespace insur {
     const int numLayers = tracker.barrels().at(0).layers().size(); // TO DO : ugly
     for (int layerNumber = 1; layerNumber <= numLayers; layerNumber++) {
       // POSITIVE X SIDE
-      TCanvas* ZPhiCanvasPos = new TCanvas(Form("ZPhiPowerChainBarrelLayer%d_positiveXSide", layerNumber),
-					Form("(ZPhi), Barrel Layer %d. (+X) side.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+      std::unique_ptr<TCanvas> ZPhiCanvasPos(new TCanvas(Form("ZPhiPowerChainBarrelLayer%d_positiveXSide", layerNumber),
+					Form("(ZPhi), Barrel Layer %d. (+X) side.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasPos->cd();
       PlotDrawer<ZPhi, TypePowerChainTransparentColor> zphiBarrelDrawerPos;
       zphiBarrelDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
@@ -7934,12 +7966,12 @@ namespace insur {
 		  && m.isPositiveXSide()
 		  ); 
 	} );
-      zphiBarrelDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos);
-      zphiBarrelDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos);
-      ZPhiLayerPlots.push_back(ZPhiCanvasPos);
+      zphiBarrelDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
+      zphiBarrelDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
+      ZPhiLayerPlots.push_back(std::move(ZPhiCanvasPos));
       // NEGATIVE X SIDE
-      TCanvas* ZPhiCanvasNeg = new TCanvas(Form("ZPhiPowerChainBarrelLayer%d_negativeXSide", layerNumber),
-					Form("(ZPhi), Barrel Layer %d. (-X) side.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+      std::unique_ptr<TCanvas> ZPhiCanvasNeg(new TCanvas(Form("ZPhiPowerChainBarrelLayer%d_negativeXSide", layerNumber),
+					Form("(ZPhi), Barrel Layer %d. (-X) side.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasNeg->cd();
       PlotDrawer<ZPhi, TypePowerChainTransparentColor> zphiBarrelDrawerNeg;
       zphiBarrelDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
@@ -7948,39 +7980,39 @@ namespace insur {
 		  && !m.isPositiveXSide()
 		  ); 
 	} );
-      zphiBarrelDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg);
-      zphiBarrelDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg);
-      ZPhiLayerPlots.push_back(ZPhiCanvasNeg);
+      zphiBarrelDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
+      zphiBarrelDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
+      ZPhiLayerPlots.push_back(std::move(ZPhiCanvasNeg));
     }
        
     // NEGATIVE CABLING SIDE. BARREL (XY).
     bool isRotatedY180 = false;
-    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas.reset(new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegCanvas->cd();
     PlotDrawer<XYNeg, TypePowerChainTransparentColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveZEnd() < 0); } );
-    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
-    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas.get());
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas.get());
     drawFrameOfReference(isRotatedY180, barrelScalingFactor);
 
     // POSITIVE CABLING SIDE. BARREL CENTRAL MODULES (XY).
     isRotatedY180 = false;
-    XYCentralCanvas = new TCanvas("XYCentralCanvas", "XYCentralView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCentralCanvas.reset(new TCanvas("XYCentralCanvas", "XYCentralView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCentralCanvas->cd();
     PlotDrawer<XY, TypePowerChainTransparentColor> xyCentralBarrelDrawer;
     xyCentralBarrelDrawer.addModules( tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.uniRef().ring == 1); } );
-    xyCentralBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCentralCanvas);
-    xyCentralBarrelDrawer.drawModules<ContourStyle>(*XYCentralCanvas);
+    xyCentralBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCentralCanvas.get());
+    xyCentralBarrelDrawer.drawModules<ContourStyle>(*XYCentralCanvas.get());
     drawFrameOfReference(isRotatedY180, barrelScalingFactor);
 
     // POSITIVE CABLING SIDE. BARREL (XY).
     isRotatedY180 = false;
-    XYCanvas = new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYCanvas.reset(new TCanvas("XYCanvas", "XYView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYCanvas->cd();
     PlotDrawer<XY, TypePowerChainTransparentColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveZEnd() > 0); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYCanvas.get());
     drawFrameOfReference(isRotatedY180, barrelScalingFactor);
 
     // ENDCAPS DISK SURFACE.
@@ -7995,31 +8027,31 @@ namespace insur {
 	    if ((surfaceIndex % 2) == 1) {
 	      isRotatedY180 = true;;
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosRotateY180PowerChainEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosRotateY180PowerChainEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						   Form("(XY) Section : %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      PlotDrawer<XYRotateY180, TypePowerChainTransparentColor> xyDiskDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
 	      drawFrameOfReference(isRotatedY180, forwardScalingFactor);
-	      XYPosPowerChainsDiskSurfaces.push_back(XYSurfaceDisk);
+	      XYPosPowerChainsDiskSurfaces.push_back(std::move(XYSurfaceDisk));
 	    }
 	    // (+Z) towards you
 	    else {
 	      isRotatedY180 = false;
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosPowerChainEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosPowerChainEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						   Form("(XY) Section : %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      PlotDrawer<XY, TypePowerChainTransparentColor> xyDiskDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
-	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
 	      drawFrameOfReference(isRotatedY180, forwardScalingFactor);
-	      XYPosPowerChainsDiskSurfaces.push_back(XYSurfaceDisk);
+	      XYPosPowerChainsDiskSurfaces.push_back(std::move(XYSurfaceDisk));
 	    }
 	  }
 	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
@@ -8034,8 +8066,8 @@ namespace insur {
    * GBT plots.
    */
   void Vizard::createInnerCablingPlotsGBTs(const Tracker& tracker,
-					   std::vector<TCanvas*> &ZPhiLayerPlots,
-					   std::vector<TCanvas*> &XYPosGBTsDiskSurfaces) {
+					   std::vector<std::unique_ptr<TCanvas> > &ZPhiLayerPlots,
+					   std::vector<std::unique_ptr<TCanvas> > &XYPosGBTsDiskSurfaces) {
 
     const std::pair<double, double> maxRadii = computeInnerCablingPlotsMaxRadii(tracker);
     const double forwardViewPort = maxRadii.second;
@@ -8047,8 +8079,8 @@ namespace insur {
     const int numLayers = tracker.barrels().at(0).layers().size(); // TO DO : ugly
     for (int layerNumber = 1; layerNumber <= numLayers; layerNumber++) {
       // POSITIVE X SIDE
-      TCanvas* ZPhiCanvasPos = new TCanvas(Form("ZPhiGBTBarrelLayer%d_positiveXSide", layerNumber),
-					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+      std::unique_ptr<TCanvas> ZPhiCanvasPos(new TCanvas(Form("ZPhiGBTBarrelLayer%d_positiveXSide", layerNumber),
+					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasPos->cd();
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerPos;
@@ -8059,8 +8091,8 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
 		  ); 
 	} );
-      zphiBarrelContourDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos);
-      zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos);
+      zphiBarrelContourDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
+      zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
       // Filled modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelFillDrawerPos;
       zphiBarrelFillDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
@@ -8070,11 +8102,11 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 		  ); 
 	} );
-      zphiBarrelFillDrawerPos.drawModules<FillStyle>(*ZPhiCanvasPos);
-      ZPhiLayerPlots.push_back(ZPhiCanvasPos);
+      zphiBarrelFillDrawerPos.drawModules<FillStyle>(*ZPhiCanvasPos.get());
+      ZPhiLayerPlots.push_back(std::move(ZPhiCanvasPos));
       // NEGATIVE X SIDE
-      TCanvas* ZPhiCanvasNeg = new TCanvas(Form("ZPhiGBTBarrelLayer%d_negativeXSide", layerNumber),
-					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+      std::unique_ptr<TCanvas> ZPhiCanvasNeg(new TCanvas(Form("ZPhiGBTBarrelLayer%d_negativeXSide", layerNumber),
+					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasNeg->cd();
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerNeg;
@@ -8085,8 +8117,8 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
 		  ); 
 	} );
-      zphiBarrelContourDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg);
-      zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg);
+      zphiBarrelContourDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
+      zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
       // Filled modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelFillDrawerNeg;
       zphiBarrelFillDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
@@ -8096,8 +8128,8 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 		  ); 
 	} );
-      zphiBarrelFillDrawerNeg.drawModules<FillStyle>(*ZPhiCanvasNeg);
-      ZPhiLayerPlots.push_back(ZPhiCanvasNeg);
+      zphiBarrelFillDrawerNeg.drawModules<FillStyle>(*ZPhiCanvasNeg.get());
+      ZPhiLayerPlots.push_back(std::move(ZPhiCanvasNeg));
     }
 
 
@@ -8114,9 +8146,9 @@ namespace insur {
 	    if ((surfaceIndex % 2) == 1) {
 	      bool isRotatedY180 = true;;
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosRotateY180GBTEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosRotateY180GBTEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						   Form("(XY) Section : %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      // Filled modules
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskFillDrawer(forwardViewPort, forwardViewPort);
@@ -8125,8 +8157,8 @@ namespace insur {
 			   && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
 			   );
 		} );
-	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	      xyDiskFillDrawer.drawModules<FillStyle>(*XYSurfaceDisk);
+	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskFillDrawer.drawModules<FillStyle>(*XYSurfaceDisk.get());
 	      // Contour modules
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskContourDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskContourDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
@@ -8134,17 +8166,17 @@ namespace insur {
 			   && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 			   );
 		} );
-	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
 	      drawFrameOfReference(isRotatedY180, forwardScalingFactor);
-	      XYPosGBTsDiskSurfaces.push_back(XYSurfaceDisk);
+	      XYPosGBTsDiskSurfaces.push_back(std::move(XYSurfaceDisk));
 	    }
 	    // (+Z) towards you
 	    else {
 	      bool isRotatedY180 = false;
 	      const std::vector<const Module*>& surfaceModules = found->second;
-	      TCanvas* XYSurfaceDisk = new TCanvas(Form("XYPosGBTEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
+	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosGBTEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
 						   Form("(XY) Section : %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      // Filled modules
 	      PlotDrawer<XY, TypeGBTTransparentColor> xyDiskFillDrawer(forwardViewPort, forwardViewPort);
@@ -8153,8 +8185,8 @@ namespace insur {
 			   && (femod((m.getGBT() ? m.getGBT()->GBTPhiIndex() : 0), 2) == 0)
 			   );
 		} );
-	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk);
-	      xyDiskFillDrawer.drawModules<FillStyle>(*XYSurfaceDisk);
+	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskFillDrawer.drawModules<FillStyle>(*XYSurfaceDisk.get());
 	      // Contour modules
 	      PlotDrawer<XY, TypeGBTTransparentColor> xyDiskContourDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskContourDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
@@ -8162,9 +8194,9 @@ namespace insur {
 			   && (femod((m.getGBT() ? m.getGBT()->GBTPhiIndex() : 0), 2) == 1)
 			   );
 		} );
-	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk);
+	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
 	      drawFrameOfReference(isRotatedY180, forwardScalingFactor);
-	      XYPosGBTsDiskSurfaces.push_back(XYSurfaceDisk);
+	      XYPosGBTsDiskSurfaces.push_back(std::move(XYSurfaceDisk));
 	    }
 	  }
 	  else logERROR("Tried to access modules belonging to one of the 4 disk surfaces, but empty container.");
@@ -8179,8 +8211,8 @@ namespace insur {
    * Bundles plots.
    */
   void Vizard::createInnerCablingPlotsBundles(const Tracker& tracker,
-					      TCanvas *&XYNegCanvas, TCanvas *&XYPosCanvas,
-					      std::vector<TCanvas*> &XYPosBundlesDisks) {
+					      std::unique_ptr<TCanvas> &XYNegCanvas, std::unique_ptr<TCanvas> &XYPosCanvas,
+					      std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDisks) {
 
     const std::pair<double, double> maxRadii = computeInnerCablingPlotsMaxRadii(tracker);
     const double forwardViewPort = maxRadii.second;
@@ -8191,22 +8223,22 @@ namespace insur {
        
     // NEGATIVE CABLING SIDE. BARREL.
     bool isRotatedY180 = false;
-    XYNegCanvas = new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYNegCanvas.reset(new TCanvas("XYNegCanvas", "XYNegView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYNegCanvas->cd();
     PlotDrawer<XYNeg, TypeInnerBundleTransparentColor> xyNegBarrelDrawer;
     xyNegBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveZEnd() < 0); } );
-    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas);
-    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas);
+    xyNegBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvas.get());
+    xyNegBarrelDrawer.drawModules<ContourStyle>(*XYNegCanvas.get());
     drawFrameOfReference(isRotatedY180, barrelScalingFactor);
 
     // POSITIVE CABLING SIDE. BARREL.
     isRotatedY180 = false;
-    XYPosCanvas = new TCanvas("XYPosCanvas", "XYPosView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYPosCanvas.reset(new TCanvas("XYPosCanvas", "XYPosView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYPosCanvas->cd();
     PlotDrawer<XY, TypeInnerBundleTransparentColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(tracker.modules().begin(), tracker.modules().end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveZEnd() > 0); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYPosCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYPosCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYPosCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYPosCanvas.get());
     drawFrameOfReference(isRotatedY180, barrelScalingFactor);
 
     // POSITIVE CABLING SIDE.
@@ -8215,17 +8247,17 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       if (anEndcap.disks().size() > 0) {
 	const Disk& lastDisk = anEndcap.disks().back();
-	TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
+	std::unique_ptr<TCanvas> XYCanvasDisk(new TCanvas(Form("XYPosBundleEndcap_%sAnyDisk", anEndcap.myid().c_str()),
 					    Form("(XY) Projection : %s, any Disk. (CMS +Z points towards you). 1 color <=> 1 Fibre Bundle.", 
 						 anEndcap.myid().c_str()),
-					    vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+					    vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	XYCanvasDisk->cd();
 	PlotDrawer<XY, TypeInnerBundleTransparentColor> xyDiskDrawer(forwardViewPort, forwardViewPort);
 	xyDiskDrawer.addModules(lastDisk);
-	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
-	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
+	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
+	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
 	drawFrameOfReference(isRotatedY180, forwardScalingFactor);
-	XYPosBundlesDisks.push_back(XYCanvasDisk);
+	XYPosBundlesDisks.push_back(std::move(XYCanvasDisk));
       }
     }
 
@@ -8236,17 +8268,17 @@ namespace insur {
    * DTC plots.
    */
   void Vizard::createInnerCablingPlotsDTCs(const Tracker& tracker,
-					   TCanvas *&RZCanvas,
-					   TCanvas *&XYPosCanvas,
-					   std::vector<TCanvas*> &XYPosDTCsDisks) {
+					   std::unique_ptr<TCanvas> &RZCanvas,
+					   std::unique_ptr<TCanvas> &XYPosCanvas,
+					   std::vector<std::unique_ptr<TCanvas> > &XYPosDTCsDisks) {
 
     const std::set<Module*>& trackerModules = tracker.modules();
-    RZCanvas = new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY);
+    RZCanvas.reset(new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY));
     RZCanvas->cd();
     PlotDrawer<YZFull, TypeInnerDTCTransparentColor> yzDrawer;
     yzDrawer.addModules(tracker);
-    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas);
-    yzDrawer.drawModules<ContourStyle>(*RZCanvas);
+    yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas.get());
+    yzDrawer.drawModules<ContourStyle>(*RZCanvas.get());
 
     const std::pair<double, double> maxRadii = computeInnerCablingPlotsMaxRadii(tracker);
     const double forwardViewPort = maxRadii.second;
@@ -8257,12 +8289,12 @@ namespace insur {
 
     // POSITIVE CABLING SIDE. BARREL.
     bool isRotatedY180 = false;
-    XYPosCanvas = new TCanvas("XYPosCanvas", "XYPosView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY );
+    XYPosCanvas.reset(new TCanvas("XYPosCanvas", "XYPosView Canvas", vis_min_canvas_sizeX, vis_min_canvas_sizeY ));
     XYPosCanvas->cd();
     PlotDrawer<XY, TypeInnerDTCTransparentColor> xyBarrelDrawer;
     xyBarrelDrawer.addModules(trackerModules.begin(), trackerModules.end(), [] (const Module& m ) { return (m.subdet() == BARREL && m.isPositiveZEnd() > 0); } );
-    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYPosCanvas);
-    xyBarrelDrawer.drawModules<ContourStyle>(*XYPosCanvas);
+    xyBarrelDrawer.drawFrame<SummaryFrameStyle>(*XYPosCanvas.get());
+    xyBarrelDrawer.drawModules<ContourStyle>(*XYPosCanvas.get());
     drawFrameOfReference(isRotatedY180, barrelScalingFactor);
 
     // POSITIVE CABLING SIDE.
@@ -8271,17 +8303,17 @@ namespace insur {
     for (auto& anEndcap : tracker.endcaps() ) {
       if (anEndcap.disks().size() > 0) {
 	const Disk& lastDisk = anEndcap.disks().back();
-	TCanvas* XYCanvasDisk = new TCanvas(Form("XYPosDTCEndcap_%sAnyDisk", anEndcap.myid().c_str()),
+	std::unique_ptr<TCanvas> XYCanvasDisk(new TCanvas(Form("XYPosDTCEndcap_%sAnyDisk", anEndcap.myid().c_str()),
 					    Form("(XY) Projection : %s, one Disk. (CMS +Z points towards you). 1 color <=> 1 DTC.", 
 						 anEndcap.myid().c_str()),
-					    vis_min_canvas_sizeX, vis_min_canvas_sizeY);
+					    vis_min_canvas_sizeX, vis_min_canvas_sizeY));
 	XYCanvasDisk->cd();
 	PlotDrawer<XY, TypeInnerDTCTransparentColor> xyDiskDrawer(forwardViewPort, forwardViewPort);
 	xyDiskDrawer.addModules(lastDisk);
-	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk);
-	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk);
+	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
+	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
 	drawFrameOfReference(isRotatedY180, forwardScalingFactor);
-	XYPosDTCsDisks.push_back(XYCanvasDisk);
+	XYPosDTCsDisks.push_back(std::move(XYCanvasDisk));
       }
     }
   }
@@ -8376,7 +8408,7 @@ namespace insur {
 
   // Helper function to convert a histogram into a TProfile
   TProfile* Vizard::newProfile(TH1D* sourceHistogram, double xlow, double xup, int desiredNBins /* = 0 */) {
-    if (sourceHistogram == NULL) return NULL;
+    if (!sourceHistogram) return nullptr;
     int nBins = sourceHistogram->GetNbinsX();
     if (desiredNBins != 0 && desiredNBins < nBins) nBins = desiredNBins;
     TProfile* resultProfile = new TProfile(Form("%s_profile",sourceHistogram->GetName()),
@@ -9154,7 +9186,7 @@ namespace insur {
     // Graphic representation of the materials volumes in the (RZ) plane
     double maxR = myTracker.maxR()*1.2;
     double maxZ = myTracker.maxZ()*1.2;
-    TCanvas* allVolumesCanvas = new TCanvas("allVolumesCanvas", "allVolumesCanvas"); // TODO Factory for canvases?!
+    std::unique_ptr<TCanvas> allVolumesCanvas(new TCanvas("allVolumesCanvas", "allVolumesCanvas")); // TODO Factory for canvases?!
     allVolumesCanvas->cd();
     TH2D* allVolumesPlot = new TH2D("allVolumesPlot", ";z [mm];r [mm]", 200, -maxZ, maxZ, 100, 0, maxR);
     allVolumesPlot->Draw();
@@ -9169,7 +9201,7 @@ namespace insur {
 
     WeightsPerSubdetector totalWeights;
     //std::vector<MaterialProperties*> totalMaterials;
-    //Vector<unique_ptr<Base>>.  vec.emplace_back(new Derived())
+    //Vector<unique_ptr<Base> >.  vec.emplace_back(new Derived())
 
     std::vector<int> allColors;
     allColors.push_back(kOrange);
@@ -9268,7 +9300,7 @@ namespace insur {
     allVolumesPlot->GetXaxis()->SetRangeUser(-maxZ, maxZ);
     allVolumesPlot->GetYaxis()->SetRangeUser(0, maxR);
 
-    RootWImage& servicesImage = myContent.addImage(allVolumesCanvas, vis_max_canvas_sizeX, vis_min_canvas_sizeY);
+    RootWImage& servicesImage = myContent.addImage(std::move(allVolumesCanvas), vis_max_canvas_sizeX, vis_min_canvas_sizeY);
     servicesImage.setComment("All material volumes, (RZ) view.");
     servicesImage.setName("AllMaterialVolumesRZ");
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -6596,47 +6596,50 @@ namespace insur {
 
       int nBins = profileNames.size();
 
-      TH1D myFrame("myFrame", "", nBins, 0, nBins);
-      myFrame.SetYTitle("Optimal distance range [mm]");
-      myFrame.SetMinimum(0);
-      myFrame.SetMaximum(6);
-      TAxis* xAxis = myFrame.GetXaxis();
+      TH1D* myFrame = new TH1D("myFrame", "", nBins, 0, nBins);
+      myFrame->SetYTitle("Optimal distance range [mm]");
+      myFrame->SetMinimum(0);
+      myFrame->SetMaximum(6);
+      TAxis* xAxis = myFrame->GetXaxis();
 
-      TGraphErrors rangeGraphBad;
-      TGraphErrors rangeGraph;
+      TGraphErrors* rangeGraphBad = new TGraphErrors();
+      TGraphErrors* rangeGraph = new TGraphErrors();
       int rangeGraphPoints;
 
       std::map<int, TGraphErrors>& spacingTuningGraphs = a.getSpacingTuningGraphs();
       TGraphErrors& availableSpacings = spacingTuningGraphs[-1];
 
-
       for (unsigned int i=0; i<profileNames.size(); ++i) {
-        double min = a.getTriggerRangeLowLimit(profileNames[i]);
-        double max = a.getTriggerRangeHighLimit(profileNames[i]);
-        tempString = profileNames[i];
-        tempString.substr(profileBag::TriggerProfileName.size(), tempString.size()-profileBag::TriggerProfileName.size());
-        xAxis->SetBinLabel(i+1, tempString.c_str());
-        if (min<max) {
-          rangeGraphPoints=rangeGraph.GetN();
-          rangeGraph.SetPoint(rangeGraphPoints, i+0.5, (min+max)/2.);
-          rangeGraph.SetPointError(rangeGraphPoints, 0.25, (max-min)/2.);
-        } else {
-          rangeGraphPoints=rangeGraphBad.GetN();
-          rangeGraphBad.SetPoint(rangeGraphPoints, i+0.5, (min+max)/2.);
-          rangeGraphBad.SetPointError(rangeGraphPoints, 0.25, (min-max)/2.);
-        }
+	double min = a.getTriggerRangeLowLimit(profileNames[i]);
+	double max = a.getTriggerRangeHighLimit(profileNames[i]);
+	tempString = profileNames[i];
+	tempString.substr(profileBag::TriggerProfileName.size(), tempString.size()-profileBag::TriggerProfileName.size());
+	xAxis->SetBinLabel(i+1, tempString.c_str());
+	if (min<max) {
+	  rangeGraphPoints=rangeGraph->GetN();
+	  rangeGraph->SetPoint(rangeGraphPoints, i+0.5, (min+max)/2.);
+	  rangeGraph->SetPointError(rangeGraphPoints, 0.25, (max-min)/2.);
+	} else {
+	  rangeGraphPoints=rangeGraph->GetN();
+	  rangeGraphBad->SetPoint(rangeGraphPoints, i+0.5, (min+max)/2.);
+	  rangeGraphBad->SetPointError(rangeGraphPoints, 0.25, (min-max)/2.);
+	}
       }
 
       TCanvas* rangeCanvas = new TCanvas();
       rangeCanvas->cd();
       rangeCanvas->SetFillColor(color_plot_background);
       rangeCanvas->SetGrid(0,1);
-      myFrame.Draw();
-      rangeGraph.SetFillColor(Palette::color(1));
-      rangeGraph.Draw("same 2");
-      rangeGraphBad.SetFillColor(Palette::color(2));
-      rangeGraphBad.Draw("same 2");
+      myFrame->SetBit(1); // rangeCanvas takes ownership of it
+      myFrame->Draw();
+      rangeGraph->SetFillColor(Palette::color(1));
+      rangeGraph->SetBit(1);  // rangeCanvas takes ownership of it
+      rangeGraph->Draw("same 2");
+      rangeGraphBad->SetFillColor(Palette::color(2));
+      rangeGraphBad->SetBit(1);  // rangeCanvas takes ownership of it
+      rangeGraphBad->Draw("same 2");
       availableSpacings.SetMarkerStyle(0);
+      availableSpacings.SetBit(0);
       availableSpacings.Draw("p same");
 
       RootWImage& RangeImage = spacingSummaryContent.addImage(rangeCanvas, vis_std_canvas_sizeX, vis_min_canvas_sizeY);


### PR DESCRIPTION
There was a heavy and unnecessary use of TCanvas::DrawClone().
This was is order to avoid transferring TCanvas objects ownership from Analyzer & Vizard to RootWeb.
This was considerably increasing run time.

Since TCanvas has no move semantics, just use unique_ptr<TCanvas> in the caller code instead!!

