### PR TITLE
Add 'zebra' layout IT 620: alternation of 25x100 and 50x50 modules 

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide
@@ -1,4 +1,4 @@
-// 1x2 chips pixel module (25um x 100um)
+// 1x2 chips pixel module (50um x 50um)
 // Chip size 16.8 x 21.6
 moduleType pixel_1x2_50x50_wide  // pixel modules should always have a type starting with keyword 'pixel_'
 
@@ -29,4 +29,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 4  // green
+plotColor 6  // clear blue

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide
@@ -1,0 +1,32 @@
+// 1x2 chips pixel module (25um x 100um)
+// Chip size 16.8 x 21.6
+moduleType pixel_1x2_50x50_wide  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.25mm)
+width 16.8
+length 43.45
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+deadAreaExtraLength 0.5
+deadAreaExtraWidth 0.5
+chipNegativeXExtraWidth 0.0   
+chipPositiveXExtraWidth 1.0
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.050
+  stripLengthEstimate 0.050
+  numROCX 1 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 4  // green

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
@@ -1,4 +1,4 @@
-// 2x2 chips pixel module (25um x 100um)
+// 2x2 chips pixel module (50um x 50um)
 // Chip size 16.8 x 21.6
 moduleType pixel_2x2_50x50_wide  // pixel modules should always have a type starting with keyword 'pixel_'
 
@@ -29,4 +29,4 @@ Sensor 1 {
   powerPerChannel 0.0 // mW
 }
 
-plotColor 10  // orange
+plotColor 3  // yellow

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
@@ -1,0 +1,32 @@
+// 2x2 chips pixel module (25um x 100um)
+// Chip size 16.8 x 21.6
+moduleType pixel_2x2_50x50_wide  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.25mm)
+width 33.85
+length 43.45
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+deadAreaExtraLength 0.5
+deadAreaExtraWidth 0.5
+chipNegativeXExtraWidth 1.0
+chipPositiveXExtraWidth 1.0
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.050
+  stripLengthEstimate 0.050
+  numROCX 2 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 10  // orange

--- a/geometries/CMS_Phase2/OT616_200_IT620.cfg
+++ b/geometries/CMS_Phase2/OT616_200_IT620.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V616_200.cfg
+@include Pixel/Pixel_V6/Pixel_V6_2_0.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_2_0.cfg
@@ -1,0 +1,66 @@
+  Barrel PXB {
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_461
+    
+    zOverlap -1.3 // 1.3mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity -1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      numRods 12
+    }
+    Layer 2 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/50x50
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+    }
+    Layer 3 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+    }
+    Layer 4 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/50x50
+      destination BPIX4
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_2_0.cfg
@@ -23,7 +23,7 @@
     smallParity -1
     zRotation 1.570796327
     
-    Disk 1 {
+    Disk 1,3,5,7 {
       Ring 1-2 { 
         @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
       }
@@ -32,7 +32,7 @@
       }
       @include-std CMS_Phase2/Pixel/Resolutions/25x100 
     }
-    Disk 2 { 
+    Disk 2,4,6,8 { 
       Ring 1-2 { 
         @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
       }
@@ -40,60 +40,6 @@
         @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
       }
       @include-std CMS_Phase2/Pixel/Resolutions/50x50  
-    }
-    Disk 3 {
-      Ring 1-2 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
-      }
-      Ring 3-4 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
-      }
-      @include-std CMS_Phase2/Pixel/Resolutions/25x100
-    }
-    Disk 4 { 
-      Ring 1-2 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
-      }
-      Ring 3-4 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
-      }
-      @include-std CMS_Phase2/Pixel/Resolutions/50x50
-    }
-    Disk 5 {
-      Ring 1-2 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
-      }
-      Ring 3-4 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
-      }
-      @include-std CMS_Phase2/Pixel/Resolutions/25x100
-    }
-    Disk 6 { 
-      Ring 1-2 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
-      }
-      Ring 3-4 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
-      }
-      @include-std CMS_Phase2/Pixel/Resolutions/50x50
-    }
-    Disk 7 { 
-      Ring 1-2 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
-      }
-      Ring 3-4 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
-      }
-      @include-std CMS_Phase2/Pixel/Resolutions/25x100
-    }
-    Disk 8 { 
-      Ring 1-2 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
-      }
-      Ring 3-4 { 
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
-      }
-      @include-std CMS_Phase2/Pixel/Resolutions/50x50
     }
     
     Disk 1 { placeZ 250.00 }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_2_0.cfg
