### PR TITLE
Merged friday's code: Assign MFB fanout branches to modules in TEDD

### DIFF
--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -375,15 +375,16 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   std::string summaryFullType() const;
 
   // OT CABLING
-  void setBundle(OuterBundle* bundle) { bundle_ = bundle ; }
+  const int isPositiveCablingSide() const;                    // Can be different from (Z) end. 
+                                                              // 'Positive cabling side': the module end up connected on a DTC on (Z+) end.
+  void setBundle(OuterBundle* bundle) { bundle_ = bundle ; }  // MFB
   const OuterBundle* getBundle() const { return bundle_; }
-  void setEndcapFanoutBranch(const int branchIndex) { endcapFanoutBranch_ = branchIndex; }
-  const int getEndcapFanoutBranch() const { return endcapFanoutBranch_; }
-  const int isPositiveCablingSide() const;
   const int bundlePlotColor() const; 
+  void setEndcapFiberFanoutBranch(const int branchIndex) { endcapFiberFanoutBranch_ = branchIndex; } // Branch of the MFB fanout
+  const int getEndcapFiberFanoutBranch() const { return endcapFiberFanoutBranch_; }
   const int opticalChannelSectionPlotColor() const;
   const int powerChannelSectionPlotColor() const; 
-  const OuterDTC* getDTC() const;
+  const OuterDTC* getDTC() const;                             // DTC
   const int dtcPlotColor() const;
   const int dtcPhiSectorRef() const;
 
@@ -432,7 +433,7 @@ private:
 
   // OT CABLING MAP
   OuterBundle* bundle_ = nullptr;
-  int endcapFanoutBranch_ = 0;
+  int endcapFiberFanoutBranch_ = 0;
   // IT CABLING MAP
   PowerChain* powerChain_ = nullptr;
   int phiRefInPowerChain_;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -377,8 +377,8 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   // OT CABLING
   void setBundle(OuterBundle* bundle) { bundle_ = bundle ; }
   const OuterBundle* getBundle() const { return bundle_; }
-  void setEndcapBundleFanoutInput(const int inputIndex) { endcapBundleFanoutInput_ = inputIndex; }
-  const int getEndcapBundleFanoutInput() const { return endcapBundleFanoutInput_; }
+  void setEndcapFanoutBranch(const int branchIndex) { endcapFanoutBranch_ = branchIndex; }
+  const int getEndcapFanoutBranch() const { return endcapFanoutBranch_; }
   const int isPositiveCablingSide() const;
   const int bundlePlotColor() const; 
   const int opticalChannelSectionPlotColor() const;
@@ -432,7 +432,7 @@ private:
 
   // OT CABLING MAP
   OuterBundle* bundle_ = nullptr;
-  int endcapBundleFanoutInput_ = 0;
+  int endcapFanoutBranch_ = 0;
   // IT CABLING MAP
   PowerChain* powerChain_ = nullptr;
   int phiRefInPowerChain_;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -377,6 +377,8 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   // OT CABLING
   void setBundle(OuterBundle* bundle) { bundle_ = bundle ; }
   const OuterBundle* getBundle() const { return bundle_; }
+  void setEndcapBundleFanoutInput(const int inputIndex) { endcapBundleFanoutInput_ = inputIndex; }
+  const int getEndcapBundleFanoutInput() const { return endcapBundleFanoutInput_; }
   const int isPositiveCablingSide() const;
   const int bundlePlotColor() const; 
   const int opticalChannelSectionPlotColor() const;
@@ -430,6 +432,7 @@ private:
 
   // OT CABLING MAP
   OuterBundle* bundle_ = nullptr;
+  int endcapBundleFanoutInput_ = 0;
   // IT CABLING MAP
   PowerChain* powerChain_ = nullptr;
   int phiRefInPowerChain_;

--- a/include/OuterCabling/ModulesToBundlesConnector.hh
+++ b/include/OuterCabling/ModulesToBundlesConnector.hh
@@ -45,6 +45,8 @@ private:
   // STAGERRING
   void staggerModules(std::map<int, OuterBundle*>& bundles);
 
+  void assignEndcapBundlesFanoutInputs(std::map<int, OuterBundle*>& bundles);
+
   // CHECKING
   void checkModulesToBundlesCabling(const std::map<int, OuterBundle*>& bundles) const;
 

--- a/include/OuterCabling/ModulesToBundlesConnector.hh
+++ b/include/OuterCabling/ModulesToBundlesConnector.hh
@@ -45,10 +45,12 @@ private:
   // STAGERRING
   void staggerModules(std::map<int, OuterBundle*>& bundles);
 
-  void assignEndcapBundlesFanoutBranches(std::map<int, OuterBundle*>& bundles);
-
   // CHECKING
   void checkModulesToBundlesCabling(const std::map<int, OuterBundle*>& bundles) const;
+
+  // ENDCAPS ONLY: ASSIGN THE MFB FANOUTS BRANCHES TO THE MODULES
+  void connectEndcapModulesToBundlesFanoutBranches(std::map<int, OuterBundle*>& bundles);
+  void checkEndcapModulesToBundlesFanoutBranchesCabling(const std::map<int, OuterBundle*>& bundles) const;
 
   std::map<int, OuterBundle*> bundles_;     // positive cabling side bundles.
   std::map<int, OuterBundle*> negBundles_;  // negative cabling side bundles.

--- a/include/OuterCabling/ModulesToBundlesConnector.hh
+++ b/include/OuterCabling/ModulesToBundlesConnector.hh
@@ -45,7 +45,7 @@ private:
   // STAGERRING
   void staggerModules(std::map<int, OuterBundle*>& bundles);
 
-  void assignEndcapBundlesFanoutInputs(std::map<int, OuterBundle*>& bundles);
+  void assignEndcapBundlesFanoutBranches(std::map<int, OuterBundle*>& bundles);
 
   // CHECKING
   void checkModulesToBundlesCabling(const std::map<int, OuterBundle*>& bundles) const;

--- a/include/OuterCabling/outer_cabling_constants.hh
+++ b/include/OuterCabling/outer_cabling_constants.hh
@@ -14,6 +14,11 @@ static const int outer_cabling_maxNumBundlesPerCable = 6;
 // Maximum number of DTCs per phi sector (one (Z) end)
 static const int outer_cabling_maxNumDTCsPerNonantPerZEnd = 12;
 
+// TEDD only: max number of fanout branches per MFB.
+// This is not necessary to get the OT cabling map running:
+// it just provides extra installation info.
+static const int outer_cabling_maxNumFanoutBranchesPerEndcapBundle = 4;
+
 
 // PHI SLICES
 // Size of the phi slices used
