### PR TITLE
Add OT616_IT613 combination + Fixes in XML export to support that geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 tkLayout requires:
 
-    ROOT version > 5.34.09 (root and root-config should be in user's path)
-    BOOST version > 1.50
-    gcc version > 4.7
+    ROOT version 5.34.09 (root and root-config should be in user's path)
+    BOOST version 1.50
+    gcc version 4.7
 
 If you are on lxplus, you can just run a bash shell and then:
 

--- a/geometries/CMS_Phase2/OT616_200_IT613.cfg
+++ b/geometries/CMS_Phase2/OT616_200_IT613.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V616_200.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_3.cfg

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -1361,6 +1361,7 @@ namespace insur {
       srspec.moduletypes.push_back(minfo_zero);
 
 
+
       // rods in layer algorithm(s)
       // OUTER TRACKER
       if (!isPixelTracker) {
@@ -1418,6 +1419,10 @@ namespace insur {
 	  pconverter.str("");
 	  pconverter << (phiForbiddenRanges.at(forbiddenPhiUpperAIndex) - phiForbiddenRanges.at(1)) * 180. / M_PI << "*deg";
 	  alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
+	  // WARNING: Set RadisuIn parameter to the radius of the firstPhiRod.
+	  // The algorithm will indeed start by placing (in phi) that firstPhiRod, at radius whatever is assigned to radisuIn.
+	  // RadiusIn is just a name, and does not imply that the radius is low !!!!
+	  // Look at PhiAltAlgo implementation.
 	  pconverter.str("");
 	  pconverter << firstPhiRodRadius << "*mm";
 	  alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -1359,8 +1359,6 @@ namespace insur {
       rspec.moduletypes.push_back(minfo_zero);
       srspec.partselectors.push_back(rodname.str());
       srspec.moduletypes.push_back(minfo_zero);
-        
-   
 
 
       // rods in layer algorithm(s)


### PR DESCRIPTION
- Adds OT616 on top of IT613.

- Alternation in phi of inner / outer radii rods in TBPS was flipped.
Fix issue in cone shape extrema calculation.
Cleaned ladder phi placement (would have assigned outer radii to RadisuIn parameter in PhiAltAlgo, which would have worked, but is very ugly).

- Adds warning for TBPX export.
Skewed TBPX ladders phi placement is incorrect by default. 
Skewed Barrel XML export should be done!!

NB: Extractor.cc code is very ugly (not mine ;p), would need to bin evth, and simply starts from a geometry visitor!