### PR TITLE
Overall barrels rotation: Avoid hardcoded values, replaced by booleans

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Flat/OT.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/OT.cfg
@@ -8,7 +8,7 @@ Tracker Outer {
     zOverlap 0
     phiOverlap 0.5
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     @include-std CMS_Phase2/OuterTracker/moduleOperatingParms

--- a/geometries/CMS_Phase2/OuterTracker/Flat/OT_16Rings.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/OT_16Rings.cfg
@@ -8,7 +8,7 @@ Tracker Outer {
     zOverlap 0
     phiOverlap 0.5
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     smallParity 1
     
     @include-std CMS_Phase2/OuterTracker/moduleOperatingParms

--- a/geometries/CMS_Phase2/OuterTracker/Flat/OT_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/OT_200.cfg
@@ -8,7 +8,7 @@ Tracker Outer {
     zOverlap 0
     phiOverlap 0.5
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     smallParity 1
     
     @include-std CMS_Phase2/OuterTracker/moduleOperatingParms

--- a/geometries/CMS_Phase2/OuterTracker/Flat/TB2S_V360_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/TB2S_V360_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Flat/TBPS_V0_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Flat/TBPS_V0_200.cfg
@@ -1,6 +1,6 @@
 Barrel TBPS {
       @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_flat.cfg
-      barrelRotation 1.57079632679   
+      rotateBarrelByHalfPi true   
       
       smallParity 1
       phiOverlap 0.5

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT.cfg
@@ -6,7 +6,7 @@ Tracker Outer {
     zError 70
     zOverlap 0
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     
     barrelDetIdScheme Phase2Subdetector5
     endcapDetIdScheme Phase2Subdetector4

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_200.cfg
@@ -6,7 +6,7 @@ Tracker Outer {
     zError 70
     zOverlap 0
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
     trackingTags trigger,tracker
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_autoPlacement.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_autoPlacement.cfg
@@ -6,7 +6,7 @@ Tracker Outer {
     zError 70
     zOverlap 0  // should be 1, no ?
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
     trackingTags trigger,tracker
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_auto_Old.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_auto_Old.cfg
@@ -6,7 +6,7 @@ Tracker Outer {
     zError 70
     zOverlap 0
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true
     @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
     trackingTags trigger,tracker
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V351_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V351_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity -1
   phiSegments 2
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V360_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V360_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V460_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V460_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V616_200.cfg
@@ -4,7 +4,7 @@ Barrel TB2S {
   
   bigParity 1
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V624_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V624_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V625_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V625_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V626_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V626_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V627_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V627_200.cfg
@@ -5,7 +5,7 @@ Barrel TB2S {
   bigParity 1
   phiSegments 6
   smallParity 1
-  barrelRotation 1.57079632680
+  rotateBarrelByHalfPi true
 
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/pt2S
   @includestd CMS_Phase2/OuterTracker/Materials/pt2S_200_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V360_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V360_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil on 2016-07-15
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V361_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V361_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil on 2016-07-16
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V362_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V362_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil 2016-07-16_2
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V363_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V363_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil 2016-07-16_2
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V364_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V364_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil 2016-07-16_2
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V365_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V365_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil 2016-07-16_2
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V366_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V366_200.cfg
@@ -1,5 +1,5 @@
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V462_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V462_200.cfg
@@ -2,7 +2,7 @@
 // By Kamil 2016-07-16_2
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V612_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V612_200.cfg
@@ -1,5 +1,5 @@
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V615_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V615_200.cfg
@@ -1,5 +1,5 @@
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V616_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V616_200.cfg
@@ -1,5 +1,5 @@
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V711_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V711_200.cfg
@@ -1,5 +1,5 @@
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V712_200.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V712_200.cfg
@@ -1,5 +1,5 @@
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/Timing_V401.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/Timing_V401.cfg
@@ -6,7 +6,6 @@ Barrel TimingBarrel {
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTB2S
   
   trackingTags tracker
-  barrelRotation 0.
   
   numRods 36
   bigParity 1

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_0_0.cfg
@@ -25,7 +25,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
@@ -33,7 +33,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 69 
     }
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 120
     }
@@ -53,6 +53,6 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_0_1.cfg
@@ -25,7 +25,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50
@@ -33,7 +33,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 69 
     }
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 120
     }
@@ -53,6 +53,6 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_2_0.cfg
@@ -25,7 +25,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
@@ -33,7 +33,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 69 
     }
@@ -44,7 +44,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 110
     }
@@ -55,6 +55,6 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_3_0.cfg
@@ -26,7 +26,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100
@@ -34,7 +34,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode auto 
       placeRadiusHint 69 
     }
@@ -45,7 +45,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode auto
       phiOverlap 2 
       placeRadiusHint 120
@@ -58,6 +58,6 @@
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
       phiOverlap 2
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_3_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_3_1.cfg
@@ -26,7 +26,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50
@@ -34,7 +34,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode auto 
       placeRadiusHint 69 
     }
@@ -45,7 +45,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode auto
       phiOverlap 2 
       placeRadiusHint 120
@@ -58,6 +58,6 @@
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX4
       phiOverlap 2
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_1.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_2.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
       @includestd CMS_Phase2/Pixel/Resolutions/50x200
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_2_3.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4_10000
       @includestd CMS_Phase2/Pixel/Resolutions/100x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_3_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_6_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_6_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_6_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_4_6_1.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_5_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_5_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_6_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_6_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_7_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/BPIX_4_7_0.cfg
@@ -23,7 +23,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 12
     }
     Layer 2 {
@@ -32,7 +32,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       numRods 24
@@ -43,7 +43,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       numRods 20
@@ -54,7 +54,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       numRods 28
     }
   }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_0.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_3.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_4.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_5.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_2_6.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_3.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_4.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_5.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_6.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_7.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_7.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_8.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_0_8.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_1_0.cfg
@@ -8,7 +8,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_1_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_1_2_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_1_2_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_1_2_5.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_1.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_2.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_2_3.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_3_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_4_1.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_1.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_5_2.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_6_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_6_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_6_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V4/Pixel_V4_6_1.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_0.cfg
@@ -30,7 +30,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       
       isTilted true
       isTiltedAuto true
@@ -93,7 +93,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       
@@ -165,7 +165,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       
@@ -236,7 +236,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       
       
       isTilted true

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_1.cfg
@@ -30,7 +30,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       
       isTilted true
       isTiltedAuto true
@@ -91,7 +91,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       
@@ -160,7 +160,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       
@@ -230,7 +230,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       
       
       isTilted true

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/BPIX_5_0_3.cfg
@@ -30,7 +30,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L1
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX1
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
       
       isTilted true
       isTiltedAuto true
@@ -91,7 +91,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L2
       @includestd CMS_Phase2/Pixel/Resolutions/50x50
       destination BPIX2
-      layerRotation 0.112
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 60
       
@@ -160,7 +160,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L3
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX3
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       radiusMode fixed
       placeRadiusHint 100
       
@@ -232,7 +232,7 @@
       @includestd CMS_Phase2/Pixel/Materials/rod_tilted_BPIX_L4
       @includestd CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX4
-      layerRotation 0.098
+      rotateLayerByRodsDeltaPhiHalf true
       
       
       isTilted true

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_0.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V5/Pixel_V5_0_3.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_0_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_0_1.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_0_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_0_2.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_0.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_1.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_2.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_3.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_3.cfg
@@ -9,7 +9,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true
   
   @include-std CMS_Phase2/Pixel/moduleOperatingParms
   

--- a/geometries/Outdated/3xPS_3x2S_5disks_SLHC7.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_SLHC7.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_SLHC7.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_SLHC7.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_baseline.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_baseline.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_baseline.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_baseline.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_baseline_pixelV0.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_baseline_pixelV0.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_baseline_pixelV0.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_baseline_pixelV0.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_baseline_retune.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_baseline_retune.cfg
@@ -9,7 +9,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/3xPS_3x2S_5disks_baseline_retune.cfg
+++ b/geometries/Outdated/3xPS_3x2S_5disks_baseline_retune.cfg
@@ -9,7 +9,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/8inch.cfg
+++ b/geometries/Outdated/8inch.cfg
@@ -9,7 +9,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/8inch.cfg
+++ b/geometries/Outdated/8inch.cfg
@@ -9,7 +9,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/Pixel/Pixel_V1_1_1/Pixel_V1_1_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_1_1/Pixel_V1_1_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   @include ../Supports/SupportsFPIX_V0_1.cfg

--- a/geometries/Outdated/Pixel/Pixel_V1_1_1/Pixel_V1_1_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_1_1/Pixel_V1_1_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   @include ../Supports/SupportsFPIX_V0_1.cfg

--- a/geometries/Outdated/Pixel/Pixel_V1_1_1/Pixel_V1_1_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_1_1/Pixel_V1_1_1.cfg
@@ -47,7 +47,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_50x50
@@ -57,7 +57,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -69,7 +69,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -81,7 +81,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_1_2/Pixel_V1_1_2.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_1_2/Pixel_V1_1_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_1_2/Pixel_V1_1_2.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_1_2/Pixel_V1_1_2.cfg
@@ -47,7 +47,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_50x50
@@ -57,7 +57,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -69,7 +69,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -81,7 +81,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_1_2/Pixel_V1_1_2.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_1_2/Pixel_V1_1_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_2_1/Pixel_V1_2_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_2_1/Pixel_V1_2_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_2_1/Pixel_V1_2_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_2_1/Pixel_V1_2_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_2_1/Pixel_V1_2_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_2_1/Pixel_V1_2_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_3_1/Pixel_V1_3_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_3_1/Pixel_V1_3_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_3_1/Pixel_V1_3_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_3_1/Pixel_V1_3_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_3_1/Pixel_V1_3_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_3_1/Pixel_V1_3_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include ../Stations/stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_4_1/Pixel_V1_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_4_1/Pixel_V1_4_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_4_1/Pixel_V1_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_4_1/Pixel_V1_4_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_4_1/Pixel_V1_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_4_1/Pixel_V1_4_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_5_1/Pixel_V1_5_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_5_1/Pixel_V1_5_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_5_1/Pixel_V1_5_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_5_1/Pixel_V1_5_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_5_1/Pixel_V1_5_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_5_1/Pixel_V1_5_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_5_2/Pixel_V1_5_2.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_5_2/Pixel_V1_5_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V1_5_2/Pixel_V1_5_2.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_5_2/Pixel_V1_5_2.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V1_5_2/Pixel_V1_5_2.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V1_5_2/Pixel_V1_5_2.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V2_4_1/Pixel_V2_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V2_4_1/Pixel_V2_4_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V2_4_1/Pixel_V2_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V2_4_1/Pixel_V2_4_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V2_4_1/Pixel_V2_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V2_4_1/Pixel_V2_4_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V3_4_1/Pixel_V3_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V3_4_1/Pixel_V3_4_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V3_4_1/Pixel_V3_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V3_4_1/Pixel_V3_4_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V3_4_1/Pixel_V3_4_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V3_4_1/Pixel_V3_4_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   @include stations_BPIX_Service_Cylinder_near // TODO: Test, then move it inside the barrel!
   

--- a/geometries/Outdated/Pixel/Pixel_V3_5_1/Pixel_V3_5_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V3_5_1/Pixel_V3_5_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  rotateBarrelByHalfPi true079632679
+  rotateBarrelByHalfPi true
  
   trackingTags pixel,tracker
   

--- a/geometries/Outdated/Pixel/Pixel_V3_5_1/Pixel_V3_5_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V3_5_1/Pixel_V3_5_1.cfg
@@ -46,7 +46,7 @@ Tracker Pixels {
       destination BPIX1
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.262
+      rotateLayerByRodsDeltaPhiHalf true
     }
     Layer 2 {
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x3_25x100
@@ -56,7 +56,7 @@ Tracker Pixels {
       destination BPIX2
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.131
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 62
     }
@@ -68,7 +68,7 @@ Tracker Pixels {
       destination BPIX3
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.079
+      rotateLayerByRodsDeltaPhiHalf true
       //radiusMode fixed
       placeRadiusHint 105
     }
@@ -80,7 +80,7 @@ Tracker Pixels {
       destination BPIX4
       plotColor 7
       Ring 2,4 { plotColor 8 }
-      layerRotation 0.056
+      rotateLayerByRodsDeltaPhiHalf true
     }
   }
 

--- a/geometries/Outdated/Pixel/Pixel_V3_5_1/Pixel_V3_5_1.cfg
+++ b/geometries/Outdated/Pixel/Pixel_V3_5_1/Pixel_V3_5_1.cfg
@@ -10,7 +10,7 @@ Tracker Pixels {
 
   servicesForcedUp false
 
-  barrelRotation 1.57079632679
+  rotateBarrelByHalfPi true079632679
  
   trackingTags pixel,tracker
   

--- a/geometries/Outdated/SingleLayerStraight.cfg
+++ b/geometries/Outdated/SingleLayerStraight.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight.cfg
+++ b/geometries/Outdated/SingleLayerStraight.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight_L1.cfg
+++ b/geometries/Outdated/SingleLayerStraight_L1.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight_L1.cfg
+++ b/geometries/Outdated/SingleLayerStraight_L1.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight_L2.cfg
+++ b/geometries/Outdated/SingleLayerStraight_L2.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight_L2.cfg
+++ b/geometries/Outdated/SingleLayerStraight_L2.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight_L3.cfg
+++ b/geometries/Outdated/SingleLayerStraight_L3.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/SingleLayerStraight_L3.cfg
+++ b/geometries/Outdated/SingleLayerStraight_L3.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/TBPS_V351_200.cfg
+++ b/geometries/Outdated/TBPS_V351_200.cfg
@@ -2,7 +2,7 @@
 // Legacy tilted barrel using .csv files
 
 Barrel TBPS {
-  rotateBarrelByHalfPi true07963268
+  rotateBarrelByHalfPi true
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/Outdated/TBPS_V351_200.cfg
+++ b/geometries/Outdated/TBPS_V351_200.cfg
@@ -2,7 +2,7 @@
 // Legacy tilted barrel using .csv files
 
 Barrel TBPS {
-  barrelRotation 1.5707963268
+  rotateBarrelByHalfPi true07963268
   @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTBPS_tilted.cfg
   @includestd CMS_Phase2/OuterTracker/ModuleTypes/ptPS
   @includestd CMS_Phase2/OuterTracker/Conversions/flangeTBPS

--- a/geometries/Outdated/TechnicalProposal2014.cfg
+++ b/geometries/Outdated/TechnicalProposal2014.cfg
@@ -11,7 +11,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/TechnicalProposal2014.cfg
+++ b/geometries/Outdated/TechnicalProposal2014.cfg
@@ -11,7 +11,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/TechnicalProposal2014_nopix.cfg
+++ b/geometries/Outdated/TechnicalProposal2014_nopix.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    rotateBarrelByHalfPi true079632679
+    rotateBarrelByHalfPi true
     smallParity 1
 
     trackingTags trigger,tracker

--- a/geometries/Outdated/TechnicalProposal2014_nopix.cfg
+++ b/geometries/Outdated/TechnicalProposal2014_nopix.cfg
@@ -10,7 +10,7 @@ Tracker Outer {
     zOverlap 1
     phiOverlap 1
     etaCut 10
-    barrelRotation 1.57079632679
+    rotateBarrelByHalfPi true079632679
     smallParity 1
 
     trackingTags trigger,tracker

--- a/include/Barrel.hh
+++ b/include/Barrel.hh
@@ -32,6 +32,7 @@ class Barrel : public PropertyObject, public Buildable, public Identifiable<stri
   Property<bool  , Default>   outerRadiusFixed;
   Property<bool  , Default>   sameRods;
   Property<double, Default>   barrelRotation;
+  Property<bool  , Default>   rotateBarrelByHalfPi;
   Property<double, Default>   supportMarginOuter;
   Property<double, Default>   supportMarginInner;
 
@@ -46,6 +47,7 @@ public:
     outerRadiusFixed(  "outerRadiusFixed"  , parsedAndChecked(), true),
     sameRods(          "sameRods"          , parsedAndChecked(), false),
     barrelRotation(    "barrelRotation"    , parsedOnly(), 0.),
+    rotateBarrelByHalfPi("rotateBarrelByHalfPi", parsedOnly(), false),
     supportMarginOuter("supportMarginOuter", parsedOnly(), 2.),
     supportMarginInner("supportMarginInner", parsedOnly(), 2.),
     layerNode(         "Layer"             , parsedOnly()),

--- a/include/Layer.hh
+++ b/include/Layer.hh
@@ -93,6 +93,7 @@ public:
 
   Property<int, NoDefault> numRods;
   FixedSizeMultiProperty<std::vector<double>, 4,','> phiForbiddenRanges;
+  Property<bool, Default> rotateLayerByRodsDeltaPhiHalf;
 
   Property<int, NoDefault> buildNumModulesFlat;
   Property<int, NoDefault> buildNumModulesTilted;
@@ -126,7 +127,8 @@ public:
 	    sameParityRods ("sameParityRods" , parsedAndChecked(), true),
 	    layerRotation  ("layerRotation",   parsedOnly(), 0.),
 	    numRods        ("numRods"        , parsedOnly()),
-	    phiForbiddenRanges("phiForbiddenRanges", parsedOnly()),	    
+	    phiForbiddenRanges("phiForbiddenRanges", parsedOnly()),
+	    rotateLayerByRodsDeltaPhiHalf("rotateLayerByRodsDeltaPhiHalf", parsedOnly(), false),
 	    buildNumModulesFlat("numModulesFlat"     , parsedOnly()),
 	    buildNumModulesTilted("numModulesTilted"     , parsedOnly()),
 	    isTilted       ("isTilted"       , parsedOnly(), false),

--- a/src/Barrel.cc
+++ b/src/Barrel.cc
@@ -19,22 +19,31 @@ void Barrel::build() {
       Layer* layer = GeometryFactory::make<Layer>(myid());
       layer->myid(i);
 
+      // Compute layer's radii
       if      (i == 1)           { if (innerRadiusFixed()) layer->radiusMode(Layer::FIXED); layer->placeRadiusHint(innerRadius()); } 
       else if (i == numLayers()) { if (outerRadiusFixed()) layer->radiusMode(Layer::FIXED); layer->placeRadiusHint(outerRadius()); } 
       else                       { layer->placeRadiusHint(innerRadius() + (outerRadius()-innerRadius())/(numLayers()-1)*(i-1)); }
-
       if (sameRods()) { 
         layer->minBuildRadius(innerRadius()); 
         layer->maxBuildRadius(outerRadius()); 
         layer->sameParityRods(true);
       }
 
+      // Store all layer properties
       layer->store(propertyTree());
       if (layerNode.count(i) > 0) layer->store(layerNode.at(i)); // TO DO: WARNING!! layer->placeRadiusHint is reassigned here!!
+
+      // Build the layer
       layer->build();
+
+      // Additional barrel rotation
       layer->rotateZ(barrelRotation());
       if (rotateBarrelByHalfPi()) { layer->rotateZ(M_PI / 2.); }
+
+      // Additional layer rotation
       layer->rotateZ(layer->layerRotation());
+
+      // Store the layer
       layers_.push_back(layer);
     }
 

--- a/src/Barrel.cc
+++ b/src/Barrel.cc
@@ -33,6 +33,7 @@ void Barrel::build() {
       if (layerNode.count(i) > 0) layer->store(layerNode.at(i)); // TO DO: WARNING!! layer->placeRadiusHint is reassigned here!!
       layer->build();
       layer->rotateZ(barrelRotation());
+      if (rotateBarrelByHalfPi()) { layer->rotateZ(M_PI / 2.); }
       layer->rotateZ(layer->layerRotation());
       layers_.push_back(layer);
     }

--- a/src/Layer.cc
+++ b/src/Layer.cc
@@ -194,7 +194,7 @@ void Layer::check() {
     if (radiusMode() != RadiusMode::FIXED) throw PathfulException("Skewed layer mode: the (average) radii of layers must be specified.");
     if (isTilted()) throw PathfulException("A layer was set to both skewed and tilted: this is not presently supported.");
     if (phiForbiddenRanges.state()) throw PathfulException("Skewed layer mode: phiForbiddenRange is not supported.");
-    if (rotateLayerByRodsDeltaPhiHalf.state()) throw PathfulException("Skewed layer mode: rotateLayerByRodsDeltaPhiHalf is not supported.");
+    if (rotateLayerByRodsDeltaPhiHalf()) throw PathfulException("Skewed layer mode: rotateLayerByRodsDeltaPhiHalf is not supported.");
     if (phiOverlap.state()) throw PathfulException("Skewed layer mode: phiOverlap should not be specified.");
     if (phiSegments.state()) throw PathfulException("Skewed layer mode: phiSegments should not be specified.");
   }


### PR DESCRIPTION
**- Overall Barrel rotation:** 
If one wants to rotate the barrel by Pi/2 (classic case):
Instead of:
_barrelRotation 1.57079632679_
use:
_rotateBarrelByHalfPi true_
This is obviously cleaner and much less error-prone.

**- Overall Layer rotation:** 
There were hardcoded values, which were redundant with _numRods_ info, and error-prone.
Instead of:
_layerRotation 0.262_
use:
_rotateLayerByRodsDeltaPhiHalf true_

NB: _barrelRotation_ and _layerRotation_ parameters are still supported, and hardcoded values can be put in cfg files if ever desired.
But please only use these only if really needed!
