### PR TITLE
Update TEDD 616 with feasability measures

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V616_200.cfg
@@ -26,11 +26,11 @@ Endcap TEDD_1 {
   // NB: zError and rSafetyMargin can be specified per disk or per ring!
   // zError: luminous region coverage, transition ring (i) with ring (i+1).
   // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
-  //zError 150                           
+  //zError 150                              // great coverage!
   //rSafetyMargin 15.0 
-  //Ring 9 { rSafetyMargin 38.0 }        // will force the radial distance between rings 9 and 11 to avoid clash.   
+  //Ring 9 { rSafetyMargin 38.0 }           // will force the radial distance between rings 9 and 11 to avoid clash.   
  
-  Ring 1 { ringOuterRadius 283.252 }        // NICK 2018-12-10 
+  Ring 1 { ringOuterRadius 283.252 }        // NICK 2019-01-11
   Ring 2 { ringOuterRadius 331 }
   Ring 3 { ringOuterRadius 364.307 }
   Ring 4 { ringOuterRadius 414 } 
@@ -44,7 +44,7 @@ Endcap TEDD_1 {
   Ring 12 { ringOuterRadius 838 } 
   Ring 13 { ringOuterRadius 904.8 } 
   Ring 14 { ringOuterRadius 1013.4 } 
-  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11   
+  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11  
   
   
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V616_200.cfg
@@ -26,14 +26,14 @@ Endcap TEDD_2 {
   // NB: zError and rSafetyMargin can be specified per disk or per ring!
   // zError: luminous region coverage, transition ring (i) with ring (i+1).
   // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
-  //zError 150                           // great coverage!
+  //zError 150                              // great coverage!
   //rSafetyMargin 15.0
-  //Ring 9 { rSafetyMargin 38.0 }        // will force the radial distance between rings 9 and 11 to avoid clash. 
+  //Ring 9 { rSafetyMargin 38.0 }           // will force the radial distance between rings 9 and 11 to avoid clash. 
     
   Ring 1 { removeModule true } 
   Ring 2 { removeModule true }  
   Ring 3 { removeModule true }
-  Ring 4 { ringOuterRadius 378.114 }        // NICK 2018-12-10
+  Ring 4 { ringOuterRadius 378.114 }        // NICK 2019-01-11
   Ring 5 { ringOuterRadius 412.101 }
   Ring 6 { ringOuterRadius 460.726 }
   Ring 7 { ringOuterRadius 494.631 }

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -218,13 +218,14 @@ OT615_200_IT404.cfg	   Diff with OT614 is in TBPS:
 OT616_200_IT404.cfg	   Diff with OT615:
                        Reduced outermost radius to leave space for BTL. Increased innermost radius for IT insertion.
                          - TEDD:
-                           TEDD 1, inner rings: (+41um) +7 mm  +1.01-0.5                 # IT insertion
-                           TEDD 2, inner rings: +2 mm  +1.01-0.5                  # IT insertion
-                           TEDD 1 and 2, outer rings: -27 mm -0.09+0.5           # Leave space for BTL
+                           bigDelta: 15.075 mm -> 15.755 mm (needed more disk separation).
+                           TEDD 1, inner rings: +7.041 mm (IT insertion) +0.51 mm (margin with dee edge).
+                           TEDD 2, inner rings: +2 mm (IT insertion) +0.51 mm (margin with dee edge).
+                           TEDD 1 and 2, outer rings: -27 mm (BTL) +0.41 mm (margin with dee edge).
                            TEDD 2: -4 modules in Ring 7, -4 modules in Ring 14.
                            Adjusted intermediate radii (needs feedback from Mechanics)
                          - TB2S:
-                             L3: rods radii: -25 mm. numRods: -2 rods.      # Leave space for BTL
+                             L3: radius -27 mm (OT envelope shrink) +2 mm (smaller no-go zone between TB2S and BTL). numRods: -2 rods.
                          - TBPS:
                              L1: +2 mm in last 5 rings radii.
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                          


### PR DESCRIPTION
There needs to be a 1 mm distance between the dee edge and the modules edges, instead of 1.5 mm. This results in: TEDD 1 and TEDD 2 inner: -0.5 mm. TEDD outer: +0.5 mm. 

**Summary of the changes in TEDD overall since TDR (615 rotated):** 
- bigDelta: 15.075 mm -> 15.755 mm (needed more disk separation).
- TEDD 1, inner rings: +7.041 mm (IT insertion) +0.51 mm (margin with dee edge).
- TEDD 2, inner rings: +2 mm (IT insertion) +0.51 mm (margin with dee edge).
- TEDD 1 and 2, outer rings: -27 mm (BTL) +0.41 mm (margin with dee edge).
- TEDD 2: -4 modules in Ring 7, -4 modules in Ring 14.
- Adjusted intermediate radii (needs feedback from Mechanics)