### PR TITLE
Added IT 613: Stretched TEPX in Z + Remove trackingTag on lumi ring

### DIFF
--- a/geometries/CMS_Phase2/OT614_200_IT613.cfg
+++ b/geometries/CMS_Phase2/OT614_200_IT613.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V614_200.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_3.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_1_0.cfg
@@ -1,4 +1,6 @@
   Barrel PXB {
+    trackingTags pixel,tracker
+      
     @include ../Supports/SupportsBPIX_V1.cfg
     @include-std CMS_Phase2/Pixel/Conversions/flange_BPIX
     @include ../Pixel_V4/stations_BPIX_Service_Cylinder_near

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_0.cfg
@@ -1,8 +1,8 @@
-
   Endcap FPIX_1 {    
     phiSegments 4
     etaCut 10
     zError 70
+    
     trackingTags pixel,tracker
 
     @includestd CMS_Phase2/Pixel/Materials/disk_FPIX

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_0.cfg
@@ -49,6 +49,7 @@
       numModules 32 
       ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
     }
+    
     Disk 1 { placeZ 250.00 }
     Disk 2 { placeZ 319.76 }
     Disk 3 { placeZ 408.99 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_0.cfg
@@ -57,6 +57,7 @@
       numModules 48
       ringOuterRadius 254
     }
+    
     Disk 1 { placeZ 1750.00 }
     Disk 2 { placeZ 1985.43 }
     Disk 3 { placeZ 2250.83 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_0.cfg
@@ -2,6 +2,7 @@
     phiSegments 4
     etaCut 10
     zError 70
+    
     trackingTags pixel,tracker
 
     @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_3.cfg
@@ -28,8 +28,7 @@
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       numModules 20
       ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
-    }
-    
+    }   
     Disk 1-3 {
       Ring 1 {
         trackingTags pixel,tracker    
@@ -38,10 +37,10 @@
     Disk 4 {
       Ring 1 {
         //trackingTags pixel,tracker
-        plotColor 5                  // different color, since no dedicated tracking tag
+        plotColor 5                  // brown. Different color, since no dedicated tracking tag
       } 
     }
-    
+        
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
@@ -50,6 +49,7 @@
       numModules 28
       ringOuterRadius 144.0          // to be tuned
     }
+    
     Ring 3 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
@@ -58,6 +58,7 @@
       numModules 36
       ringOuterRadius 181.3          // to be tuned
     }
+    
     Ring 4 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
@@ -66,6 +67,7 @@
       numModules 44
       ringOuterRadius 217.9           // to be tuned
     }
+    
     Ring 5 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
@@ -74,6 +76,7 @@
       numModules 48
       ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
     }
+    
     Disk 1 { placeZ 1750.00 }
     Disk 2 { placeZ 2009.59 }
     Disk 3 { placeZ 2307.69 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_3.cfg
@@ -2,7 +2,6 @@
     phiSegments 4
     etaCut 10
     zError 70
-    trackingTags pixel,tracker
 
     @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
     @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
@@ -21,6 +20,8 @@
     bigParity 1
     smallParity -1
     zRotation 1.570796327
+ 
+    
     Ring 1 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
@@ -28,10 +29,24 @@
       numModules 20
       ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
     }
+    
+    Disk 1-3 {
+      Ring 1 {
+        trackingTags pixel,tracker    
+      }
+    }    
+    Disk 4 {
+      Ring 1 {
+        //trackingTags pixel,tracker
+        plotColor 5                  // different color, since no dedicated tracking tag
+      } 
+    }
+    
     Ring 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
       numModules 28
       ringOuterRadius 144.0          // to be tuned
     }
@@ -39,6 +54,7 @@
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
       numModules 36
       ringOuterRadius 181.3          // to be tuned
     }
@@ -46,6 +62,7 @@
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
       numModules 44
       ringOuterRadius 217.9           // to be tuned
     }
@@ -53,6 +70,7 @@
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
       @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
       numModules 48
       ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
     }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_1_3.cfg
@@ -1,0 +1,69 @@
+  Endcap FPIX_2 {
+    phiSegments 4
+    etaCut 10
+    zError 70
+    trackingTags pixel,tracker
+
+    @includestd CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @includestd CMS_Phase2/Pixel/Conversions/flange_FPIX
+    @include ../Pixel_V4/stations_FPIX_2_3_Service_Cylinder_near
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 4 
+    bigDelta 2 
+    outerRadius 253.95
+    numRings 5
+    minZ 1620
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 28
+      ringOuterRadius 144.0          // to be tuned
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 36
+      ringOuterRadius 181.3          // to be tuned
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 44
+      ringOuterRadius 217.9           // to be tuned
+    }
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @includestd CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
+      @includestd CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 48
+      ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
+    }
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 2009.59 }
+    Disk 3 { placeZ 2307.69 }
+    Disk 4 { placeZ 2650.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_3.cfg
@@ -1,0 +1,28 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  barrelRotation 1.57079632679
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+ 
+  trackingTags pixel,tracker
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_1_0.cfg
+  @include ../Pixel_V6/FPIX1_6_1_0.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+  @include ../Supports/IT_Support_Tube_V1_0.cfg
+  @include ../Supports/IT_Service_Cylinder_V1_0.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_3.cfg
@@ -12,8 +12,6 @@ Tracker Pixels {
   barrelRotation 1.57079632679
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
- 
-  trackingTags pixel,tracker
   
   barrelDetIdScheme Phase2Subdetector1
   endcapDetIdScheme Phase2Subdetector4

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -452,7 +452,15 @@ OT614_200_IT611.cfg                  OT Version 6.1.4
                                      
 OT614_200_IT612.cfg                  OT Version 6.1.4                                     
                                      Based from Inner Tracker version 6.1.1.
-                                     bigDelta: 4 mm -> 2 mm, smallDelta: 2 mm -> 4 mm.                                                                                                                                    
+                                     bigDelta: 4 mm -> 2 mm, smallDelta: 2 mm -> 4 mm. 
+                                     
+OT614_200_IT613.cfg                  OT Version 6.1.4                                     
+                                     Based from Inner Tracker version 6.1.2.
+                                     Stretched TEDD in Z (there will be no dedicated lumi device, so can go up to bulkhead).
+                                     * Disk 1: same Z.
+                                     * Disk 2: 1985.43 mm -> 2009.59 mm   
+                                     * Disk 3: 2250.83 mm -> 2307.69 mm       
+                                     * Disk 4: 2550.00 mm -> 2650.00 mm (set same Z as last TEDD disk's meanZ for now).                                                                                                                                                               
                                      
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                        
                                                                                            


### PR DESCRIPTION
Stretched TEPX in Z (since there will be no dedicated lumi device).
TEPX last disk is set to be at the same meanZ as TEDD last disk. This will be further tuned when bulkhead design is advanced.

Removed tracking tag for TEDD Disk 4 Ring 1 (lumi ring).
Hence, that ring is not taken into accout in local param resolution plots AND tracking plots.

TO DO: Lumi ring still appears on hit counts on geo page.
Set the possibility to have INACTIVE hits on a module.
-> Module property: inactive
-> Change Hit constructor (with Module parameter) to avoid having all hits on module to be ACTIVE by default (use the Module property).
-> CHECK ALL ASSUMPTIONS in the code on hits on modules: should not assume them active by default. This is true for hit counts plots, but probably also at other places.
-> Careful to keep hits on modules (even inactive ;p) into account in MB plots.