### PR TITLE
Mini-PR: avoid overlaps in geometries with old IT modules sizes

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x1_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x1_25x100
@@ -14,7 +14,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 0.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x1_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x1_50x50
@@ -14,7 +14,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 0.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 0.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_short
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_short
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 0.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 0.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 1.0
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_short
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_short
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 1.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x200
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x200
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 1.0   
 chipPositiveXExtraWidth 1.0

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50
@@ -15,7 +15,7 @@ sensorThickness 0.150
 hybridThickness 0.5
 chipThickness 0.5
 
-deadAreaExtraLength 0.5
+deadAreaExtraLength 0.09    // mass is correctly set up. Shorter length (0.09 mm instead of 0.5 mm) is only to avoid overlaps in old geometries.
 deadAreaExtraWidth 0.5
 chipNegativeXExtraWidth 1.0   
 chipPositiveXExtraWidth 1.0


### PR DESCRIPTION
IT modules descriptions for old geometries (before change in pixel size): use a dead area length that avoids clashes in those geometries.

This is needed in preparing CMSSW geometries for TBPX services placement studies.
Indeed, these geometries are based on the non-skewed TBPX geometries, before change in IT modules size (this does not have any impact for this study anyway).