### PR TITLE
Added IT 611: 2x2 modules in Rings 1 and 2 in TEPX (from Lea)

### DIFF
--- a/config/chemical_mixtures.list
+++ b/config/chemical_mixtures.list
@@ -205,6 +205,7 @@ Cu_Elinks_TFPX_R2	       8.96	                    Cu:1
 Cu_Elinks_TFPX_R3		     8.96	                    Cu:1
 Cu_Elinks_TFPX_R4	       8.96	                    Cu:1
 Cu_Elinks_TEPX_R1	       8.96	                    Cu:1
+Cu_Elinks_TEPX_R1_4chipmodules		 8.96	                    Cu:1
 Cu_Elinks_TEPX_R2		     8.96	                    Cu:1
 Cu_Elinks_TEPX_R2_4chipmodules		 8.96	                    Cu:1
 Cu_Elinks_TEPX_R3	       8.96	                    Cu:1

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L1_1chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L1_1chipmodules_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 1:
+// Layer 1: module with 1 chip
 // 2 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L1_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L1_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 1:
+// Layer 1: module with 2 chips
 // 1 module/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L2_1chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L2_1chipmodules_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 2:
+// Layer 2: module with 1 chip
 // 6 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L2_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L2_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 2:
+// Layer 2: module with 2 chips
 // ~2.25 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L3_1chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L3_1chipmodules_Elinks_to_1GBT
