### PR TITLE
Adds support of new rings paradigm in TEPX

### DIFF
--- a/geometries/CMS_Phase2/OT614_200_IT612.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT612.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_2.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_1.cfg
@@ -13,7 +13,7 @@
     numDisks 4
     smallDelta 2 
     bigDelta 4 
-    outerRadius 254
+    outerRadius 253.95
     numRings 5
     minZ 1620
     //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
@@ -25,36 +25,36 @@
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
-      numModules 20  // NB: Go down to numModules = 18 ?????????????????????
-      ringOuterRadius 106.35        // ????? So that Rmin = 62.9 mm, is that the right constraint?
+      numModules 20
+      ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
     }
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 28
-      ringOuterRadius 143.15
+      ringOuterRadius 144.0          // to be tuned
     }
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 36
-      ringOuterRadius 179.85
+      ringOuterRadius 181.3          // to be tuned
     }
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 44
-      ringOuterRadius 216.65
+      ringOuterRadius 217.9           // to be tuned
     }
     Ring 5 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 48
-      ringOuterRadius 253.40           // ????? So that Rmax < 254 mm, is that the right constraint?
+      ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
     }
     Disk 1 { placeZ 1750.00 }
     Disk 2 { placeZ 1985.43 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_2.cfg
@@ -1,0 +1,69 @@
+  Endcap FPIX_2 {
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include ../Pixel_V4/stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 4 
+    bigDelta 2 
+    outerRadius 253.95
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 28
+      ringOuterRadius 144.0          // to be tuned
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 181.3          // to be tuned
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 44
+      ringOuterRadius 217.9           // to be tuned
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 1985.43 }
+    Disk 3 { placeZ 2250.83 }
+    Disk 4 { placeZ 2550.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_2.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_1_0.cfg
+  @include ../Pixel_V6/FPIX1_6_1_0.cfg
+  @include ../Pixel_V6/FPIX2_6_1_2.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -433,8 +433,12 @@ OT614_200_IT611.cfg                  OT Version 6.1.4
                                      Materials: adapted correspondingly.
                                      NB: numModules / GBT still follow IT404 cabling map, will need slight update (+4 modules in R4).
                                      WARNING: Rings radii to be tuned!! 
-                                     Rmin set to 62.9 mm, is that fine? Rmax < 254 mm, is that the constrainst?  
-                                     What is the Rmax constrainst on TFPX???                                                                                                     
+                                     Rmin set to 62.9 mm, is that fine? Rmax < 254.52 mm, is that the constrainst?  
+                                     What is the Rmax constrainst on TFPX???  
+                                     
+OT614_200_IT612.cfg                  OT Version 6.1.4                                     
+                                     Based from Inner Tracker version 6.1.1.
+                                     bigDelta: 4 mm -> 2 mm, smallDelta: 2 mm -> 4 mm.                                                                                                                                    
                                      
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                        
                                                                                            

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -360,6 +360,7 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   virtual UniRef uniRef() const = 0;
   virtual int16_t moduleRing() const { return -1; }
   virtual const int diskSurface() const { return -1; }
+  virtual const bool isSmallerAbsZModuleInRing() const { return true; }
 
   inline bool isPixelModule() const { return (moduleType().find(insur::type_pixel) != std::string::npos); }
   inline bool isTimingModule() const { return (moduleType().find(insur::type_timing) != std::string::npos); }
@@ -581,7 +582,7 @@ public:
   int16_t side() const { return (int16_t)signum(center().Z()); }
   Property<int, AutoDefault> endcapDiskSurface;
   void setIsSmallerAbsZModuleInRing(const bool isSmallerAbsZModuleInRing) { isSmallerAbsZModuleInRing_ = isSmallerAbsZModuleInRing; }
-  const bool isSmallerAbsZModuleInRing() const { return isSmallerAbsZModuleInRing_; }
+  const bool isSmallerAbsZModuleInRing() const override { return isSmallerAbsZModuleInRing_; }
   const int diskSurface() const override { return endcapDiskSurface(); }
 
   EndcapModule(Decorated* decorated, const std::string subdetectorName) :

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -580,6 +580,8 @@ public:
   int16_t blade() const { return (int16_t)myid(); } // CUIDADO Think of a better name!
   int16_t side() const { return (int16_t)signum(center().Z()); }
   Property<int, AutoDefault> endcapDiskSurface;
+  void setIsSmallerAbsZModuleInRing(const bool isSmallerAbsZModuleInRing) { isSmallerAbsZModuleInRing_ = isSmallerAbsZModuleInRing; }
+  const bool isSmallerAbsZModuleInRing() const { return isSmallerAbsZModuleInRing_; }
   const int diskSurface() const override { return endcapDiskSurface(); }
 
   EndcapModule(Decorated* decorated, const std::string subdetectorName) :
@@ -739,6 +741,9 @@ public:
   PosRef posRef() const { return (PosRef){ subdetectorId(), (side() > 0 ? disk() : -disk()), ring(), blade() }; }
   TableRef tableRef() const { return (TableRef){ subdetectorName(), disk(), ring() }; }
   UniRef uniRef() const { return UniRef{ subdetectorName(), disk(), ring(), blade(), side() }; }
+
+private:
+  bool isSmallerAbsZModuleInRing_;
 };
 
 

--- a/include/Extractor.hh
+++ b/include/Extractor.hh
@@ -40,6 +40,10 @@ namespace insur {
    */
   class Extractor {
     class LayerAggregator : public GeometryVisitor { // CUIDADO quick'n'dirty visitor-based adaptor to interface with legacy spaghetti code
+      // NB: What the hell is this design??
+      // What should be done: add moduleComplex directy in the geo core, allowing to get extrema info as soon as the geo is built, from the geo classes.
+      // Remove the geo bundles and directly access info from the existing classes!
+      // Full Extractor in general would need to be written in a clean way (would require ~1 month work though).
       std::vector<Layer*> barrelLayers_;
       std::vector<Disk*> endcapLayers_;
       std::vector<std::vector<ModuleCap> > layerCap_;

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -59,7 +59,7 @@ public:
   const std::string subDetectorName() const { return myPowerChain_->subDetectorName(); }
   const int layerDiskNumber() const { return myPowerChain_->layerDiskNumber(); }
   const int ringNumber() const { return myPowerChain_->ringNumber(); }
-  const bool isRingInnerEnd() const { return myPowerChain_->isRingInnerEnd(); }
+  const bool isSmallerAbsZRingSide() const { return myPowerChain_->isSmallerAbsZRingSide(); }
   const int ringQuarterIndex() const { return myPowerChain_->ringQuarterIndex(); }
   const int powerChainPhiRef() const { return myPowerChain_->phiRef(); }
   

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -46,7 +46,7 @@ public:
 
   const bool isBarrel() const { return isBarrel_; }
   const int ringNumber() const { return ringNumber_; }
-  const bool isRingInnerEnd() const { return isRingInnerEnd_; }
+  const bool isSmallerAbsZRingSide() const { return isSmallerAbsZRingSide_; }
 
   const PowerChainType powerChainType() const { return powerChainType_; }
 
@@ -77,7 +77,7 @@ private:
   
   bool isBarrel_;
   int ringNumber_;
-  bool isRingInnerEnd_;
+  bool isSmallerAbsZRingSide_;
 
   PowerChainType powerChainType_;
 

--- a/include/InnerCabling/inner_cabling_functions.hh
+++ b/include/InnerCabling/inner_cabling_functions.hh
@@ -20,9 +20,9 @@ namespace inner_cabling_functions {
   const bool isBarrel(const std::string subDetectorName);
   const int computeInnerTrackerQuarterIndex(const bool isPositiveZEnd, const bool isPositiveXSide);
   const int computeSubDetectorIndex(const std::string subDetectorName);
-  const int computeRingQuarterIndex(const int ringNumber, const bool isRingInnerEnd);
+  const int computeRingQuarterIndex(const int ringNumber, const bool isSmallerAbsZRingSide);
   const int computeRingNumber(const int ringQuarterIndex);
-  const bool isRingInnerEnd(const int ringQuarterIndex);
+  const bool isSmallerAbsZRingSide(const int ringQuarterIndex);
 
   // compute number of ELinks per module
   const int computeNumELinksPerModule(const std::string subDetectorName, const int layerOrRingNumber);

--- a/include/Ring.hh
+++ b/include/Ring.hh
@@ -154,6 +154,9 @@ class Ring : public PropertyObject, public Buildable, public Identifiable<int>, 
   Property<double, Default> ringGap;
   Property<int   , Default> smallParity;
 
+  bool isSmallerAbsZRingInDisk_;
+  bool isRingOn4Dees_;
+
   double minRadius_, maxRadius_;
 
   std::string subdetectorName_;
@@ -239,6 +242,11 @@ public:
     for (const auto& m : modules_) { averageZ = averageZ + m.center().Z(); } 
     averageZ /= numModules(); return averageZ;
   }
+
+  void setIsSmallerAbsZRingInDisk(const bool isSmallerAbsZRingInDisk) { isSmallerAbsZRingInDisk_ = isSmallerAbsZRingInDisk; }
+  const bool isSmallerAbsZRingInDisk() const { return isSmallerAbsZRingInDisk_; }
+  void setIsRingOn4Dees(const bool isRingOn4Dees) { isRingOn4Dees_ = isRingOn4Dees; }
+  const bool isRingOn4Dees() const { return isRingOn4Dees_; }
 
   void cutAtEta(double eta);
 

--- a/include/tk2CMSSW_datatypes.hh
+++ b/include/tk2CMSSW_datatypes.hh
@@ -216,7 +216,6 @@ namespace insur {
      * @brief This is a struct to collect temporary information about an endcap ring and the modules within it.
      * @param name The logical part name that identifies the ring
      * @param childname The logical part name that identifies the modules contained in the ring
-     * @param fw Is it the forward ring of the disk ?
      * @param isZPlus Is the ring (and disk) in the positive-z side ?
      * @param fw_flipped Are modules in the forward part (big |z|) of the ring flipped ?
      * @param phi The angle <i>phi</i> in the x/y-plane of the first module on the ring
@@ -229,20 +228,25 @@ namespace insur {
     struct ERingInfo {
         std::string name;
         std::string childname;
-        bool fw;
-        bool isZPlus;
-        bool fw_flipped;
-        int modules;
-        double mthk;
-        double rmin;
-        double rmid;
-        double rmax;
-        double zmin;
-        double zmax;
-        double zfw;
-        double startPhiAnglefw;  // in RAD
-        double zbw;
-        double startPhiAnglebw;  // in RAD
+        bool isDiskAtPlusZEnd;
+        int numModules;
+        double moduleThickness;
+        double radiusMin;
+        double radiusMid;
+        double radiusMax;
+        double zMin;
+        double smallAbsZModulesZMax;
+        double zMean;
+        double bigAbsZModulesZMin;
+        double zMax;
+        bool isRingOn4Dees;
+        
+        double surface1ZMean;
+        double surface1StartPhi;  // in RAD       
+        bool surface1IsFlipped;
+        double surface2ZMean;
+        double surface2StartPhi;  // in RAD
+        bool surface2IsFlipped;
     };
     /**
      * @struct BTiltedRingInfo

--- a/include/tk2CMSSW_datatypes.hh
+++ b/include/tk2CMSSW_datatypes.hh
@@ -216,14 +216,13 @@ namespace insur {
      * @brief This is a struct to collect temporary information about an endcap ring and the modules within it.
      * @param name The logical part name that identifies the ring
      * @param childname The logical part name that identifies the modules contained in the ring
-     * @param isZPlus Is the ring (and disk) in the positive-z side ?
-     * @param fw_flipped Are modules in the forward part (big |z|) of the ring flipped ?
-     * @param phi The angle <i>phi</i> in the x/y-plane of the first module on the ring
-     * @param modules The number of modules within the ring
-     * @param mthk Thickness of one of the ring's modules (hybrids included)
-     * @param rmin The minimum radius of the ring, as measured from the z-axis 
-     * @param rmid The radius of the module mean point, as measured from the z-axis
-     * @param rmax The maximum radius of the ring, as measured from the z-axis
+     * @param isDiskAtPlusZEnd Is the ring (and disk) in the positive-z side ?
+     * @param numModules The number of modules within the ring
+     * @param moduleThickness Thickness of one of the ring's modules (hybrids included)
+     * @param radiusMin The minimum radius of the ring, as measured from the z-axis 
+     * @param radiusMid The radius of the module mean point, as measured from the z-axis
+     * @param radiusMax The maximum radius of the ring, as measured from the z-axis
+     * @param surface1StartPhi The angle <i>phi</i> in the x/y-plane of the first module on the ring
      */
     struct ERingInfo {
         std::string name;

--- a/include/tk2CMSSW_datatypes.hh
+++ b/include/tk2CMSSW_datatypes.hh
@@ -214,15 +214,24 @@ namespace insur {
     /**
      * @struct ERingInfo
      * @brief This is a struct to collect temporary information about an endcap ring and the modules within it.
-     * @param name The logical part name that identifies the ring
-     * @param childname The logical part name that identifies the modules contained in the ring
-     * @param isDiskAtPlusZEnd Is the ring (and disk) in the positive-z side ?
-     * @param numModules The number of modules within the ring
-     * @param moduleThickness Thickness of one of the ring's modules (hybrids included)
-     * @param radiusMin The minimum radius of the ring, as measured from the z-axis 
-     * @param radiusMid The radius of the module mean point, as measured from the z-axis
-     * @param radiusMax The maximum radius of the ring, as measured from the z-axis
-     * @param surface1StartPhi The angle <i>phi</i> in the x/y-plane of the first module on the ring
+     * @param name The logical part name that identifies the ring.
+     * @param childname The logical part name that identifies the modules contained in the ring.
+     * @param isDiskAtPlusZEnd Is the ring (and disk) in the Tracker positive (Z) end ?
+     * @param numModules The number of modules within the ring.
+     * @param moduleThickness Thickness of one of the ring's modules (hybrids included).
+     * @param radiusMin The minimum radius of the ring, as measured from the (Z) axis.
+     * @param radiusMid The radius of the module mean point, as measured from the (Z) axis.
+     * @param radiusMax The maximum radius of the ring, as measured from the (Z) axis.
+     * @param zMin Min Z ever reached by any point of a module belonging to the ring.
+     * @param smallAbsZSurfaceZMax MaxZ of the half of the modules which are located at the smallest |Z|.
+     * @param zMid ring's placement Z.
+     * @param bigAbsZSurfaceZMin MinZ of the half of the modules which are located at the biggest |Z|.
+     * @param zMax Max Z ever reached by any point of a module belonging to the ring.
+     * @param isRingOn4Dees Are the ring modules spread over 4 dees?
+     * surface i is randomly one half of the ring modules (Either the modules located at smaller |Z|, either the modules located at bigger |Z|).
+     * @param surfaceiZMid ZMid of modules belonging to surface i. Assumption: same for all modules.
+     * @param surfaceiStartPhi Start Phi Angle of modules belonging to surface i.
+     * @param surfaceiIsFlipped Are the modules belonging to surface i flipped?
      */
     struct ERingInfo {
         std::string name;
@@ -234,16 +243,16 @@ namespace insur {
         double radiusMid;
         double radiusMax;
         double zMin;
-        double smallAbsZModulesZMax;
-        double zMean;
-        double bigAbsZModulesZMin;
+        double smallAbsZSurfaceZMax;
+        double zMid;
+        double bigAbsZSurfaceZMin;
         double zMax;
         bool isRingOn4Dees;
         
-        double surface1ZMean;
+        double surface1ZMid;
         double surface1StartPhi;  // in RAD       
         bool surface1IsFlipped;
-        double surface2ZMean;
+        double surface2ZMid;
         double surface2StartPhi;  // in RAD
         bool surface2IsFlipped;
     };

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -212,6 +212,8 @@ void Disk::buildTopDown(const ScanEndcapInfo& extremaDisksInfo) {
     ring->myid(i);
     ring->build();
     ring->translateZ(parity > 0 ? bigDelta() : -bigDelta());
+    ring->setIsSmallerAbsZRingInDisk(parity < 0);
+    ring->setIsRingOn4Dees(ring->smallDelta() > bigDelta());
 
     rings_.insert(rings_.begin(), ring);
     ringIndexMap_[i] = ring;

--- a/src/Disk.cc
+++ b/src/Disk.cc
@@ -210,10 +210,10 @@ void Disk::buildTopDown(const ScanEndcapInfo& extremaDisksInfo) {
 
     // NOW THAT RADIUS HAS BEEN CALCULATED, FINISH BUILDING THE RING AND STORE IT
     ring->myid(i);
-    ring->build();
-    ring->translateZ(parity > 0 ? bigDelta() : -bigDelta());
-    ring->setIsSmallerAbsZRingInDisk(parity < 0);
     ring->setIsRingOn4Dees(ring->smallDelta() > bigDelta());
+    ring->setIsSmallerAbsZRingInDisk(parity < 0);
+    ring->build();
+    ring->translateZ(parity > 0 ? bigDelta() : -bigDelta());   
 
     rings_.insert(rings_.begin(), ring);
     ringIndexMap_[i] = ring;

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -2133,7 +2133,7 @@ namespace insur {
 
 		  shape.name_tag = myRingInfo.name + "InnerCut";
 		  shape.rmin = myRingInfo.radiusMin - 2. * xml_epsilon;
-		  shape.rmax = myInnerRingRMax + xml_epsilon;
+		  shape.rmax = myInnerRingRMax + 2. * xml_epsilon;
 		  shape.dz = (myRingInfo.bigAbsZSurfaceZMin - myRingInfo.smallAbsZSurfaceZMax) / 2.0 - xml_epsilon;
 		  s.push_back(shape);
 
@@ -2154,7 +2154,7 @@ namespace insur {
 		   const double myOuterRingRMin = myOuterRingInfo.radiusMin;
 
 		  shape.name_tag = myRingInfo.name + "OuterCut";
-		  shape.rmin = myOuterRingRMin - xml_epsilon;
+		  shape.rmin = myOuterRingRMin - 2. * xml_epsilon;
 		  shape.rmax = myRingInfo.radiusMax + 2. * xml_epsilon;
 		  shape.dz = (myRingInfo.bigAbsZSurfaceZMin - myRingInfo.smallAbsZSurfaceZMax) / 2.0 - xml_epsilon;
 		  s.push_back(shape);

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -74,7 +74,7 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const double modCenterX = m.center().X();
   const bool isPositiveXSide = computeXSide(modCenterX);
 
-  const bool isRingInnerEnd = ( (m.diskSurface() % 2 ) == 1);
+  const bool isSmallerAbsZRingSide = m.isSmallerAbsZModuleInRing();
   
   const double modPhi = m.center().Phi();
   const std::pair<int, int> phiRefs = computeForwardModulePhiPowerChain(modPhi, numModulesInRing_, isPositiveZEnd);
@@ -82,7 +82,7 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const int modulePhiRefInPowerChain = phiRefs.second;
   m.setPhiRefInPowerChain(modulePhiRefInPowerChain);
 
-  const int ringQuarterIndex = inner_cabling_functions::computeRingQuarterIndex(ringNumber_, isRingInnerEnd);
+  const int ringQuarterIndex = inner_cabling_functions::computeRingQuarterIndex(ringNumber_, isSmallerAbsZRingSide);
 
   // BUILD POWER CHAIN IF NECESSARY, AND CONNECT MODULE TO POWER CHAIN
   buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, ringQuarterIndex);

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -13,7 +13,7 @@ PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const 
   myid(powerChainId);
   isBarrel_ = inner_cabling_functions::isBarrel(subDetectorName);
   ringNumber_ = inner_cabling_functions::computeRingNumber(ringQuarterIndex);
-  isRingInnerEnd_ = inner_cabling_functions::isRingInnerEnd(ringQuarterIndex);
+  isSmallerAbsZRingSide_ = inner_cabling_functions::isSmallerAbsZRingSide(ringQuarterIndex);
 
   powerChainType_ = computePowerChainType(isBarrel_, layerDiskNumber, ringNumber_);
 

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -116,9 +116,9 @@ namespace inner_cabling_functions {
    * A given IT ring is divided by (X) side AND per dee side: hence notion of ring quarter.
    * Each ring quarter is identified by a unique index.
    */
-  const int computeRingQuarterIndex(const int ringNumber, const bool isRingInnerEnd) {
-    const int isRingInnerEndIndex = (!isRingInnerEnd);
-    const int ringQuarterIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isRingInnerEndIndex);
+  const int computeRingQuarterIndex(const int ringNumber, const bool isSmallerAbsZRingSide) {
+    const int isSmallerAbsZRingSideIndex = (!isSmallerAbsZRingSide);
+    const int ringQuarterIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZRingSideIndex);
     return ringQuarterIndex;
   }
 
@@ -134,11 +134,11 @@ namespace inner_cabling_functions {
 
 
   /*
-   * Retrieve, from the index, whether one is on one dee side or the other.
+   * Retrieve, from the index, whether one is on one ring (Z) side or the other.
    */
-  const bool isRingInnerEnd(const int ringQuarterIndex) {
-    const bool isRingInnerEnd = (ringQuarterIndex % 2 ? true : false);
-    return isRingInnerEnd;
+  const bool isSmallerAbsZRingSide(const int ringQuarterIndex) {
+    const bool isSmallerAbsZRingSide = (ringQuarterIndex % 2 ? false : true);
+    return isSmallerAbsZRingSide;
   }
 
 

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -87,8 +87,9 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta) {
     mod->rotateZ(2.*M_PI*(i+alignmentRotation)/numMods); // CUIDADO had a rotation offset of PI/2
     mod->rotateZ(zRotation());
     mod->translateZ(parity*smallDelta);
-    mod->setIsSmallerAbsZModuleInRing(parity != 1);
-    mod->flipped(parity != 1);
+    mod->setIsSmallerAbsZModuleInRing(parity < 0);
+    const bool isFlipped = (!isRingOn4Dees() ? (parity < 0) : isSmallerAbsZRingInDisk());
+    mod->flipped(isFlipped);
     modules_.push_back(mod);  
   }
 }

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -87,6 +87,7 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta) {
     mod->rotateZ(2.*M_PI*(i+alignmentRotation)/numMods); // CUIDADO had a rotation offset of PI/2
     mod->rotateZ(zRotation());
     mod->translateZ(parity*smallDelta);
+    mod->setIsSmallerAbsZModuleInRing(parity != 1);
     mod->flipped(parity != 1);
     modules_.push_back(mod);  
   }

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -88,7 +88,12 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta) {
     mod->rotateZ(zRotation());
     mod->translateZ(parity*smallDelta);
     mod->setIsSmallerAbsZModuleInRing(parity < 0);
-    const bool isFlipped = (!isRingOn4Dees() ? (parity < 0) : isSmallerAbsZRingInDisk());
+    const bool isFlipped = (!isRingOn4Dees() ? (parity < 0) // Case where ring modules are placed on both sides of a same dee.
+			                                    // Half of the ring modules are flipped: 
+			                                    // the ones placed with parity < 0, hence on the small |Z| side.
+			    : isSmallerAbsZRingInDisk()); // Case where ring modules are placed on 4 dees.
+                                                          // If the ring is on the small |Z| side with respect to the disk:
+                                                          // all ring modules are flipped.
     mod->flipped(isFlipped);
     modules_.push_back(mod);  
   }

--- a/src/Tracker.cc
+++ b/src/Tracker.cc
@@ -101,15 +101,15 @@ void Tracker::addHierarchyInfoToModules() {
     }
     void visit(Disk& d)   {
       layerDiskId_ = d.myid();
-      diskAverageZ_ = d.averageZ();
     }
     void visit(RodPair& r){
       rodRingId_ = r.myid(); 
     }
     void visit(Ring& r) {
       rodRingId_ = r.myid();
-      ringAverageZ_ = r.averageZ();
-      bigDeltaIndex_ = ((fabs(ringAverageZ_) > fabs(diskAverageZ_)) ? 2 : 0);
+      isRingOn4Dees_ = r.isRingOn4Dees();
+      const int ringIncrement = (isRingOn4Dees_ ? 1 : 2);
+      bigDeltaIndex_ = (r.isSmallerAbsZRingInDisk() ? 0 : ringIncrement);
     }
     void visit(Module& m) { 
       m.subdetectorId(subdetectorId_); 
@@ -121,7 +121,8 @@ void Tracker::addHierarchyInfoToModules() {
     void visit(EndcapModule& m) { 
       m.disk(layerDiskId_);
       m.ring(rodRingId_);
-      int smallDeltaIndex = ((fabs(m.center().Z()) > fabs(ringAverageZ_)) ? 1 : 0);
+      const int moduleIncrement = (isRingOn4Dees_? 2 : 1);
+      int smallDeltaIndex = (m.isSmallerAbsZModuleInRing() ? 0 : moduleIncrement);
       // Get which disk surface the module belongs to.
       // Disk Surface 1 is the surface with the lowest |Z|.
       // Disk Surface 4 is the surface with the biggest |Z|.
@@ -133,8 +134,7 @@ void Tracker::addHierarchyInfoToModules() {
     int subdetectorId_ = 0;
     int layerDiskId_;
     int rodRingId_;
-    double diskAverageZ_;
-    double ringAverageZ_;
+    bool isRingOn4Dees_;
     int bigDeltaIndex_;
   };
 

--- a/xml/pixfwd.xml
+++ b/xml/pixfwd.xml
@@ -43,16 +43,16 @@
    <ZSection z="95.90*cm" rMin="2.8*cm" rMax="[RootRadius1]"/>
    <ZSection z="95.90*cm" rMin="2.8*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
    <ZSection z="120.9*cm" rMin="2.8*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
-   <ZSection z="120.9*cm" rMin="6.3*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
-   <ZSection z="261.9*cm" rMin="6.3*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
+   <ZSection z="120.9*cm" rMin="6.23*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
+   <ZSection z="261.9*cm" rMin="6.23*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
  </Polycone>
  <Polycone name="Phase2PixelEndcap" startPhi="0*deg" deltaPhi="360*deg" >
    <ZSection z="[RootStartZ]"  rMin="2.8*cm" rMax="[RootRadius1]"/>
    <ZSection z="120.9*cm"   rMin="2.8*cm" rMax="[RootRadius1]"/>
-   <ZSection z="120.9*cm"   rMin="6.3*cm" rMax="[RootRadius1]"/>
-   <ZSection z="129.9*cm"   rMin="6.3*cm" rMax="[RootRadius1]"/>
-   <ZSection z="129.9*cm"   rMin="6.3*cm" rMax="[RootRadius2]"/>
-   <ZSection z="261.9*cm"   rMin="6.3*cm" rMax="[RootRadius2]"/>
+   <ZSection z="120.9*cm"   rMin="6.23*cm" rMax="[RootRadius1]"/>
+   <ZSection z="129.9*cm"   rMin="6.23*cm" rMax="[RootRadius1]"/>
+   <ZSection z="129.9*cm"   rMin="6.23*cm" rMax="[RootRadius2]"/>
+   <ZSection z="261.9*cm"   rMin="6.23*cm" rMax="[RootRadius2]"/>
  </Polycone>
  <SubtractionSolid name="Phase2OTForward">
    <rSolid name="Forward"/>

--- a/xml/trackerVolumeTemplate.xml
+++ b/xml/trackerVolumeTemplate.xml
@@ -5,14 +5,14 @@
 -->
 <Polycone name="<!--mid point marker-->" startPhi="0*deg" deltaPhi="360*deg">
   <!-- TEMPORARY!! Should be defined automatically -->
-  <ZSection z="-291.0*cm" rMin="6.3*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-  <ZSection z="-150.0*cm" rMin="6.3*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="-291.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="-150.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-150.0*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>    <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" -->
   <ZSection z="-22.70*cm" rMin="2.6*cm" rMax="[tracker:TrackerOutermostRadius]"/>    <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" -->
   <ZSection z="22.70*cm" rMin="2.6*cm" rMax="[tracker:TrackerOutermostRadius]"/>     <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm" -->
   <ZSection z="22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>     <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm" -->
   <ZSection z="150.0*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-  <ZSection z="150.0*cm" rMin="6.3*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-  <ZSection z="291.0*cm" rMin="6.3*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="150.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="291.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
 </Polycone>


### PR DESCRIPTION
bigDelta: distance in Z between the center of a disk and the center of a ring.
smallDelta: distance in Z between the center of a ring and the center of a module.

Adds support for smallDelta > bigDelta case.
Obviously still need to keep support for smallDelta < bigDelta.

smallDelta > bigDelta: Modules of a ring are placed on 4 dees.
smallDelta < bigDelta: Modules of a ring are placed on 2 dees: half of the modules on each dee side.

See page 4 at https://indico.cern.ch/event/746593/contributions/3164208/attachments/1726785/2789605/EPIX_Geometry_02102018.pdf.

In practice, what needed to be adapted was:
- Added info on Ring and EndcapModule classes about how the configuration is.
Ring::isRingOn4Dees() (is smallDelta > bigDelta ?)
Ring::isSmallerAbsZRingInDisk() (is ring placed at -bigDelta in its disk ?)
EndcapModule::isSmallerAbsZModuleInRing() (is modules placed at -smallDelta in its ring)?

- Adapted modules flip.

- Adapted IT cabling map.

- Adapted XML export.

Also add IT layout IT 612, with smallDelta = 4 mm and bigDelta = 2 mm.