### PR TITLE
Base OT cabling map on OT 616 by default + Added more detailed information on website on services channels (exchange with Axel)

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V616_200.cfg
@@ -25,9 +25,12 @@ Endcap TEDD_1 {
   //////////////////////////////////
   /// RINGS RADII AUTO PLACEMENT ///
   //////////////////////////////////
-  // NB: rSafetyMargin and zError can also be specified per ring!
+  // NB: zError and rSafetyMargin can be specified per disk or per ring!
+  // zError: luminous region coverage, transition ring (i) with ring (i+1).
+  // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
+  zError 150                           // great coverage!
   rSafetyMargin 15.0 
-  zError 76
+  Ring 9 { rSafetyMargin 38.0 }        // will force the radial distance between rings 9 and 11 to avoid clash. 
 
   alignEdges true
   moduleShape rectangular

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V616_200.cfg
@@ -27,9 +27,12 @@ Endcap TEDD_2 {
   //////////////////////////////////
   /// RINGS RADII AUTO PLACEMENT ///
   //////////////////////////////////
-  // NB: rSafetyMargin and zError can also be specified per ring!
+  // NB: zError and rSafetyMargin can be specified per disk or per ring!
+  // zError: luminous region coverage, transition ring (i) with ring (i+1).
+  // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
+  zError 150                           // great coverage!
   rSafetyMargin 15.0
-  zError 70
+  Ring 9 { rSafetyMargin 38.0 }        // will force the radial distance between rings 9 and 11 to avoid clash. 
 
   alignEdges true
   moduleShape rectangular

--- a/include/OuterCabling/ServicesChannel.hh
+++ b/include/OuterCabling/ServicesChannel.hh
@@ -29,6 +29,8 @@ public:
 
 protected:
   int channelNumber_;
+  std::string channelName_;
+  std::string chanelNamePP1Convention_;
   bool isPositiveCablingSide_; 
   Container sections_;
   };*/

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -183,7 +183,7 @@ namespace insur {
    */
   // TODO: make sure the following constants are only used in
   // mainConfigHandler
-  static const std::string default_cabledOTName                  = "OT614";
+  static const std::string default_cabledOTName                  = "OT616";
   static const std::string default_cabledITName                  = "IT404";
   static const std::string default_mattabdir                     = "config";
   static const std::string default_mattabfile                    = "mattab.list";

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -180,7 +180,7 @@ namespace insur {
    * Build an optical cabling map, which connects each module to a bundle, cable, DTC. 
    * Can actually be reused for power cables routing.
    * Please note that this is independant from any cable Material Budget consideration, which is done indepedently.
-   * The underlying cabling was designed for OT616, and is not garanteed to work for any other layout (should require few adaptations).
+   * The underlying cabling was designed for OT616, and is not garanteed to work for any other layout (could/should require adaptations).
    */
   bool Squid::buildOuterCablingMap(const bool outerCablingOption) {
     startTaskClock("Building optical and power cabling map in the Outer Tracker.");
@@ -524,7 +524,7 @@ namespace insur {
    */
   bool Squid::reportOuterCablingMapSite(const bool outerCablingOption, const std::string layoutName) {
     startTaskClock("Creating OT Cabling map report.");
-    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout is at your own risks (could require few adaptations).");
+    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout is at your own risks (could require adaptations).");
     if (tr) {
       // CREATE REPORT ON WEBSITE.
       v.outerCablingSummary(a, *tr, site);
@@ -544,7 +544,7 @@ namespace insur {
    */
   bool Squid::reportInnerCablingMapSite(const bool innerCablingOption, const std::string layoutName) {
     startTaskClock("Creating IT Cabling map report.");
-    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT404 only. Forcing it on another layout is at your own risks (could require few adaptations).");
+    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT404 only. Forcing it on another layout is at your own risks (could require adaptations).");
     if (px) {
       // CREATE REPORT ON WEBSITE.
       v.innerCablingSummary(pixelAnalyzer, *px, site);

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -180,7 +180,7 @@ namespace insur {
    * Build an optical cabling map, which connects each module to a bundle, cable, DTC. 
    * Can actually be reused for power cables routing.
    * Please note that this is independant from any cable Material Budget consideration, which is done indepedently.
-   * The underlying cabling was designed for OT614, and will not work for any other layout.
+   * The underlying cabling was designed for OT616, and is not garanteed to work for any other layout (should require few adaptations).
    */
   bool Squid::buildOuterCablingMap(const bool outerCablingOption) {
     startTaskClock("Building optical and power cabling map in the Outer Tracker.");
@@ -524,7 +524,7 @@ namespace insur {
    */
   bool Squid::reportOuterCablingMapSite(const bool outerCablingOption, const std::string layoutName) {
     startTaskClock("Creating OT Cabling map report.");
-    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT614 only.");
+    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout is at your own risks (could require few adaptations).");
     if (tr) {
       // CREATE REPORT ON WEBSITE.
       v.outerCablingSummary(a, *tr, site);
@@ -544,7 +544,7 @@ namespace insur {
    */
   bool Squid::reportInnerCablingMapSite(const bool innerCablingOption, const std::string layoutName) {
     startTaskClock("Creating IT Cabling map report.");
-    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT404 only.");
+    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT404 only. Forcing it on another layout is at your own risks (could require few adaptations).");
     if (px) {
       // CREATE REPORT ON WEBSITE.
       v.innerCablingSummary(pixelAnalyzer, *px, site);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1553,7 +1553,7 @@ namespace insur {
       RootWContent* efficiencyContent = new RootWContent("Cabling efficiency (one side)", true);
       myPage->addContent(efficiencyContent);
       // Links
-      myInfo = new RootWInfo("Total number of fiber links (one side)");
+      myInfo = new RootWInfo("Total number of modules (one side)");
       int numLinks = tracker.modules().size() / 2;
       myInfo->setValue(numLinks);
       efficiencyContent->addItem(myInfo);
@@ -7352,10 +7352,14 @@ namespace insur {
 					      std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDisks, std::vector<std::unique_ptr<TCanvas> > &XYPosBundlesDiskSurfaces,
 					      std::vector<std::unique_ptr<TCanvas> > &XYNegBundlesDisks, std::vector<std::unique_ptr<TCanvas> > &XYNegBundlesDiskSurfaces) {
     
+    const std::set<Module*>& trackerModules = tracker.modules();
     RZCanvas.reset(new TCanvas("RZCanvas", "RZView Canvas", insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY));
     RZCanvas->cd();
     PlotDrawer<YZFull, TypeBundleTransparentColor> yzDrawer;
-    yzDrawer.addModules(tracker);
+    //yzDrawer.addModules(tracker);
+    yzDrawer.addModules(trackerModules.begin(), trackerModules.end(), [] (const Module& m ) { 
+	return ( (!m.getBundle()->isBarrelPSFlatPart()) || (m.getBundle()->isBarrelPSFlatPart() && (m.getBundle()->phiPosition().phiSegmentRef() == 0 || m.getBundle()->phiPosition().phiSegmentRef() == 1) ) ); 
+      } );
     yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas.get());
     yzDrawer.drawModules<ContourStyle>(*RZCanvas.get());
    


### PR DESCRIPTION
Cabling map on new envelope OT is accessible here: http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT616_200_IT404/cablingOuter.html 

Changes that were auto made in cabling map:
TB2S: 2 rods less, hence 2 less MFBs per (Z) end.
TEDD_2: 8 modules less, hence smaller number modules per MFB for a few MFBs.