@@ -1,5 +1,5 @@
-// Layer 3:
-// 28 modules/GBT
+// Layer 3: module with 1 chip
+// 28 modules/GBT !!!!!!! Warning: Obviously wrong, was put as temp material for tilted IT.
 
 Conversion {
   Input {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L3_2chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L3_2chipmodules_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 3: 1x2
+// Layer 3: module with 2 chips
 // ~4.5 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L3_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L3_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 3:
+// Layer 3: module with 4 chips
 // ~2.25 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L4_1chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L4_1chipmodules_Elinks_to_1GBT
@@ -1,5 +1,5 @@
-// Layer 4:
-// 56 modules/GBT
+// Layer 4: module with 1 chip
+// 56 modules/GBT !!!!!!! Warning: Obviously wrong, was put as temp material for tilted IT.
 
 Conversion {
   Input {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L4_2chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L4_2chipmodules_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 4: 1x2
+// Layer 4: module with 2 chips
 // ~4.5 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L4_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TBPX_L4_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// Layer 4:
+// Layer 4: module with 4 chips
 // ~4.5 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R1_4chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R1_4chipmodules_Elinks_to_1GBT
@@ -1,0 +1,16 @@
+// TEXP Ring1: module with 4 chips
+// 2.5 modules/GBT
+
+Conversion {
+  Input {
+    // Two conductors
+    Element {
+      elementName Cu_Elinks_TEPX_R1_4chipmodules
+      quantity 1.6575              // = 2.5 * quantity / module
+      unit g/m
+    }
+  }
+  Output {
+    @include GBT_and_fibres        // = 1 GBT
+  }
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R1_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R1_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TEXP Ring1:
+// TEXP Ring1: module with 2 chips
 // 5 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R2_4chipmodules_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R2_4chipmodules_Elinks_to_1GBT
@@ -1,12 +1,12 @@
-// TEXP Ring2:
-// 7 modules/GBT
+// TEXP Ring2: module with 4 chips
+// 2.33 modules/GBT
 
 Conversion {
   Input {
     // Two conductors
     Element {
-      elementName Cu_Elinks_TEPX_R2
-      quantity 4.641               // = 7 * quantity / module
+      elementName Cu_Elinks_TEPX_R2_4chipmodules
+      quantity 1.547               // = 2.33 * quantity / module
       unit g/m
     }
   }

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R2_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R2_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TEXP Ring2:
+// TEXP Ring2: module with 2 chips
 // 7 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R3_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R3_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TEXP Ring3:
+// TEXP Ring3: module with 4 chips
 // 4.5 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R4_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R4_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TEXP Ring4:
+// TEXP Ring4: module with 4 chips
 // 5 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R5_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TEPX_R5_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TEXP Ring5:
+// TEXP Ring5: module with 4 chips
 // 6 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R1_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R1_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TFPX Ring1:
+// TFPX Ring1: module with 2 chips
 // ~1.67 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R2_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R2_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TFPX Ring2:
+// TFPX Ring2: module with 2 chips
 // ~2.67 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R3_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R3_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TFPX Ring3:
+// TFPX Ring3: module with 4 chips
 // 3 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R4_Elinks_to_1GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/TFPX_R4_Elinks_to_1GBT
@@ -1,4 +1,4 @@
-// TFPX Ring4:
+// TFPX Ring4: module with 4 chips
 // 4 modules/GBT
 
 Conversion {

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R1_4chipmodules
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R1_4chipmodules
@@ -1,16 +1,16 @@
-// 1:1 conversion of Cu_Elinks_TEPX_R2_4chipmodules
+// 1:1 conversion of Cu_Elinks_TEPX_R1_4chipmodules
 
 Conversion {
   Input {
     Element {
-      elementName Cu_Elinks_TEPX_R2_4chipmodules
+      elementName Cu_Elinks_TEPX_R1_4chipmodules
       quantity 1
       unit g/m
     }
   }
   Output {
     Element {
-      elementName Cu_Elinks_TEPX_R2_4chipmodules
+      elementName Cu_Elinks_TEPX_R1_4chipmodules
       quantity 1
       unit g/m
       service true

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/TWP_to_GBT
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/TWP_to_GBT
@@ -17,6 +17,7 @@
 @include-std CMS_Phase2/Pixel/Conversions/Components/TFPX_R4_Elinks_to_1GBT
 // TEPX
 @include-std CMS_Phase2/Pixel/Conversions/Components/TEPX_R1_Elinks_to_1GBT
+@include-std CMS_Phase2/Pixel/Conversions/Components/TEPX_R1_4chipmodules_Elinks_to_1GBT
 @include-std CMS_Phase2/Pixel/Conversions/Components/TEPX_R2_Elinks_to_1GBT
 @include-std CMS_Phase2/Pixel/Conversions/Components/TEPX_R2_4chipmodules_Elinks_to_1GBT
 @include-std CMS_Phase2/Pixel/Conversions/Components/TEPX_R3_Elinks_to_1GBT

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/flange_FPIX
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/flange_FPIX
@@ -19,6 +19,7 @@ Station {
   @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TFPX_R3
   @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TFPX_R4
   @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R1
+  @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R1_4chipmodules
   @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R2
   @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R2_4chipmodules
   @include-std CMS_Phase2/Pixel/Conversions/Components/propagate_Cu_Elinks_TEPX_R3

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
@@ -1,0 +1,14 @@
+
+Materials FPIX2_R1_2x2_2500 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Elinks_TEPX_R1_4chipmodules
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Chip_Caps
+}
+

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Elinks_TEPX_R1_4chipmodules
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Elinks_TEPX_R1_4chipmodules
@@ -1,0 +1,21 @@
+// (2+1) High-Speed TWP / module
+
+Component {
+  componentName "Cabling: E-links"
+  service true
+  scaleOnSensor 0
+  // Two conductors
+  Element {
+    elementName Cu_Elinks_TEPX_R1_4chipmodules
+    quantity 0.663 
+    unit g/m
+    targetVolume 1
+  }
+  // Two insulations
+  Element {
+    elementName Kapton
+    quantity 0.057
+    unit g/m
+    targetVolume 1
+  }
+}

--- a/geometries/CMS_Phase2/OT614_200_IT611.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT611.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_1.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_0.cfg
@@ -47,7 +47,7 @@
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 32 
-      ringOuterRadius 159.99
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
     }
     Disk 1 { placeZ 250.00 }
     Disk 2 { placeZ 319.76 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_1.cfg
@@ -1,0 +1,69 @@
+  Endcap FPIX_2 {
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include ../Pixel_V4/stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 254
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20  // NB: Go down to numModules = 18 ?????????????????????
+      ringOuterRadius 106.35        // ????? So that Rmin = 62.9 mm, is that the right constraint?
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 28
+      ringOuterRadius 143.15
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 179.85
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 44
+      ringOuterRadius 216.65
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 253.40           // ????? So that Rmax < 254 mm, is that the right constraint?
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_1.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_1_0.cfg
+  @include ../Pixel_V6/FPIX1_6_1_0.cfg
+  @include ../Pixel_V6/FPIX2_6_1_1.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -425,7 +425,16 @@ OT614_200_IT610.cfg                  OT Version 6.1.4
                                      * Ring 2: Rcenter: 126.9 mm -> 116.25 mm.
                                      * Ring 3: Rcenter: 166.4 mm -> 155.75 mm.
                                      * Ring 3: Rcenter: 209.9 mm -> 196.25 mm.
-                                     * Ring 4: Rcenter: +0.36 mm (keep same Rhigh).                                                                         
+                                     * Ring 4: Rcenter: +0.36 mm (keep same Rhigh).       
+                                     
+OT614_200_IT611.cfg                  OT Version 6.1.4                                     
+                                     Based from Inner Tracker version 6.1.0.
+                                     TEPX: 2x2 modules in Ring 1 and Ring 2.
+                                     Materials: adapted correspondingly.
+                                     NB: numModules / GBT still follow IT404 cabling map, will need slight update (+4 modules in R4).
+                                     WARNING: Rings radii to be tuned!! 
+                                     Rmin set to 62.9 mm, is that fine? Rmax < 254 mm, is that the constrainst?  
+                                     What is the Rmax constrainst on TFPX???                                                                                                     
                                      
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                        
                                                                                            


### PR DESCRIPTION
See https://indico.cern.ch/event/746593/contributions/3164208/attachments/1726785/2789605/EPIX_Geometry_02102018.pdf 
TO DO: Update materials (cooling not done, check e-links + GBTs, which are still based on IT 404 cabling map). Radii could be tuned.