### PR TITLE
Adds support for bigParity on tilted rods phi placement. 

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V616_200.cfg
@@ -6,6 +6,7 @@ Barrel TBPS {
 
   numLayers 3
   startZMode modulecenter
+  bigParity 1
 
   //////////////////////////
   /// FLAT PART GEOMETRY ///

--- a/src/Layer.cc
+++ b/src/Layer.cc
@@ -1033,17 +1033,21 @@ void Layer::buildTilted() {
   float rodCenterPhiShift = 2*M_PI/numRods();
 
   TiltedRodPair* first = GeometryFactory::make<TiltedRodPair>(subdetectorName());
-  first->myid(1);
-  first->isOuterRadiusRod(false);
   first->store(propertyTree());
-  first->build(rodTemplate, tmspecsi, 1);
+  first->myid(1); 
+  const bool isFirstRodAtOuterRadius = (bigParity() > 0 ? true : false);
+  const std::vector<TiltedModuleSpecs> myFirstRodSensorsCenters = (bigParity() > 0 ? tmspecso : tmspecsi);
+  first->isOuterRadiusRod(isFirstRodAtOuterRadius); 
+  first->build(rodTemplate, myFirstRodSensorsCenters, !isFirstRodAtOuterRadius);
   rods_.push_back(first);
 
   TiltedRodPair* second = GeometryFactory::make<TiltedRodPair>(subdetectorName());
-  second->myid(2);
-  second->isOuterRadiusRod(true);
   second->store(propertyTree());
-  second->build(rodTemplate, tmspecso, 0);
+  second->myid(2);
+  const bool isSecondRodAtOuterRadius = (bigParity() > 0 ? false : true);
+  const std::vector<TiltedModuleSpecs> mySecondRodSensorsCenters = (bigParity() > 0 ? tmspecsi : tmspecso);
+  second->isOuterRadiusRod(isSecondRodAtOuterRadius);  
+  second->build(rodTemplate, mySecondRodSensorsCenters, !isSecondRodAtOuterRadius);
   second->rotateZ(rodCenterPhiShift);
   rods_.push_back(second);
 


### PR DESCRIPTION
This allows to change design, following misinterpretation from the Mechanics, that would be hard to correct from their side. This change in tracker design, instead, has no impact on tracker performance.