### PR TITLE
Fixed regressions of new environment on slc6

### DIFF
--- a/ROOT-env.sh
+++ b/ROOT-env.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
-#source /cvmfs/sft.cern.ch/lcg/views/LCG_95/$ARCH-opt/setup.sh 
-#source $RELEASE_LCG/ROOT/6.16.00/$ARCH-opt/ROOT-env.sh 
-#export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+# Following line set up full LCG view: nice but hide what is strictly necessary.
+# source /cvmfs/sft.cern.ch/lcg/views/LCG_95/$ARCH-opt/setup.sh 
 
+# Following 2 lines (1 is enough) would be nicer to set up ROOT env.
+# source $RELEASE_LCG/ROOT/6.16.00/$ARCH-opt/ROOT-env.sh 
+# export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+
+# Unfortunately, all solutions above break a lot of things on slc6 (fonts, emacs...), as described in 
+# https://root-forum.cern.ch/t/root-production-release-v6-14-00-is-out/29360/23 .
+
+# Only source strictly necessary ROOT dependencies, if ever you find a better solution for slc6, please PR it!
 source $RELEASE_LCG/vdt/0.4.2/$ARCH-opt/vdt-env.sh
 source $RELEASE_LCG/Davix/0.7.1/$ARCH-opt/Davix-env.sh
 source $RELEASE_LCG/png/1.6.17/$ARCH-opt/png-env.sh

--- a/ROOT-env.sh
+++ b/ROOT-env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#source /cvmfs/sft.cern.ch/lcg/views/LCG_95/$ARCH-opt/setup.sh 
+#source $RELEASE_LCG/ROOT/6.16.00/$ARCH-opt/ROOT-env.sh 
+#export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+
+source $RELEASE_LCG/vdt/0.4.2/$ARCH-opt/vdt-env.sh
+source $RELEASE_LCG/Davix/0.7.1/$ARCH-opt/Davix-env.sh
+source $RELEASE_LCG/png/1.6.17/$ARCH-opt/png-env.sh
+source $RELEASE_LCG/tbb/2019_U1/$ARCH-opt/tbb-env.sh
+source $RELEASE_LCG/sqlite/3210000/$ARCH-opt/sqlite-env.sh

--- a/setupCMake_slc6.sh
+++ b/setupCMake_slc6.sh
@@ -1,13 +1,14 @@
 ARCH=x86_64-slc6-gcc8
+CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
 RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
 VIEW_LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_95
 
-# CMAKE
-export PATH=/cvmfs/sft.cern.ch/lcg/contrib/CMake/3.13.4/Linux-x86_64/bin/:$PATH
 
+# CMAKE
+export PATH=$CONTRIB/CMake/3.13.4/Linux-x86_64/bin/:$PATH
 
 # COMPILER
-source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8.2.0/$ARCH-opt/setup.sh
+source $CONTRIB/gcc/8.2.0/$ARCH-opt/setup.sh
 export CC=`which gcc`
 export CXX=`which g++`
 

--- a/setupCMake_slc6.sh
+++ b/setupCMake_slc6.sh
@@ -1,7 +1,9 @@
+#!/bin/bash
+
 ARCH=x86_64-slc6-gcc8
 CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
 RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
-VIEW_LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_95
+TK_DIRECTORY=$(dirname $BASH_SOURCE)
 
 
 # CMAKE
@@ -14,7 +16,7 @@ export CXX=`which g++`
 
 # ROOT
 source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
-export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+source $TK_DIRECTORY/ROOT-env.sh
 
 # BOOST
 export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include
@@ -22,3 +24,4 @@ export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/
 # DOXYGEN
 export DOXYGEN_PATH=$RELEASE_LCG/doxygen/1.8.11/$ARCH-opt/bin/
 export PATH=${DOXYGEN_PATH}:${PATH}
+

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -1,7 +1,6 @@
-ARCH=x86_64-slc6-gcc8
-CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
-RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
-VIEW_LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_95
+export ARCH=x86_64-slc6-gcc8
+export CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
+export RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
 
 
 # COMPILER
@@ -9,7 +8,7 @@ source $CONTRIB/gcc/8.2.0/$ARCH-opt/setup.sh
 
 # ROOT
 source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
-#export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+source ROOT-env.sh
 
 # BOOST
 export BOOST_INCLUDE=$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include
@@ -24,38 +23,3 @@ export PATH=${DOXYGEN_PATH}:${PATH}
 # UPDATE PATH
 export PATH=`pwd`/bin:$PATH
 