@@ -1,0 +1,140 @@
+  Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_461
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    
+    Disk 1 {
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100 
+    }
+    Disk 2 { 
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/50x50  
+    }
+    Disk 3 {
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+    }
+    Disk 4 { 
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/50x50
+    }
+    Disk 5 {
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+    }
+    Disk 6 { 
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/50x50
+    }
+    Disk 7 { 
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+    }
+    Disk 8 { 
+      Ring 1-2 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_50x50_wide 
+      }
+      Ring 3-4 { 
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide 
+      }
+      @include-std CMS_Phase2/Pixel/Resolutions/50x50
+    }
+    
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 855.78 }
+    Disk 7 { placeZ 1094.57 }
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+    
+    
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+  }
+  

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_2_0.cfg
@@ -1,0 +1,107 @@
+  Endcap FPIX_2 {
+    phiSegments 4
+    etaCut 10
+    zError 70
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TEPX_613
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TEPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 4 
+    bigDelta 2 
+    outerRadius 253.95
+    numRings 5
+    minZ 1616
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    
+    Disk 1 {
+      Ring 1-5 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
+        @include-std CMS_Phase2/Pixel/Resolutions/50x50
+      }
+    }
+    Disk 2 {
+      Ring 1-5 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+        @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      }
+    }
+    Disk 3 {
+      Ring 1-5 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
+        @include-std CMS_Phase2/Pixel/Resolutions/50x50   
+      }
+    }
+    Disk 4 {
+      Ring 1-5 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+        @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      }
+    }
+    
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 2009.59 }
+    Disk 3 { placeZ 2307.69 }
+    Disk 4 { placeZ 2650.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+    
+      
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+      numModules 20
+      ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
+    }   
+    Disk 1-3 {
+      Ring 1 {
+        trackingTags pixel,tracker    
+      }
+    }    
+    Disk 4 {
+      Ring 1 {
+        //trackingTags pixel,tracker
+        plotColor 5                  // brown. Different color, since no dedicated tracking tag
+      } 
+    }
+        
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
+      trackingTags pixel,tracker
+      numModules 28
+      ringOuterRadius 144.0          // to be tuned
+    }
+    
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
+      trackingTags pixel,tracker
+      numModules 36
+      ringOuterRadius 181.3          // to be tuned
+    }
+    
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
+      trackingTags pixel,tracker
+      numModules 44
+      ringOuterRadius 217.9           // to be tuned
+    }
+    
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
+      trackingTags pixel,tracker
+      numModules 48
+      ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
+    }
+    
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX2_6_2_0.cfg
@@ -22,25 +22,13 @@
     smallParity -1
     zRotation 1.570796327
     
