### PR TITLE
Phase-out of AFS: move all dependencies to CVMFS (with no need of local install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 tkLayout requires:
 
     ROOT version > 5.34.09 (root and root-config should be in user's path)
-    BOOST version > 1.55
+    BOOST version > 1.50
     gcc version > 4.7
 
 If you are on lxplus, you can just run a bash shell and then:

--- a/setupCMake_slc6.sh
+++ b/setupCMake_slc6.sh
@@ -1,7 +1,7 @@
-source /afs/cern.ch/sw/lcg/app/releases/ROOT/5.34.09/x86_64-slc6-gcc47-dbg/root/bin/thisroot.sh
-source /afs/cern.ch/sw/lcg/contrib/gcc/4.7/x86_64-slc6-gcc47-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/5.34.09/x86_64-slc6-gcc47-dbg/root/bin/thisroot.sh
+source /cvmfs/sft.cern.ch/lcg/external/gcc/4.7.2/x86_64-slc6-gcc47-opt/setup.sh
 export CC=`which gcc`
 export CXX=`which g++`
-export BOOST_LIB=/afs/cern.ch/sw/lcg/external/Boost/1.55.0_python2.7/x86_64-slc6-gcc47-opt/lib
-export BOOST_INCLUDE=/afs/cern.ch/sw/lcg/external/Boost/1.55.0_python2.7/x86_64-slc6-gcc47-opt/include/boost-1_55
-export BOOST_SUFFIX=-gcc47-mt-1_55 
+export BOOST_LIB=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib/
+export BOOST_INCLUDE=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/include/boost-1_50
+export BOOST_SUFFIX=-gcc47-mt-1_50

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -1,11 +1,13 @@
-source /afs/cern.ch/sw/lcg/app/releases/ROOT/5.34.09/x86_64-slc6-gcc47-dbg/root/bin/thisroot.sh
-source /afs/cern.ch/sw/lcg/contrib/gcc/4.7/x86_64-slc6-gcc47-opt/setup.sh
-export LD_LIBRARY_PATH=/afs/cern.ch/sw/lcg/external/Boost/1.55.0_python2.7/x86_64-slc6-gcc47-opt/lib:$LD_LIBRARY_PATH
-export BOOST_LIB=/afs/cern.ch/sw/lcg/external/Boost/1.55.0_python2.7/x86_64-slc6-gcc47-opt/lib
-export BOOST_INCLUDE=/afs/cern.ch/sw/lcg/external/Boost/1.55.0_python2.7/x86_64-slc6-gcc47-opt/include/boost-1_55
-export BOOST_SUFFIX=-gcc47-mt-1_55 
-export DOXYGEN_PATH=/afs/cern.ch/sw/lcg/external/doxygen/1.8.2/x86_64-slc6-gcc47-opt/bin
+source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/5.34.09/x86_64-slc6-gcc47-dbg/root/bin/thisroot.sh
 
+source /cvmfs/sft.cern.ch/lcg/external/gcc/4.7.2/x86_64-slc6-gcc47-opt/setup.sh
+
+export BOOST_INCLUDE=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/include/boost-1_50
+export BOOST_LIB=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib/
+export BOOST_SUFFIX=-gcc47-mt-1_50
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib:$LD_LIBRARY_PATH
+
+export DOXYGEN_PATH=/cvmfs/sft.cern.ch/lcg/external/doxygen/1.8.2/x86_64-slc6-gcc47-opt/bin
 if [ -d $DOXYGEN_PATH ] ; then
   export PATH=${DOXYGEN_PATH}:${PATH}
 fi


### PR DESCRIPTION
Notes:
- gcc 
gcc 4.7 not available anymore in /contrib, but found it in /external

- BOOST 
BOOST 1.55.0_python2.7 not available anymore for x86_64-slc6-gcc47 architecture, but found for x86_64-slc6-gcc48 architecture.
Linker errors as described in https://svn.boost.org/trac10/ticket/10038#no1 appear with simple move to /cvmfs/sft.cern.ch/lcg/releases/Boost/1.55.0_python2.7-70d89/x86_64-slc6-gcc48-opt/
They could not be resolved with dirty trick provided at https://codeyarns.com/2017/09/20/undefined-reference-to-boost-copy_file/.
Eventually solved this by downgrading to Boost 1.50.0_python2.7, which does not require any dirty trick :)