-
-
- #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libvdt.so . 
- #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib64/libdavix.so.0 . 
- #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libpng16.so.16 .
- #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libASImage.so .
-
-
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/vdt/0.4.2/x86_64-slc6-gcc8-opt/vdt-env.sh
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/Davix/0.7.1/x86_64-slc6-gcc8-opt/Davix-env.sh
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/png/1.6.17/x86_64-slc6-gcc8-opt/png-env.sh
-
-
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/tbb/2019_U1/x86_64-slc6-gcc8-opt/tbb-env.sh
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/sqlite/3210000/x86_64-slc6-gcc8-opt/sqlite-env.sh
-
-
-
-
-
-
-
-
-
-
-
-
-
-#source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/ROOT/6.16.00/x86_64-slc6-gcc8-opt/ROOT-env.sh 
-
-
-# FONT
-#export FONTCONFIG_PATH=$VIEW_LCG/$ARCH-opt/etc/fonts/:$FONTCONFIG_PATH
-#export FONTCONFIG_FILE
-#source /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/setup.sh 

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -1,6 +1,9 @@
-export ARCH=x86_64-slc6-gcc8
-export CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
-export RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
+#!/bin/bash
+
+ARCH=x86_64-slc6-gcc8
+CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
+RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
+TK_DIRECTORY=$(dirname $BASH_SOURCE)
 
 
 # COMPILER
@@ -8,7 +11,7 @@ source $CONTRIB/gcc/8.2.0/$ARCH-opt/setup.sh
 
 # ROOT
 source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
-source ROOT-env.sh
+source $TK_DIRECTORY/ROOT-env.sh
 
 # BOOST
 export BOOST_INCLUDE=$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -1,10 +1,11 @@
 ARCH=x86_64-slc6-gcc8
+CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
 RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
 VIEW_LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_95
 
 
 # COMPILER
-source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8.2.0/$ARCH-opt/setup.sh
+source $CONTRIB/gcc/8.2.0/$ARCH-opt/setup.sh
 
 # ROOT
 source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -9,7 +9,7 @@ source $CONTRIB/gcc/8.2.0/$ARCH-opt/setup.sh
 
 # ROOT
 source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
-export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+#export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
 
 # BOOST
 export BOOST_INCLUDE=$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include
@@ -26,8 +26,21 @@ export PATH=`pwd`/bin:$PATH
 
 
 
+ cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libvdt.so . 
+ cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib64/libdavix.so.0 . 
+ cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libpng16.so.16 .
+ cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libASImage.so .
+ 
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/tbb/2019_U1/x86_64-slc6-gcc8-opt/tbb-env.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/sqlite/3210000/x86_64-slc6-gcc8-opt/sqlite-env.sh
+
+#source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/ROOT/6.16.00/x86_64-slc6-gcc8-opt/ROOT-env.sh 
+
+
+
+
 
 # FONT
-export FONTCONFIG_PATH=$VIEW_LCG/$ARCH-opt/etc/fonts/:$FONTCONFIG_PATH
+#export FONTCONFIG_PATH=$VIEW_LCG/$ARCH-opt/etc/fonts/:$FONTCONFIG_PATH
 #export FONTCONFIG_FILE
 #source /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/setup.sh 

--- a/setup_slc6.sh
+++ b/setup_slc6.sh
@@ -26,18 +26,33 @@ export PATH=`pwd`/bin:$PATH
 
 
 
- cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libvdt.so . 
- cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib64/libdavix.so.0 . 
- cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libpng16.so.16 .
- cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libASImage.so .
- 
+ #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libvdt.so . 
+ #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib64/libdavix.so.0 . 
+ #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libpng16.so.16 .
+ #cp /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/lib/libASImage.so .
+
+
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/vdt/0.4.2/x86_64-slc6-gcc8-opt/vdt-env.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/Davix/0.7.1/x86_64-slc6-gcc8-opt/Davix-env.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/png/1.6.17/x86_64-slc6-gcc8-opt/png-env.sh
+
+
 source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/tbb/2019_U1/x86_64-slc6-gcc8-opt/tbb-env.sh
 source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/sqlite/3210000/x86_64-slc6-gcc8-opt/sqlite-env.sh
 
+
+
+
+
+
+
+
+
+
+
+
+
 #source /cvmfs/sft.cern.ch/lcg/releases/LCG_95/ROOT/6.16.00/x86_64-slc6-gcc8-opt/ROOT-env.sh 
-
-
-
 
 
 # FONT


### PR DESCRIPTION
As described in https://root-forum.cern.ch/t/root-production-release-v6-14-00-is-out/29360/23 
The use of LCG views break fonts, emacs,etc on slc6.
This allows to use the latest environment, without anything broken on slc6 :)

TO DO: Also need to provide support for CC7, as lxplus is switching to it.