-    Disk 1 {
+    Disk 1,3 {
       Ring 1-5 {
         @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
         @include-std CMS_Phase2/Pixel/Resolutions/50x50
       }
     }
-    Disk 2 {
-      Ring 1-5 {
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
-        @include-std CMS_Phase2/Pixel/Resolutions/25x100
-      }
-    }
-    Disk 3 {
-      Ring 1-5 {
-        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_50x50_wide
-        @include-std CMS_Phase2/Pixel/Resolutions/50x50   
-      }
-    }
-    Disk 4 {
+    Disk 2,4 {
       Ring 1-5 {
         @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
         @include-std CMS_Phase2/Pixel/Resolutions/25x100

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_2_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_2_0.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_2_0.cfg
+  @include FPIX1_6_2_0.cfg
+  @include FPIX2_6_2_0.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -462,9 +462,16 @@ OT614_200_IT613.cfg                  OT Version 6.1.4
                                      * Disk 1: same Z.
                                      * Disk 2: 1985.43 mm -> 2009.59 mm   
                                      * Disk 3: 2250.83 mm -> 2307.69 mm       
-                                     * Disk 4: 2550.00 mm -> 2650.00 mm (set same Z as last TEDD disk's meanZ for now).                                                                                                                                                               
-                                     
->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                        
+                                     * Disk 4: 2550.00 mm -> 2650.00 mm (set same Z as last TEDD disk's meanZ for now).                                                                                                                                                                            
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>    
+
+
+============   ZEBRA STUDIES   ============                 
+OT616_200_IT620.cfg                  OT Version 6.1.6
+                                     Based from Inner Tracker version 6.1.3.
+                                     Alternation of layers with 25x100 and 50x50 pixel aspect ratios.
+                                     Layouts fully with 25x100 or 50x50 were studied, but not one that would include a mix of the 2!
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                  
                                                                                            
 
 ============   TIMING BARREL LAYER STUDIES   =============

--- a/include/VizardTools.hh
+++ b/include/VizardTools.hh
@@ -45,7 +45,6 @@ static const int occupancyPrecision = 1;
 static const int rphiResolutionPrecision = 0;
 static const int rphiResolutionRmsePrecision = 1;
 static const int pitchPrecision = 0;
-static const int stripLengthPrecision = 1;
 static const int millionChannelPrecision = 2;
 static const int totalPowerPrecision = 2;
 static const int modulePowerPrecision = 0;

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -2228,8 +2228,8 @@ namespace insur {
     std::ostringstream anRphiResolutionTrigger;
     std::ostringstream aYResolutionTrigger;
     std::ostringstream aPitchPair;
-    std::ostringstream aStripLength;
-    std::ostringstream aSegment;
+    std::ostringstream stripLengthStream;
+    std::ostringstream numSegmentsStream;
     std::ostringstream anNstrips;
     std::ostringstream aNumberMod;
     std::ostringstream aNumberSens;
@@ -2257,8 +2257,8 @@ namespace insur {
     static const int channelRow = 8;
     static const int nstripsRow = 9;
     static const int segmentsRow = 10;
-    static const int striplengthRow = 11;
-    static const int pitchpairsRow = 12;
+    static const int pitchpairsRow = 11;
+    static const int striplengthRow = 12;
     static const int rphiResolutionRow = 13;
     static const int rphiResolutionRmseRow = 14;
     static const int yResolutionRow = 15;
@@ -2291,7 +2291,7 @@ namespace insur {
     moduleTable->setContent(rphiResolutionTriggerRow, 0, "R/Phi resolution [pt] ("+muLetter+"m)");
     moduleTable->setContent(yResolutionTriggerRow, 0, "Y resolution [pt] ("+muLetter+"m)");
     moduleTable->setContent(pitchpairsRow, 0, "Pitch (min/max) ("+muLetter+"m)");
-    moduleTable->setContent(striplengthRow, 0, "Strip length (mm)");
+    moduleTable->setContent(striplengthRow, 0, "Strip length ("+muLetter+"m)");
     moduleTable->setContent(segmentsRow, 0, "Segments x Chips");
     moduleTable->setContent(nstripsRow, 0, "Chan/Sensor");
     moduleTable->setContent(numbermodsRow, 0, "N. mod");
@@ -2432,7 +2432,7 @@ namespace insur {
       if ( v.tagMapAveYResolutionTrigger[(*tagMapIt).first] != v.tagMapAveYResolution[(*tagMapIt).first] )
         aYResolutionTrigger << std::dec << std::fixed << std::setprecision(rphiResolutionPrecision) << v.tagMapAveYResolutionTrigger [(*tagMapIt).first] / v.tagMapCount[(*tagMapIt).first] / Units::um; // mm -> um
 
-      // Pitches
+      // Pitch
       aPitchPair.str("");
       loPitch=int((*tagMapIt).second->outerSensor().minPitch() / Units::um); // mm -> um
       hiPitch=int((*tagMapIt).second->outerSensor().maxPitch() / Units::um); // mm -> um
@@ -2444,31 +2444,32 @@ namespace insur {
           << "/" << std::fixed << std::setprecision(pitchPrecision) << hiPitch;
       }
 
-      // Strip Lengths and segmentation
-      aStripLength.str("");
-      aSegment.str("");
-      // One number only if all the same
-      if ((*tagMapIt).second->minSegments() == (*tagMapIt).second->maxSegments()) {
-        // Strip length
-        aStripLength << std::fixed << std::setprecision(stripLengthPrecision)
-          << (*tagMapIt).second->length()/(*tagMapIt).second->minSegments();  // CUIDADO!!!! what happens with single sided modules????
-        // Segments
-        aSegment << std::dec << (*tagMapIt).second->minSegments()
-          << "x" << (*tagMapIt).second->outerSensor().numROCX();
-      } else { // They are different
-        for (int iFace=0; iFace<(*tagMapIt).second->numSensors(); ++iFace) {
-          // Strip length
-          aStripLength << std::fixed << std::setprecision(stripLengthPrecision)
-            << (*tagMapIt).second->length()/(*tagMapIt).second->sensors().at(iFace).numSegmentsEstimate();
-          // Segments
-          aSegment << std::dec << (*tagMapIt).second->sensors().at(iFace).numSegmentsEstimate()
-            << "x" << (*tagMapIt).second->sensors().at(iFace).numROCX();
-          if (iFace<(*tagMapIt).second->numSensors() - 1) {
-            aStripLength << ", ";
-            aSegment << ", ";
-          }
-        }
+
+      // Strip Length   
+      stripLengthStream.str("");
+      int stripLengthKeep = 0;
+      for (const auto& sensorIt : aModule->sensors()) {
+	const int stripLength = (int)(sensorIt.stripLength() / Units::um); // mm -> um
+	if (stripLength != stripLengthKeep) {
+	  if (stripLengthKeep != 0) { stripLengthStream << ", "; }
+	  stripLengthStream << stripLength;
+	}
+	stripLengthKeep	= stripLength;
       }
+
+
+      // numSegments x num ROC(s) in X
+      numSegmentsStream.str("");
+      int numSegmentsKeep = 0;
+      for (const auto& sensorIt : aModule->sensors()) {
+	const int numSegments = sensorIt.numSegmentsEstimate();
+	if (numSegments != numSegmentsKeep) {
+	  if (numSegmentsKeep != 0) { numSegmentsStream << ", "; }
+	  numSegmentsStream << numSegments << "x" << sensorIt.numROCX();
+	}
+	numSegmentsKeep = numSegments;
+      }
+
 
       // Nstrips
       anNstrips.str("");
@@ -2543,8 +2544,8 @@ namespace insur {
       moduleTable->setContent(rphiResolutionTriggerRow, iType, anRphiResolutionTrigger.str());
       moduleTable->setContent(yResolutionTriggerRow, iType, aYResolutionTrigger.str());
       moduleTable->setContent(pitchpairsRow, iType, aPitchPair.str());
-      moduleTable->setContent(striplengthRow, iType, aStripLength.str());
-      moduleTable->setContent(segmentsRow, iType, aSegment.str());
+      moduleTable->setContent(striplengthRow, iType, stripLengthStream.str());
+      moduleTable->setContent(segmentsRow, iType, numSegmentsStream.str());
       moduleTable->setContent(nstripsRow, iType, anNstrips.str());
       moduleTable->setContent(numbermodsRow, iType, aNumberMod.str());
       moduleTable->setContent(numbersensRow, iType, aNumberSens.str());


### PR DESCRIPTION
- Add 'zebra' layout with layers alternatively with 25x100 and 50x50 modules.
Innermost TBPX layer and last TEPX disk are with 25x100 modules.

### Geometry

**Reference:** ![](http://ghugo.web.cern.ch/ghugo/layouts/test/OT616_200_IT613/img042.png)
**Zebre:** ![](http://ghugo.web.cern.ch/ghugo/layouts/test/OT616_200_IT620/img042.png)

_Color code:_
green: 1x2, 25x100
orange: 2x2, 25x100
blue:1x2, 50x50
yellow:2x2, 50x50

### Tracker parameters resolution comparison:
**Reference:** http://cms-tklayout.web.cern.ch/cms-tklayout/layouts-work/repository-git-dev/OT616_200_IT613/errorstracker.html 
**Zebre:** http://cms-tklayout.web.cern.ch/cms-tklayout/layouts-work/repository-git-dev/OT616_200_IT620/errorstracker.html 

- Also fix an issue in rounding, leading to wrong stripLength being displayed in the modules table on website.
