### PR TITLE
Adds support for bigParity on tilted rods phi placement. 

### DIFF
--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -223,11 +223,12 @@ OT616_200_IT404.cfg	   Diff with OT615:
                            TEDD 2, inner rings: +2 mm (IT insertion) +0.51 mm (margin with dee edge).
                            TEDD 1 and 2, outer rings: -27 mm (BTL) +0.41 mm (margin with dee edge).
                            TEDD 2: -4 modules in Ring 7, -4 modules in Ring 14.
-                           Adjusted intermediate radii (needs feedback from Mechanics)
+                           Adjusted intermediate radii.
                          - TB2S:
                              L3: radius -27 mm (OT envelope shrink) +2 mm (smaller no-go zone between TB2S and BTL). numRods: -2 rods.
                          - TBPS:
                              L1: +2 mm in last 5 rings radii.
+                             All layers: flipped bigParity.
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                          
         
 ===========   POST-TDR INNER TRACKER STUDIES   ===========                           

--- a/src/Layer.cc
+++ b/src/Layer.cc
@@ -1034,7 +1034,7 @@ void Layer::buildTilted() {
   first->store(propertyTree());
   first->myid(1); 
   const bool isFirstRodAtOuterRadius = (bigParity() > 0 ? true : false);
-  const std::vector<TiltedModuleSpecs> myFirstRodSensorsCenters = (bigParity() > 0 ? tmspecso : tmspecsi);
+  const std::vector<TiltedModuleSpecs> myFirstRodSensorsCenters = (isFirstRodAtOuterRadius ? tmspecso : tmspecsi);
   first->isOuterRadiusRod(isFirstRodAtOuterRadius); 
   first->build(rodTemplate, myFirstRodSensorsCenters, !isFirstRodAtOuterRadius);
   rods_.push_back(first);
@@ -1043,7 +1043,7 @@ void Layer::buildTilted() {
   second->store(propertyTree());
   second->myid(2);
   const bool isSecondRodAtOuterRadius = (bigParity() > 0 ? false : true);
-  const std::vector<TiltedModuleSpecs> mySecondRodSensorsCenters = (bigParity() > 0 ? tmspecsi : tmspecso);
+  const std::vector<TiltedModuleSpecs> mySecondRodSensorsCenters = (isSecondRodAtOuterRadius ? tmspecso : tmspecsi);
   second->isOuterRadiusRod(isSecondRodAtOuterRadius);  
   second->build(rodTemplate, mySecondRodSensorsCenters, !isSecondRodAtOuterRadius);
   const double rodCenterPhiShift = 2 * M_PI / numRods();

--- a/src/OuterCabling/ModulesToBundlesConnector.cc
+++ b/src/OuterCabling/ModulesToBundlesConnector.cc
@@ -523,7 +523,7 @@ void ModulesToBundlesConnector::connectEndcapModulesToBundlesFanoutBranches(std:
 
 	  // STORE, PER DISK SURFACE, WHICH DEE MODULES ARE ON.
 	  if ( fabs(modPhiModuloPi) > outer_cabling_roundingTolerance 
-	       && fabs(modPhiModuloPi - M_PI) > outer_cabling_roundingTolerance
+	       && fabs(modPhiModuloPi - M_PI) > outer_cabling_roundingTolerance // module at (Y=0), if any, does not matter!
 	       ) {
 	    const int diskSurfaceIndex = module->diskSurface();
 	    const double modPhi = femod(module->center().Phi(), 2.*M_PI);      // modulo 2 PI

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8876,8 +8876,8 @@ namespace insur {
 		  const int numModulesPerDiskSurface = found->second;
 		  patternInfo << numModulesPerDiskSurface;
 		}
-		else logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
-			      + "has 0 module belonging to fanout branch " + any2str(fanoutBranchIndex));
+		else { logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
+				+ "has 0 module belonging to fanout branch " + any2str(fanoutBranchIndex)); }
 	      }
 	      patternInfo << ", ";
   
@@ -8957,8 +8957,8 @@ namespace insur {
 		  // Create combination
 		  combination.insert(numModulesPerDiskSurface);
 		}
-		else logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
-			      + "has 0 module belonging to fanout branch " + any2str(fanoutBranchIndex));
+		else { logERROR("In TEDD, bundle " + any2str(bundle->myid()) 
+				+ "has 0 module belonging to fanout branch " + any2str(fanoutBranchIndex)); }
 	      }
 	      // Count the occurences of each combination.
 	      combinationsDistribution[combination] += 1;


### PR DESCRIPTION
This allows to change design. It comes from a misinterpretation from the Mechanics, that would be hard to correct on their side. 
This change in tracker design should obviously have no impact on tracker performance.