@@ -21,6 +26,9 @@ static const int outer_cabling_numNonants = 9;
 static const double outer_cabling_nonantWidth = 2. * M_PI / outer_cabling_numNonants;                            // 40°
 static const double outer_cabling_semiNonantWidth = 2. * M_PI / (2. * outer_cabling_numNonants);                 // 20°
 static const double outer_cabling_endcapStripStripPhiRegionWidth = 2. * M_PI / (3. * outer_cabling_numNonants);  // 13.333°
+static const int outer_cabling_phiNonantCrossingDifferentDeesIndex = 4; // Phi nonant spread on different dees (ie, on present OT, crossing (Y=0)).
+                                                                        // Can be set to irrealistic index (50 for example) if no phi nonant is on different dees!
+                                                                        // This is used only for MFB fanout assignment, in TEDD.
 
 // Offset are sometimes used to set the phi slices.
 // This has been tried to be reduced to the bare minimum: only 2 hardcoded constants :)

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -101,9 +101,9 @@ struct Type { // Module-maintained color
 };
 
 // OT CABLING
-struct TypeFanoutBranchTransparentColor { // Module-maintained Bundle fanout input color
+struct TypeFanoutBranchTransparentColor { // Module-maintained Bundle fanout branch color
   double operator()(const Module& m) {
-    const bool isOddFanoutBranchIndex = ((m.getEndcapFanoutBranch() % 2) == 1);
+    const bool isOddFanoutBranchIndex = ((m.getEndcapFiberFanoutBranch() % 2) == 1);
     const bool isTransparent = ((m.isPositiveCablingSide() > 0) ? isOddFanoutBranchIndex : !isOddFanoutBranchIndex);
     return Palette::color(m.bundlePlotColor(), isTransparent);
   }

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -101,6 +101,14 @@ struct Type { // Module-maintained color
 };
 
 // OT CABLING
+struct TypeBundleFanoutInputTransparentColor { // Module-maintained Bundle fanout input color
+  double operator()(const Module& m) {
+    const bool isOddFanoutInputIndex = ((m.getEndcapBundleFanoutInput() % 2) == 1);
+    const bool isTransparent = ((m.isPositiveCablingSide() > 0) ? isOddFanoutInputIndex : !isOddFanoutInputIndex);
+    return Palette::color(m.bundlePlotColor(), isTransparent);
+  }
+};
+
 struct TypeBundleColor { // Module-maintained Bundle color
   double operator()(const Module& m) {
     return Palette::color(m.bundlePlotColor());

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -101,10 +101,10 @@ struct Type { // Module-maintained color
 };
 
 // OT CABLING
-struct TypeBundleFanoutInputTransparentColor { // Module-maintained Bundle fanout input color
+struct TypeFanoutBranchTransparentColor { // Module-maintained Bundle fanout input color
   double operator()(const Module& m) {
-    const bool isOddFanoutInputIndex = ((m.getEndcapBundleFanoutInput() % 2) == 1);
-    const bool isTransparent = ((m.isPositiveCablingSide() > 0) ? isOddFanoutInputIndex : !isOddFanoutInputIndex);
+    const bool isOddFanoutBranchIndex = ((m.getEndcapFanoutBranch() % 2) == 1);
+    const bool isTransparent = ((m.isPositiveCablingSide() > 0) ? isOddFanoutBranchIndex : !isOddFanoutBranchIndex);
     return Palette::color(m.bundlePlotColor(), isTransparent);
   }
 };

--- a/setupCMake_slc6.sh
+++ b/setupCMake_slc6.sh
@@ -2,6 +2,6 @@ source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/5.34.09/x86_64-slc6-gcc47-dbg/ro
 source /cvmfs/sft.cern.ch/lcg/external/gcc/4.7.2/x86_64-slc6-gcc47-opt/setup.sh
 export CC=`which gcc`
 export CXX=`which g++`
-export BOOST_LIB=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib/
+export BOOST_LIB=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib
 export BOOST_INCLUDE=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/include/boost-1_50
 export BOOST_SUFFIX=-gcc47-mt-1_50

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -3,7 +3,7 @@ source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/5.34.09/x86_64-slc6-gcc47-dbg/ro
 source /cvmfs/sft.cern.ch/lcg/external/gcc/4.7.2/x86_64-slc6-gcc47-opt/setup.sh
 
 export BOOST_INCLUDE=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/include/boost-1_50
-export BOOST_LIB=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib/
+export BOOST_LIB=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib
 export BOOST_SUFFIX=-gcc47-mt-1_50
 export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/external/Boost/1.50.0_python2.7/x86_64-slc6-gcc47-opt/lib:$LD_LIBRARY_PATH
 

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -527,7 +527,7 @@ ModulesToDTCsVisitor::ModulesToDTCsVisitor(bool isPositiveCablingSide) {
 }
 
 void ModulesToDTCsVisitor::preVisit() {
-  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Bundle #/I, OPT Services Channel/I, PWR Services Channel/I, Cable #/I, Cable type/C, DTC name/C, DTC CMSSW Id/U, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D" << std::endl;
+  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, MFB #/I, OPT Services Channel/I, PWR Services Channel/I, MFC #/I, MFC type/C, DTC name/C, DTC CMSSW Id/U, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D" << std::endl;
 }
 
 void ModulesToDTCsVisitor::visit(const Barrel& b) {
@@ -620,7 +620,7 @@ void CMSSWOuterTrackerCablingMapVisitor::visit(const Module& m) {
     //************************************//
 
 void InnerTrackerModulesToDTCsVisitor::preVisit() {
-  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Long Barrel ?/Boolean, Power Chain #/I, Power Chain Type/C, # ELinks Per Module/I, LP GBT #/C, Bundle #/I, DTC #/I, (+Z) End ?/Boolean, (+X) Side?/Boolean" << std::endl;
+  output_ << "Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D, Long Barrel ?/Boolean, Power Chain #/I, Power Chain Type/C, # ELinks Per Module/I, LP GBT #/C, MFB #/I, DTC #/I, (+Z) End ?/Boolean, (+X) Side?/Boolean" << std::endl;
 }
 
 void InnerTrackerModulesToDTCsVisitor::visit(const Barrel& b) {

--- a/src/OuterCabling/ModulesToBundlesConnector.cc
+++ b/src/OuterCabling/ModulesToBundlesConnector.cc
@@ -110,8 +110,8 @@ void ModulesToBundlesConnector::postVisit() {
   staggerModules(bundles_);
   staggerModules(negBundles_);
 
-  assignEndcapBundlesFanoutInputs(bundles_);
-  assignEndcapBundlesFanoutInputs(negBundles_);
+  assignEndcapBundlesFanoutBranches(bundles_);
+  assignEndcapBundlesFanoutBranches(negBundles_);
 
   // CHECK
   checkModulesToBundlesCabling(bundles_);
@@ -436,7 +436,7 @@ void ModulesToBundlesConnector::staggerModules(std::map<int, OuterBundle*>& bund
 
 
 
-void ModulesToBundlesConnector::assignEndcapBundlesFanoutInputs(std::map<int, OuterBundle*>& bundles) {
+void ModulesToBundlesConnector::assignEndcapBundlesFanoutBranches(std::map<int, OuterBundle*>& bundles) {
 
   for (auto& b : bundles) {
     const OuterBundle* myBundle = b.second;
@@ -454,9 +454,9 @@ void ModulesToBundlesConnector::assignEndcapBundlesFanoutInputs(std::map<int, Ou
 	std::map<int, bool> hasDiskSurfaceModuleInPhiPos;
 	std::map<int, bool> hasDiskSurfaceModuleInPhiNeg;
 	// initialize
-	for (int fanoutInputIndex = 1; fanoutInputIndex <= 4; fanoutInputIndex++) {
-	  hasDiskSurfaceModuleInPhiPos[fanoutInputIndex] = false;
-	  hasDiskSurfaceModuleInPhiNeg[fanoutInputIndex] = false;
+	for (int fanoutBranchIndex = 1; fanoutBranchIndex <= 4; fanoutBranchIndex++) {
+	  hasDiskSurfaceModuleInPhiPos[fanoutBranchIndex] = false;
+	  hasDiskSurfaceModuleInPhiNeg[fanoutBranchIndex] = false;
 	}
 
 	for (const auto& module : myModules) {
@@ -485,13 +485,13 @@ void ModulesToBundlesConnector::assignEndcapBundlesFanoutInputs(std::map<int, Ou
         const bool sortDiskInPhi = ( (diskSurfaceIndex == 1 || (diskSurfaceIndex == 2)) ? sortSmallAbsZDiskInPhi : sortBigAbsZDiskInPhi);
 
 	if (!sortDiskInPhi) {
-	  module->setEndcapBundleFanoutInput(diskSurfaceIndex);
+	  module->setEndcapFanoutBranch(diskSurfaceIndex);
 	}
 	else { 
 	  const double modPhi = femod(module->center().Phi(), 2.*M_PI);
-	  int endcapBundleFanoutInput = ( (modPhi < M_PI) ? 1 : 2);
-	  if (diskSurfaceIndex >= 3) endcapBundleFanoutInput += 2;
-	  module->setEndcapBundleFanoutInput(endcapBundleFanoutInput);
+	  int endcapFanoutBranchIndex = ( (modPhi < M_PI) ? 1 : 2);
+	  if (diskSurfaceIndex >= 3) endcapFanoutBranchIndex += 2;
+	  module->setEndcapFanoutBranch(endcapFanoutBranchIndex);
 	}
       }
 

--- a/src/OuterCabling/ModulesToBundlesConnector.cc
+++ b/src/OuterCabling/ModulesToBundlesConnector.cc
@@ -598,32 +598,35 @@ void ModulesToBundlesConnector::checkEndcapModulesToBundlesFanoutBranchesCabling
   for (auto& b : bundles) {
     // Work on a per MFB basis
     const OuterBundle* myBundle = b.second;
-    std::set<int> allBranchesIndexes;
+    // Endcaps only
+    if (myBundle->subDetectorName() == outer_cabling_tedd1 || myBundle->subDetectorName() == outer_cabling_tedd2) {
+      std::set<int> allBranchesIndexes;
 
-    // Loop on all the modules connected to the MFB, ancd check their fanout branch index.
-    const std::vector<Module*>& myModules = myBundle->modules();
-    for (const auto& module : myModules) {
-      const int endcapFiberFanoutBranchIndex = module->getEndcapFiberFanoutBranch();    
-      if ( endcapFiberFanoutBranchIndex <= 0 
-	   || endcapFiberFanoutBranchIndex > outer_cabling_maxNumFanoutBranchesPerEndcapBundle) {
-	logERROR(any2str("TEDD: assigning MFB fanouts to modules. ")
-		 + "OuterBundle "  + any2str(b.first)
-		 + ". Found a module connected to fanout index = " + any2str(endcapFiberFanoutBranchIndex) 
-		 + ", which is not supported."
-		 );
+      // Loop on all the modules connected to the MFB, ancd check their fanout branch index.
+      const std::vector<Module*>& myModules = myBundle->modules();
+      for (const auto& module : myModules) {
+	const int endcapFiberFanoutBranchIndex = module->getEndcapFiberFanoutBranch();    
+	if ( endcapFiberFanoutBranchIndex <= 0 
+	     || endcapFiberFanoutBranchIndex > outer_cabling_maxNumFanoutBranchesPerEndcapBundle) {
+	  logERROR(any2str("TEDD: assigning MFB fanouts to modules. ")
+		   + "OuterBundle "  + any2str(b.first)
+		   + ". Found a module connected to fanout index = " + any2str(endcapFiberFanoutBranchIndex) 
+		   + ", which is not supported."
+		   );
+	}
+	allBranchesIndexes.insert(endcapFiberFanoutBranchIndex);
       }
-      allBranchesIndexes.insert(endcapFiberFanoutBranchIndex);
-    }
 
-    // Check that, for each MFB, all fanout branches indexes are met at least once.
-    for (int branchIndex = 1; branchIndex <= outer_cabling_maxNumFanoutBranchesPerEndcapBundle; branchIndex++) {
-      if (allBranchesIndexes.find(branchIndex) == allBranchesIndexes.end()) {
-	logERROR(any2str("TEDD: assigning MFB fanouts to modules. ")
-		 + "OuterBundle "  + any2str(b.first)
-		 + ". Found 0 module with fanout branch index = " + any2str(branchIndex)
-		 );
+      // Check that, for each MFB, all fanout branches indexes are met at least once.
+      for (int branchIndex = 1; branchIndex <= outer_cabling_maxNumFanoutBranchesPerEndcapBundle; branchIndex++) {
+	if (allBranchesIndexes.find(branchIndex) == allBranchesIndexes.end()) {
+	  logERROR(any2str("TEDD: assigning MFB fanouts to modules. ")
+		   + "OuterBundle "  + any2str(b.first)
+		   + ". Found 0 module with fanout branch index = " + any2str(branchIndex)
+		   );
+	}
       }
-    }
 
+    }
   }
 }

--- a/src/OuterCabling/ModulesToBundlesConnector.cc
+++ b/src/OuterCabling/ModulesToBundlesConnector.cc
@@ -570,10 +570,10 @@ void ModulesToBundlesConnector::connectEndcapModulesToBundlesFanoutBranches(std:
 	  module->setEndcapFiberFanoutBranch(diskSurfaceIndex);
 	}
 	// Sort modules per dee:
-	// Small |Z| disk, (Y > 0) dee: fanout index = 1
-	// Small |Z| disk, (Y < 0) dee: fanout index = 2
-	// Big |Z| disk, (Y > 0) dee: fanout index = 3
-	// Big |Z| disk, (Y < 0) dee: fanout index = 4
+	// Small |Z| disk, (Y > 0) dee: fanout branch index = 1
+	// Small |Z| disk, (Y < 0) dee: fanout branch index = 2
+	// Big |Z| disk, (Y > 0) dee: fanout branch index = 3
+	// Big |Z| disk, (Y < 0) dee: fanout branch index = 4
 	else { 
 	  const double modPhi = femod(module->center().Phi(), 2.*M_PI);
 	  int endcapFiberFanoutBranchIndex = ( (modPhi < M_PI) ? 1 : 2);

--- a/src/OuterCabling/ModulesToBundlesConnector.cc
+++ b/src/OuterCabling/ModulesToBundlesConnector.cc
@@ -110,12 +110,13 @@ void ModulesToBundlesConnector::postVisit() {
   staggerModules(bundles_);
   staggerModules(negBundles_);
 
-  assignEndcapBundlesFanoutBranches(bundles_);
-  assignEndcapBundlesFanoutBranches(negBundles_);
-
   // CHECK
   checkModulesToBundlesCabling(bundles_);
   checkModulesToBundlesCabling(negBundles_);
+
+  // ENDCAPS ONLY: ASSIGN THE MFB FANOUTS BRANCHES TO THE MODULES
+  connectEndcapModulesToBundlesFanoutBranches(bundles_);
+  connectEndcapModulesToBundlesFanoutBranches(negBundles_);
 }
 
 
@@ -434,75 +435,6 @@ void ModulesToBundlesConnector::staggerModules(std::map<int, OuterBundle*>& bund
 }
 
 
-
-
-void ModulesToBundlesConnector::assignEndcapBundlesFanoutBranches(std::map<int, OuterBundle*>& bundles) {
-
-  for (auto& b : bundles) {
-    const OuterBundle* myBundle = b.second;
-    // All this happens in Endcaps only
-    if (myBundle->subDetectorName() == outer_cabling_tedd1 || myBundle->subDetectorName() == outer_cabling_tedd2) {
-     
-      bool sortSmallAbsZDiskInPhi = false;
-      bool sortBigAbsZDiskInPhi = false;
-
-      const std::vector<Module*>& myModules = myBundle->modules();
-
-      const int& myPhiSectorRef = myBundle->phiPosition().phiSectorRef();    
-      if (myPhiSectorRef == 4) {  // remove magic number
-
-	std::map<int, bool> hasDiskSurfaceModuleInPhiPos;
-	std::map<int, bool> hasDiskSurfaceModuleInPhiNeg;
-	// initialize
-	for (int fanoutBranchIndex = 1; fanoutBranchIndex <= 4; fanoutBranchIndex++) {
-	  hasDiskSurfaceModuleInPhiPos[fanoutBranchIndex] = false;
-	  hasDiskSurfaceModuleInPhiNeg[fanoutBranchIndex] = false;
-	}
-
-	for (const auto& module : myModules) {
-	  const int diskSurfaceIndex = module->diskSurface();
-	  const double modPhi = femod(module->center().Phi(), 2.*M_PI);
-
-	  // add check that phi != ~Pi
-	  if (modPhi < M_PI) { hasDiskSurfaceModuleInPhiPos[diskSurfaceIndex] = true; }
-	  else { hasDiskSurfaceModuleInPhiNeg[diskSurfaceIndex] = true; }
-	}
-
-
-	if ( (hasDiskSurfaceModuleInPhiPos.at(1) && hasDiskSurfaceModuleInPhiNeg.at(1))
-	     || (hasDiskSurfaceModuleInPhiPos.at(2) && hasDiskSurfaceModuleInPhiNeg.at(2))
-	     ) { sortSmallAbsZDiskInPhi = true; }
-	if ( (hasDiskSurfaceModuleInPhiPos.at(3) && hasDiskSurfaceModuleInPhiNeg.at(3))
-	     || (hasDiskSurfaceModuleInPhiPos.at(4) && hasDiskSurfaceModuleInPhiNeg.at(4))
-	     ) { sortBigAbsZDiskInPhi = true; }
-
-      }
-
-
-
-      for (const auto& module : myModules) {
-	const int diskSurfaceIndex = module->diskSurface();
-        const bool sortDiskInPhi = ( (diskSurfaceIndex == 1 || (diskSurfaceIndex == 2)) ? sortSmallAbsZDiskInPhi : sortBigAbsZDiskInPhi);
-
-	if (!sortDiskInPhi) {
-	  module->setEndcapFanoutBranch(diskSurfaceIndex);
-	}
-	else { 
-	  const double modPhi = femod(module->center().Phi(), 2.*M_PI);
-	  int endcapFanoutBranchIndex = ( (modPhi < M_PI) ? 1 : 2);
-	  if (diskSurfaceIndex >= 3) endcapFanoutBranchIndex += 2;
-	  module->setEndcapFanoutBranch(endcapFanoutBranchIndex);
-	}
-      }
-
-  
-    }
-  }
-}
-
-
-
-
 /* Check modules-bundles connections.
  */
 void ModulesToBundlesConnector::checkModulesToBundlesCabling(const std::map<int, OuterBundle*>& bundles) const {
@@ -529,6 +461,168 @@ void ModulesToBundlesConnector::checkModulesToBundlesCabling(const std::map<int,
 	       + "OuterBundle "  + any2str(b.first) + " is connected to " + any2str(bundleNumModules) + " modules."
 	       + " Maximum number of modules per bundle allowed is " + any2str(outer_cabling_maxNumModulesPerBundle)
 	       );
+    }
+
+  }
+}
+
+
+/*
+  Endcaps only: assign the MFB fanouts branches to the modules.
+  The modules are connected to the MFBs through 4 fanouts branches. 
+  In the Endcaps, this ends up complicated. It was hence requested by the Mechanics to have it in at automatic way.
+  This work can obviously only be done once the modules are assigned to the MFBs in a final way 
+  (hence once the modules staggering is already done).
+
+  Concept is the following: for each MFB, one looks at the modules connected to it.
+  Standard case: 1 fanout branch per disk surface.
+  Special case: phi sector crossing (Y=0): 
+  if a MFB has several modules on the same disk (not double-disk!) and in different dees,
+  then the fanout branch assignment is per dee.
+
+  Assumptions: 4 disk surfaces per dee + dee boundary at (Y=0).
+ */
+void ModulesToBundlesConnector::connectEndcapModulesToBundlesFanoutBranches(std::map<int, OuterBundle*>& bundles) {
+  // Loop on all MFBs
+  for (auto& b : bundles) {
+    // WORK ON A PER MFB BASIS
+    const OuterBundle* myBundle = b.second;
+    // Endcaps only
+    if (myBundle->subDetectorName() == outer_cabling_tedd1 || myBundle->subDetectorName() == outer_cabling_tedd2) {
+     
+
+      // STEP A: FIND, FOR EACH DISK (NOT DOUBLE-DISK!!), HOW THE BUNDLE'S MODULES SHOULD BE SORTED.
+
+      // BY DEFAULT, SORTING IS PER DISK SURFACE.
+      bool sortModulesInSmallAbsZDiskPerDee = false;
+      bool sortModulesInBigAbsZDiskPerDee = false;
+
+      // Assumes 4 disk surfaces per double-disk
+      const int numDiskSurfacesPerDoubleDisk = 4;
+
+      // Get all the modules connected to the MFB
+      const std::vector<Module*>& myModules = myBundle->modules();
+
+      // IF THE PHI SECTOR IS CROSSING SEVERAL DEES: 
+      // WE NEED TO LOOK ON WHICH DEE MODULES ARE ON.
+      const int& myPhiSectorRef = myBundle->phiPosition().phiSectorRef();    
+      if (myPhiSectorRef == outer_cabling_phiNonantCrossingDifferentDeesIndex) {
+
+	// Store, per disk surface, which dee modules are on.
+	std::map<int, bool> hasDiskSurfaceAnyModuleInYPosDee;
+	std::map<int, bool> hasDiskSurfaceAnyModuleInYNegDee;
+	// Initialize: by default, there is no module.
+	for (int diskSurfaceIndex = 1; diskSurfaceIndex <= numDiskSurfacesPerDoubleDisk; diskSurfaceIndex++) {
+	  hasDiskSurfaceAnyModuleInYPosDee[diskSurfaceIndex] = false;
+	  hasDiskSurfaceAnyModuleInYNegDee[diskSurfaceIndex] = false;
+	}
+
+	// loop on all modules connected to a MFB
+	for (const auto& module : myModules) {
+	  const double modPhiModuloPi = femod(module->center().Phi(), M_PI); // modulo PI
+
+	  // STORE, PER DISK SURFACE, WHICH DEE MODULES ARE ON.
+	  if ( fabs(modPhiModuloPi) > outer_cabling_roundingTolerance 
+	       && fabs(modPhiModuloPi - M_PI) > outer_cabling_roundingTolerance
+	       ) {
+	    const int diskSurfaceIndex = module->diskSurface();
+	    const double modPhi = femod(module->center().Phi(), 2.*M_PI);      // modulo 2 PI
+
+	    // module is on (Y > 0) dee
+	    if (modPhi < M_PI) { hasDiskSurfaceAnyModuleInYPosDee[diskSurfaceIndex] = true; }
+	    // module is on (Y < 0) dee
+	    else { hasDiskSurfaceAnyModuleInYNegDee[diskSurfaceIndex] = true; }
+	  }
+	}
+
+	// IF MODULES ARE ON 2 DEES OF THE SAME DISK SURFACE: CHOOSE DEE SORTING!	  
+	for (int diskSurfaceIndex = 1; diskSurfaceIndex <= numDiskSurfacesPerDoubleDisk; diskSurfaceIndex++) {
+	  if (hasDiskSurfaceAnyModuleInYPosDee.at(diskSurfaceIndex) && hasDiskSurfaceAnyModuleInYNegDee.at(diskSurfaceIndex)) {
+	    // If surface 1 or 2 has modules on both dees
+	    if (diskSurfaceIndex == 1 || diskSurfaceIndex == 2) { 
+	      // then small |Z| disk should have a sorting per dee! 
+	      sortModulesInSmallAbsZDiskPerDee = true; 
+	    }
+	    // If surface 3 or 4 has modules on both dees
+	    else if (diskSurfaceIndex == 3 || diskSurfaceIndex == 4) { 
+	      // then big |Z| disk should have a sorting per dee! 
+	      sortModulesInBigAbsZDiskPerDee = true; 
+	    }
+	    else { 
+	      logERROR(any2str("Unexpected number of disk surfaces per double-disk"));
+	    }
+	  } 
+	}
+
+      }
+
+
+      // STEP B: Assign the fanout branch index to the MFB's modules.
+      for (const auto& module : myModules) {
+	const int diskSurfaceIndex = module->diskSurface();
+
+	// Find out which sorting mode is relevant
+	const bool sortModulesInDiskPerDee = ( (diskSurfaceIndex == 1 || (diskSurfaceIndex == 2)) ? sortModulesInSmallAbsZDiskPerDee 
+					       : sortModulesInBigAbsZDiskPerDee);
+	// Sort modules per disk surface:
+	// fanout branch index = module's disk surface
+	if (!sortModulesInDiskPerDee) {
+	  module->setEndcapFiberFanoutBranch(diskSurfaceIndex);
+	}
+	// Sort modules per dee:
+	// Small |Z| disk, (Y > 0) dee: fanout index = 1
+	// Small |Z| disk, (Y < 0) dee: fanout index = 2
+	// Big |Z| disk, (Y > 0) dee: fanout index = 3
+	// Big |Z| disk, (Y < 0) dee: fanout index = 4
+	else { 
+	  const double modPhi = femod(module->center().Phi(), 2.*M_PI);
+	  int endcapFiberFanoutBranchIndex = ( (modPhi < M_PI) ? 1 : 2);
+	  if (diskSurfaceIndex >= 3) endcapFiberFanoutBranchIndex += 2;
+	  module->setEndcapFiberFanoutBranch(endcapFiberFanoutBranchIndex);
+	}
+      }
+
+  
+    }
+  }
+
+  checkEndcapModulesToBundlesFanoutBranchesCabling(bundles);
+}
+
+
+/* TEDD: Check modules - bundles fanouts branches connections.
+ */
+void ModulesToBundlesConnector::checkEndcapModulesToBundlesFanoutBranchesCabling(const std::map<int, OuterBundle*>& bundles) const {
+
+  // Loop on all MFBs
+  for (auto& b : bundles) {
+    // Work on a per MFB basis
+    const OuterBundle* myBundle = b.second;
+    std::set<int> allBranchesIndexes;
+
+    // Loop on all the modules connected to the MFB, ancd check their fanout branch index.
+    const std::vector<Module*>& myModules = myBundle->modules();
+    for (const auto& module : myModules) {
+      const int endcapFiberFanoutBranchIndex = module->getEndcapFiberFanoutBranch();    
+      if ( endcapFiberFanoutBranchIndex <= 0 
+	   || endcapFiberFanoutBranchIndex > outer_cabling_maxNumFanoutBranchesPerEndcapBundle) {
+	logERROR(any2str("TEDD: assigning MFB fanouts to modules. ")
+		 + "OuterBundle "  + any2str(b.first)
+		 + ". Found a module connected to fanout index = " + any2str(endcapFiberFanoutBranchIndex) 
+		 + ", which is not supported."
+		 );
+      }
+      allBranchesIndexes.insert(endcapFiberFanoutBranchIndex);
+    }
+
+    // Check that, for each MFB, all fanout branches indexes are met at least once.
+    for (int branchIndex = 1; branchIndex <= outer_cabling_maxNumFanoutBranchesPerEndcapBundle; branchIndex++) {
+      if (allBranchesIndexes.find(branchIndex) == allBranchesIndexes.end()) {
+	logERROR(any2str("TEDD: assigning MFB fanouts to modules. ")
+		 + "OuterBundle "  + any2str(b.first)
+		 + ". Found 0 module with fanout branch index = " + any2str(branchIndex)
+		 );
+      }
     }
 
   }

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1509,10 +1509,11 @@ namespace insur {
       // Bundles to Modules: Aggregation Patterns in TEDD
       /*This is used for bundle assembly.
 	For example, for a given buddle, the pattern 3-4-3-2 means that the bundle is connected to:
-	- 3 modules from disk surface 1 (the disk surface with lowest |Z|).
-	- 4 modules from disk surface 2.
-	- 3 modules from disk surface 3.
-	- 2 modules from disk surface 4 (the disk surface with biggest |Z|).*/
+	- 3 modules from fanout branch index 1.
+	- 4 modules from fanout branch index 2.
+	- 3 modules from fanout branch index 3.
+	- 2 modules from fanout branch index 4.
+      */
       myTextFile = new RootWTextFile(Form("AggregationPatternsPos%s.csv", name.c_str()), "Bundles to Modules: Aggregation Patterns in TEDD");
       myTextFile->addText(createBundlesToEndcapModulesCsv(myCablingMap, isPositiveCablingSide));
       filesContent->addItem(myTextFile);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7417,7 +7417,7 @@ namespace insur {
 						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
 						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
-	      PlotDrawer<XYRotateY180, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
+	      PlotDrawer<XYRotateY180, TypeFanoutBranchTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
@@ -7432,7 +7432,7 @@ namespace insur {
 						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
 						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
-	      PlotDrawer<XY, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
+	      PlotDrawer<XY, TypeFanoutBranchTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
@@ -7481,7 +7481,7 @@ namespace insur {
 							   anEndcap.myid().c_str(), surfaceIndex),
 						      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYNegSurfaceDisk->cd();
-	      PlotDrawer<XYNeg, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
+	      PlotDrawer<XYNeg, TypeFanoutBranchTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk.get());
@@ -7496,7 +7496,7 @@ namespace insur {
 							   anEndcap.myid().c_str(), surfaceIndex),
 						      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYNegSurfaceDisk->cd();
-	      PlotDrawer<XYNegRotateY180, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
+	      PlotDrawer<XYNegRotateY180, TypeFanoutBranchTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk.get());
@@ -8845,7 +8845,7 @@ namespace insur {
 	      const std::vector<Module*>& myModules = bundle->modules();
 	      for (const auto& module : myModules) {
 		// Get which fanout input index the module belongs to.
-		const int fanoutInputIndex = module->getEndcapBundleFanoutInput();
+		const int fanoutBranchIndex = module->getEndcapFanoutBranch();
 
 		// Module related info.
 		std::stringstream moduleInfo;
@@ -8856,25 +8856,25 @@ namespace insur {
 		  //<< module->center().Phi() * 180. / M_PI;
 			   << femod(module->center().Phi(), 2.*M_PI) * 180. / M_PI << ", "
 			   << module->center().Z() << ", "
-			   << fanoutInputIndex;
+			   << fanoutBranchIndex;
 		modulesInBundleInfo.push_back(moduleInfo.str());
 	
 	
 		// Count the number of modules per fanout input index.
-		pattern[fanoutInputIndex] += 1; 
+		pattern[fanoutBranchIndex] += 1; 
 	      }
 
 	      // Checks pattern makes sense, and put it in a-b-c-d format.
 	      std::stringstream patternInfo;
-	      for (int fanoutInputIndex = 1; fanoutInputIndex <= 4; fanoutInputIndex++) {
-		auto found = pattern.find(fanoutInputIndex);
+	      for (int fanoutBranchIndex = 1; fanoutBranchIndex <= 4; fanoutBranchIndex++) {
+		auto found = pattern.find(fanoutBranchIndex);
 		if (found != pattern.end()) {
-		  if (fanoutInputIndex != 1) patternInfo << "-";
+		  if (fanoutBranchIndex != 1) patternInfo << "-";
 		  const int numModulesPerDiskSurface = found->second;
 		  patternInfo << numModulesPerDiskSurface;
 		}
 		else logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
-			      + "does not connect to any module belonging to fanout branch " + any2str(fanoutInputIndex));
+			      + "does not connect to any module belonging to fanout branch " + any2str(fanoutBranchIndex));
 	      }
 	      patternInfo << ", ";
   
@@ -8937,9 +8937,9 @@ namespace insur {
 	      const std::vector<Module*>& myModules = bundle->modules();
 	      for (const auto& module : myModules) {
 		// Get which MFB fanout input the module belongs to.
-		const int fanoutInputIndex = module->getEndcapBundleFanoutInput();
+		const int fanoutBranchIndex = module->getEndcapFanoutBranch();
 		// Count the number of modules per MFB fanout input.
-		pattern[fanoutInputIndex] += 1; 
+		pattern[fanoutBranchIndex] += 1; 
 	      }
 
 	      // Checks pattern makes sense, and create the corresponding combination.
@@ -8947,15 +8947,15 @@ namespace insur {
 	      // One wants 1-2-3-4 and 3-4-1-2 to end up in the same combination: 1-2-3-4.
 	      // Duplicates are allowed: combination 1-2-3-3 can happen!
 	      std::multiset<int> combination;  
-	      for (int fanoutInputIndex = 1; fanoutInputIndex <= 4; fanoutInputIndex++) {
-		auto found = pattern.find(fanoutInputIndex);
+	      for (int fanoutBranchIndex = 1; fanoutBranchIndex <= 4; fanoutBranchIndex++) {
+		auto found = pattern.find(fanoutBranchIndex);
 		if (found != pattern.end()) {
 		  const int numModulesPerDiskSurface = found->second;
 		  // Create combination
 		  combination.insert(numModulesPerDiskSurface);
 		}
 		else logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
-			      + "does not connect to any module belonging to fanout branch " + any2str(fanoutInputIndex));
+			      + "does not connect to any module belonging to fanout branch " + any2str(fanoutBranchIndex));
 	      }
 	      // Count the occurences of each combination.
 	      combinationsDistribution[combination] += 1;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8853,8 +8853,7 @@ namespace insur {
 			   << module->uniRef().subdetectorName << ", "
 			   << module->uniRef().layer << ", "
 			   << module->moduleRing() << ", "
-		  //<< module->center().Phi() * 180. / M_PI;
-			   << femod(module->center().Phi(), 2.*M_PI) * 180. / M_PI << ", "
+			   << module->center().Phi() * 180. / M_PI << ", "
 			   << module->center().Z() << ", "
 			   << fanoutBranchIndex;
 		modulesInBundleInfo.push_back(moduleInfo.str());

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7393,7 +7393,7 @@ namespace insur {
 					    Form("(XY) Projection : Endcap %s, any Disk. (CMS +Z points towards you)", anEndcap.myid().c_str()),
 					    vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	XYCanvasDisk->cd();
-	PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
+	PlotDrawer<XY, TypeBundleTransparentColor> xyDiskDrawer;
 	xyDiskDrawer.addModules(lastDisk);
 	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYCanvasDisk.get());
 	xyDiskDrawer.drawModules<ContourStyle>(*XYCanvasDisk.get());
@@ -7417,7 +7417,7 @@ namespace insur {
 						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
 						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
-	      PlotDrawer<XYRotateY180, TypeBundleColor> xyDiskDrawer;
+	      PlotDrawer<XYRotateY180, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
@@ -7432,7 +7432,7 @@ namespace insur {
 						   Form("(XY) Section : Endcap %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
 						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
-	      PlotDrawer<XY, TypeBundleColor> xyDiskDrawer;
+	      PlotDrawer<XY, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
@@ -7455,7 +7455,7 @@ namespace insur {
 						    anEndcap.myid().c_str()),
 					       vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	XYNegCanvasDisk->cd();
-	PlotDrawer<XYNegRotateY180, TypeBundleColor> xyDiskDrawer;
+	PlotDrawer<XYNegRotateY180, TypeBundleTransparentColor> xyDiskDrawer;
 	xyDiskDrawer.addModules(firstDisk);
 	xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegCanvasDisk.get());
 	xyDiskDrawer.drawModules<ContourStyle>(*XYNegCanvasDisk.get());
@@ -7481,7 +7481,7 @@ namespace insur {
 							   anEndcap.myid().c_str(), surfaceIndex),
 						      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYNegSurfaceDisk->cd();
-	      PlotDrawer<XYNeg, TypeBundleColor> xyDiskDrawer;
+	      PlotDrawer<XYNeg, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk.get());
@@ -7496,7 +7496,7 @@ namespace insur {
 							   anEndcap.myid().c_str(), surfaceIndex),
 						      vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYNegSurfaceDisk->cd();
-	      PlotDrawer<XYNegRotateY180, TypeBundleColor> xyDiskDrawer;
+	      PlotDrawer<XYNegRotateY180, TypeBundleFanoutInputTransparentColor> xyDiskDrawer;
 	      xyDiskDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { return (m.subdet() == ENDCAP); } );
 	      xyDiskDrawer.drawFrame<SummaryFrameStyle>(*XYNegSurfaceDisk.get());
 	      xyDiskDrawer.drawModules<ContourStyle>(*XYNegSurfaceDisk.get());
@@ -8743,7 +8743,7 @@ namespace insur {
   std::string Vizard::createDTCsToModulesCsv(const OuterCablingMap* myCablingMap, const bool isPositiveCablingSide) {
 
     std::stringstream modulesToDTCsCsv;
-    modulesToDTCsCsv << "DTC name/C, DTC CMSSW Id/U, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, Cable #/I, Cable type/C, Bundle #/I, OPT Services Channel/I, PWR Services Channel/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
+    modulesToDTCsCsv << "DTC name/C, DTC CMSSW Id/U, DTC Phi Sector Ref/I, type /C, DTC Slot/I, DTC Phi Sector Width_deg/D, MFC #/I, MFC type/C, MFB #/I, OPT Services Channel/I, PWR Services Channel/I, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
 
     const std::map<const std::string, std::unique_ptr<const OuterDTC> >& myDTCs = (isPositiveCablingSide ? 
 										   myCablingMap->getDTCs() 
@@ -8817,7 +8817,7 @@ namespace insur {
     const std::string& summaryText = countBundlesToEndcapModulesCombinations(myCablingMap, isPositiveCablingSide);
     bundlesToEndcapModulesCsv << summaryText << std::endl;
 
-    bundlesToEndcapModulesCsv << "Bundle #/I, # Modules per Disk Surface (Sorted by increasing |Z|), Module DetId/U, Module Section/C, Module Disk/I, Module Ring/I, Module phi_deg/D" << std::endl;
+    bundlesToEndcapModulesCsv << "MFB #/I, # Modules per fanout branch index, Module DetId/U, Module Section/C, Module Disk/I, Module Ring/I, Module phi_deg/D, Module Z (mm)/D, Fanout branch index/U" << std::endl;
 
     const std::map<const std::string, std::unique_ptr<const OuterDTC> >& myDTCs = (isPositiveCablingSide ? 
 										   myCablingMap->getDTCs() 
@@ -8844,32 +8844,37 @@ namespace insur {
 	      std::vector<std::string> modulesInBundleInfo;
 	      const std::vector<Module*>& myModules = bundle->modules();
 	      for (const auto& module : myModules) {
+		// Get which fanout input index the module belongs to.
+		const int fanoutInputIndex = module->getEndcapBundleFanoutInput();
+
 		// Module related info.
 		std::stringstream moduleInfo;
 		moduleInfo << module->myDetId() << ", "
 			   << module->uniRef().subdetectorName << ", "
 			   << module->uniRef().layer << ", "
 			   << module->moduleRing() << ", "
-			   << module->center().Phi() * 180. / M_PI;
+		  //<< module->center().Phi() * 180. / M_PI;
+			   << femod(module->center().Phi(), 2.*M_PI) * 180. / M_PI << ", "
+			   << module->center().Z() << ", "
+			   << fanoutInputIndex;
 		modulesInBundleInfo.push_back(moduleInfo.str());
-
-		// Get which disk surface the module belongs to.
-		const int surfaceIndex = module->diskSurface();
-		// Count the number of modules per disk surface.
-		pattern[surfaceIndex] += 1; 
+	
+	
+		// Count the number of modules per fanout input index.
+		pattern[fanoutInputIndex] += 1; 
 	      }
 
 	      // Checks pattern makes sense, and put it in a-b-c-d format.
 	      std::stringstream patternInfo;
-	      for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
-		auto found = pattern.find(surfaceIndex);
+	      for (int fanoutInputIndex = 1; fanoutInputIndex <= 4; fanoutInputIndex++) {
+		auto found = pattern.find(fanoutInputIndex);
 		if (found != pattern.end()) {
-		  if (surfaceIndex != 1) patternInfo << "-";
+		  if (fanoutInputIndex != 1) patternInfo << "-";
 		  const int numModulesPerDiskSurface = found->second;
 		  patternInfo << numModulesPerDiskSurface;
 		}
 		else logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
-			      + "does not connect to any module belonging to disk surface" + any2str(surfaceIndex));
+			      + "does not connect to any module belonging to fanout branch " + any2str(fanoutInputIndex));
 	      }
 	      patternInfo << ", ";
   
@@ -8906,7 +8911,7 @@ namespace insur {
   */
   std::string Vizard::countBundlesToEndcapModulesCombinations(const OuterCablingMap* myCablingMap, const bool isPositiveCablingSide) {
     std::stringstream summaryText;
-    summaryText << "# Modules per disk surface (Irrespective of surface ordering)" << std::endl;
+    summaryText << "Fanouts: # Modules per branch (Irrespective of branches ordering)" << std::endl;
 
     std::map<std::multiset<int>, int> combinationsDistribution;
 
@@ -8931,10 +8936,10 @@ namespace insur {
 
 	      const std::vector<Module*>& myModules = bundle->modules();
 	      for (const auto& module : myModules) {
-		// Get which disk surface the module belongs to.
-		const int surfaceIndex = module->diskSurface();
-		// Count the number of modules per disk surface.
-		pattern[surfaceIndex] += 1; 
+		// Get which MFB fanout input the module belongs to.
+		const int fanoutInputIndex = module->getEndcapBundleFanoutInput();
+		// Count the number of modules per MFB fanout input.
+		pattern[fanoutInputIndex] += 1; 
 	      }
 
 	      // Checks pattern makes sense, and create the corresponding combination.
@@ -8942,15 +8947,15 @@ namespace insur {
 	      // One wants 1-2-3-4 and 3-4-1-2 to end up in the same combination: 1-2-3-4.
 	      // Duplicates are allowed: combination 1-2-3-3 can happen!
 	      std::multiset<int> combination;  
-	      for (int surfaceIndex = 1; surfaceIndex <= 4; surfaceIndex++) {
-		auto found = pattern.find(surfaceIndex);
+	      for (int fanoutInputIndex = 1; fanoutInputIndex <= 4; fanoutInputIndex++) {
+		auto found = pattern.find(fanoutInputIndex);
 		if (found != pattern.end()) {
 		  const int numModulesPerDiskSurface = found->second;
 		  // Create combination
 		  combination.insert(numModulesPerDiskSurface);
 		}
 		else logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
-			      + "does not connect to any module belonging to disk surface" + any2str(surfaceIndex));
+			      + "does not connect to any module belonging to fanout branch " + any2str(fanoutInputIndex));
 	      }
 	      // Count the occurences of each combination.
 	      combinationsDistribution[combination] += 1;
@@ -9068,7 +9073,7 @@ namespace insur {
   std::string Vizard::createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* myInnerCablingMap) {
 
     std::stringstream dtcsToModulesCsv;
-    dtcsToModulesCsv << "(+Z) End ?/Boolean, (+X) Side?/Boolean, DTC #/I, Bundle #/I, LP GBT #/C, # ELinks Per Module/I, Power Chain #/I, Power Chain Type/C, Long Barrel ?/Boolean, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
+    dtcsToModulesCsv << "(+Z) End ?/Boolean, (+X) Side?/Boolean, DTC #/I, MFB #/I, LP GBT #/C, # ELinks Per Module/I, Power Chain #/I, Power Chain Type/C, Long Barrel ?/Boolean, Module DetId/U, Module Section/C, Module Layer/I, Module Ring/I, Module phi_deg/D" << std::endl;
 
     const std::map<int, std::unique_ptr<InnerDTC> >& myDTCs = myInnerCablingMap->getDTCs();
     for (const auto& itDTC : myDTCs) {


### PR DESCRIPTION
OT cabling map, TEDD: 
Each MFB has 4 fanout branches, for the connections to modules.

The logics used to be simple: for each MFB, 1 fanout branch per disk surface.
Now, there is the need, for each MFB, in case the modules of a given disk (not double-disk!) belong to different dees, to make an assignment per dee instead.

This is fully automated, so that the Mechanics can pick up whatever is in AggregationsPatterns.csv

All results are at: http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT616_200_IT404/cablingOuter.html 
One can visualize the connections at the 'modules to bundles' section on the webpage. 
For example, if you look at the 'Positive cabling side', you can look at the 4 surfaces of DD 1, TEDD1.
The alternation of colors show the alternation of MFBs the modules end up connected to. The color scheme is not unique.
For a given MFB (one color), the alternation of transparent / non-transparent show the alternation of the fanout input slots that are used.
