### PR TITLE
IT cabling map: Adaptations in the code to have it computed on IT 613 (instead of IT 404)

### DIFF
--- a/include/AnalyzerVisitors/GeometricInfo.hh
+++ b/include/AnalyzerVisitors/GeometricInfo.hh
@@ -270,5 +270,20 @@ public:
 };
 
 
+    //************************************//
+    //*               Visitor             //
+    //*     CMSSWInnerTrackerCablingMap   //
+    //*                                   //
+    //************************************//
+class CMSSWInnerTrackerCablingMapVisitor : public ConstGeometryVisitor {
+  std::stringstream output_;
+ 
+public:
+  void preVisit();
+  void visit(const Module& m);
+  std::string output() const { return output_.str(); }
+};
+
+
 
 #endif // _GEOMETRICINFO_HH

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -588,6 +588,8 @@ public:
   void setIsSmallerAbsZModuleInRing(const bool isSmallerAbsZModuleInRing) { isSmallerAbsZModuleInRing_ = isSmallerAbsZModuleInRing; }
   const bool isSmallerAbsZModuleInRing() const override { return isSmallerAbsZModuleInRing_; }
   const int diskSurface() const override { return endcapDiskSurface(); }
+  const bool isAtSmallerAbsZSideInDee() const { return (femod(diskSurface(), 2) == 1); }
+  const bool isAtSmallerAbsZDeeInDoubleDisk() const { return (diskSurface() <= 2); }
 
   EndcapModule(Decorated* decorated, const std::string subdetectorName) :
     DetectorModule(decorated, subdetectorName)

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -59,7 +59,7 @@ public:
   const std::string subDetectorName() const { return myPowerChain_->subDetectorName(); }
   const int layerDiskNumber() const { return myPowerChain_->layerDiskNumber(); }
   const int ringNumber() const { return myPowerChain_->ringNumber(); }
-  const bool isSmallerAbsZRingHalf() const { return myPowerChain_->isSmallerAbsZRingHalf(); }
+  const bool isSmallerAbsZHalfRing() const { return myPowerChain_->isSmallerAbsZHalfRing(); }
   const int halfRingIndex() const { return myPowerChain_->halfRingIndex(); }
   const int powerChainPhiRef() const { return myPowerChain_->phiRef(); }
   

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -60,7 +60,7 @@ public:
   const int layerDiskNumber() const { return myPowerChain_->layerDiskNumber(); }
   const int ringNumber() const { return myPowerChain_->ringNumber(); }
   const bool isSmallerAbsZRingSide() const { return myPowerChain_->isSmallerAbsZRingSide(); }
-  const int ringQuarterIndex() const { return myPowerChain_->ringQuarterIndex(); }
+  const int halfRingIndex() const { return myPowerChain_->halfRingIndex(); }
   const int powerChainPhiRef() const { return myPowerChain_->phiRef(); }
   
 

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -59,7 +59,7 @@ public:
   const std::string subDetectorName() const { return myPowerChain_->subDetectorName(); }
   const int layerDiskNumber() const { return myPowerChain_->layerDiskNumber(); }
   const int ringNumber() const { return myPowerChain_->ringNumber(); }
-  const bool isSmallerAbsZRingSide() const { return myPowerChain_->isSmallerAbsZRingSide(); }
+  const bool isSmallerAbsZRingHalf() const { return myPowerChain_->isSmallerAbsZRingHalf(); }
   const int halfRingIndex() const { return myPowerChain_->halfRingIndex(); }
   const int powerChainPhiRef() const { return myPowerChain_->phiRef(); }
   

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -55,7 +55,7 @@ public:
   const bool isPositiveZEnd() const { return myPowerChain_->isPositiveZEnd(); }
   const bool isPositiveXSide() const { return myPowerChain_->isPositiveXSide(); }
   const bool isBarrel() const { return myPowerChain_->isBarrel(); }
-  const bool isBarrelLong() const { return myPowerChain_->isBarrelLong(); }
+  const bool isLongBarrel() const { return myPowerChain_->isLongBarrel(); }
   const std::string subDetectorName() const { return myPowerChain_->subDetectorName(); }
   const int layerDiskNumber() const { return myPowerChain_->layerDiskNumber(); }
   const int ringNumber() const { return myPowerChain_->ringNumber(); }

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -61,6 +61,8 @@ public:
   const int ringNumber() const { return myPowerChain_->ringNumber(); }
   const bool isSmallerAbsZHalfRing() const { return myPowerChain_->isSmallerAbsZHalfRing(); }
   const int halfRingIndex() const { return myPowerChain_->halfRingIndex(); }
+  const bool isAtSmallerAbsZDeeInDoubleDisk() const { return myPowerChain_->isAtSmallerAbsZDeeInDoubleDisk(); }
+  const bool isAtSmallerAbsZSideInDee() const { return myPowerChain_->isAtSmallerAbsZSideInDee(); }
   const int powerChainPhiRef() const { return myPowerChain_->phiRef(); }
   
 

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -34,8 +34,8 @@ private:
   void connectBundlesToDTCs(std::map<int, std::unique_ptr<InnerBundle> >& bundles, std::map<int, std::unique_ptr<InnerDTC> >& DTCs);
 
   // CONNECT MODULES TO GBTS
-  const std::pair<int, int> computeMaxNumModulesPerGBTInPowerChain(const int numELinksPerModule, const int numModulesInPowerChain, const bool isBarrel);
-  const std::pair<int, int> computeGBTPhiIndex(const bool isBarrel, const int ringRef, const int phiRefInPowerChain, const int maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
+  const std::pair<int, double> computeNumGBTsInPowerChain(const int numELinksPerModule, const int numModulesInPowerChain, const bool isBarrel);
+  const std::pair<int, int> computeGBTPhiIndex(const bool isBarrel, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
   const std::string computeGBTId(const int powerChainId, const int myGBTIndex) const;
   void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
   void connectOneModuleToOneGBT(Module* m, GBT* GBT) const;

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -42,7 +42,7 @@ private:
   void checkModulesToGBTsCabling(const std::map<std::string, std::unique_ptr<GBT> >& GBTs) const;
 
   // CONNECT GBTs TO BUNDLES
-  const int computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const int ringNumber) const;
+  const int computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const;
   const int computeBundleId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex) const;
   void createAndStoreBundles(GBT* myGBT, std::map<int, std::unique_ptr<InnerBundle> >& bundles, const int bundleId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex);
   void connectOneGBTToOneBundle(GBT* myGBT, InnerBundle* myBundle) const;

--- a/include/InnerCabling/ModulesToPowerChainsConnector.hh
+++ b/include/InnerCabling/ModulesToPowerChainsConnector.hh
@@ -35,9 +35,9 @@ private:
   const std::pair<int, int> computeForwardModulePhiPowerChain(const double modPhi, const int numModulesInRing, const bool isPositiveZEnd) const;
 
   // BUILDING POWER CHAIN
-  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel = false, const int ringQuarterIndex = 0);
-  const int computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex) const;
-  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex);
+  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel = false, const int halfRingIndex = 0);
+  const int computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int halfRingIndex) const;
+  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex);
   void connectModuleToPowerChain(DetectorModule& m, PowerChain* powerChain) const;
 
   // CHECKING POWER CHAIN

--- a/include/InnerCabling/ModulesToPowerChainsConnector.hh
+++ b/include/InnerCabling/ModulesToPowerChainsConnector.hh
@@ -35,9 +35,9 @@ private:
   const std::pair<int, int> computeForwardModulePhiPowerChain(const double modPhi, const int numModulesInRing, const bool isPositiveZEnd) const;
 
   // BUILDING POWER CHAIN
-  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel = false, const int halfRingIndex = 0);
+  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel = false, const int halfRingIndex = 0, const bool isAtSmallerAbsZDeeInDoubleDisk = false, const bool isAtSmallerAbsZSideInDee = false);
   const int computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int halfRingIndex) const;
-  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex);
+  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZDeeInDoubleDisk, const bool isAtSmallerAbsZSideInDee);
   void connectModuleToPowerChain(DetectorModule& m, PowerChain* powerChain) const;
 
   // CHECKING POWER CHAIN

--- a/include/InnerCabling/ModulesToPowerChainsConnector.hh
+++ b/include/InnerCabling/ModulesToPowerChainsConnector.hh
@@ -35,9 +35,9 @@ private:
   const std::pair<int, int> computeForwardModulePhiPowerChain(const double modPhi, const int numModulesInRing, const bool isPositiveZEnd) const;
 
   // BUILDING POWER CHAIN
-  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong = false, const int ringQuarterIndex = 0);
+  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel = false, const int ringQuarterIndex = 0);
   const int computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex) const;
-  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex);
+  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex);
   void connectModuleToPowerChain(DetectorModule& m, PowerChain* powerChain) const;
 
   // CHECKING POWER CHAIN

--- a/include/InnerCabling/ModulesToPowerChainsConnector.hh
+++ b/include/InnerCabling/ModulesToPowerChainsConnector.hh
@@ -30,14 +30,14 @@ public:
 private:
   // COLLECTING MODULE INFO
   const bool computeXSide(const double modCenterX) const;
-  const bool computeBarrelModuleZEnd(const int side, const int ring, const int layerNumber) const;
+  const std::pair<bool, bool> computeBarrelModuleZEnd(const int side, const int ring, const int layerNumber) const;
   const bool computeBarrelCentralModuleZEnd(const int layerNumber) const;
   const std::pair<int, int> computeForwardModulePhiPowerChain(const double modPhi, const int numModulesInRing, const bool isPositiveZEnd) const;
 
   // BUILDING POWER CHAIN
-  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex = 0);
+  void buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong = false, const int ringQuarterIndex = 0);
   const int computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex) const;
-  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex);
+  PowerChain* createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex);
   void connectModuleToPowerChain(DetectorModule& m, PowerChain* powerChain) const;
 
   // CHECKING POWER CHAIN

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -22,7 +22,7 @@ class PowerChain : public PropertyObject, public Buildable, public Identifiable<
   typedef std::vector<Module*> Container; 
 
 public:
-  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex);
+  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex);
 
   // MODULES CONNECTED TO THE POWER CHAIN.
   const Container& modules() const { return modules_; }
@@ -50,8 +50,8 @@ public:
 
   const PowerChainType powerChainType() const { return powerChainType_; }
 
-  const bool isBarrelLong() const {
-    if (isBarrel()) return isBarrelLong_;
+  const bool isLongBarrel() const {
+    if (isBarrel()) return isLongBarrel_;
     else return false;
   }
 
@@ -73,7 +73,7 @@ private:
   std::string subDetectorName_;
   int layerDiskNumber_;
   int phiRef_;
-  bool isBarrelLong_;
+  bool isLongBarrel_;
   int ringQuarterIndex_;
   
   bool isBarrel_;

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -50,8 +50,6 @@ public:
   const int ringNumber() const { return ringNumber_; }
   const bool isSmallerAbsZHalfRing() const { return isSmallerAbsZHalfRing_; }
 
-  const PowerChainType powerChainType() const { return powerChainType_; }
-
   const bool isLongBarrel() const {
     if (isBarrel()) return isLongBarrel_;
     else return false;
@@ -59,8 +57,9 @@ public:
 
   const int plotColor() const { return plotColor_; }
 
+  const PowerChainType powerChainType() const;  // Returns whether a power chain has 4 Ampere or 8 Ampere.
+
 private:
-  const PowerChainType computePowerChainType(const bool isBarrel, const int layerDiskNumber, const int ringNumber) const;
   const int computePlotColor(const bool isBarrel, const bool isPositiveZEnd, const int phiRef, const int halfRingIndex) const;
 
   void buildHvLine(const int powerChainId);
@@ -83,8 +82,6 @@ private:
   bool isBarrel_;
   int ringNumber_;
   bool isSmallerAbsZHalfRing_;
-
-  PowerChainType powerChainType_;
 
   int plotColor_;
 };

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -46,7 +46,7 @@ public:
 
   const bool isBarrel() const { return isBarrel_; }
   const int ringNumber() const { return ringNumber_; }
-  const bool isSmallerAbsZRingHalf() const { return isSmallerAbsZRingHalf_; }
+  const bool isSmallerAbsZHalfRing() const { return isSmallerAbsZHalfRing_; }
 
   const PowerChainType powerChainType() const { return powerChainType_; }
 
@@ -78,7 +78,7 @@ private:
   
   bool isBarrel_;
   int ringNumber_;
-  bool isSmallerAbsZRingHalf_;
+  bool isSmallerAbsZHalfRing_;
 
   PowerChainType powerChainType_;
 

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -22,7 +22,7 @@ class PowerChain : public PropertyObject, public Buildable, public Identifiable<
   typedef std::vector<Module*> Container; 
 
 public:
-  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex);
+  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZDeeInDoubleDisk, const bool isAtSmallerAbsZSideInDee);
 
   // MODULES CONNECTED TO THE POWER CHAIN.
   const Container& modules() const { return modules_; }
@@ -43,6 +43,8 @@ public:
   const int layerDiskNumber() const { return layerDiskNumber_; }
   const int phiRef() const { return phiRef_; }
   const int halfRingIndex() const { return halfRingIndex_; }
+  const bool isAtSmallerAbsZDeeInDoubleDisk() const { return isAtSmallerAbsZDeeInDoubleDisk_; }
+  const bool isAtSmallerAbsZSideInDee() const { return isAtSmallerAbsZSideInDee_; }
 
   const bool isBarrel() const { return isBarrel_; }
   const int ringNumber() const { return ringNumber_; }
@@ -75,6 +77,8 @@ private:
   int phiRef_;
   bool isLongBarrel_;
   int halfRingIndex_;
+  bool isAtSmallerAbsZDeeInDoubleDisk_;
+  bool isAtSmallerAbsZSideInDee_;
   
   bool isBarrel_;
   int ringNumber_;

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -22,7 +22,7 @@ class PowerChain : public PropertyObject, public Buildable, public Identifiable<
   typedef std::vector<Module*> Container; 
 
 public:
-  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex);
+  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex);
 
   // MODULES CONNECTED TO THE POWER CHAIN.
   const Container& modules() const { return modules_; }
@@ -51,7 +51,7 @@ public:
   const PowerChainType powerChainType() const { return powerChainType_; }
 
   const bool isBarrelLong() const {
-    if (isBarrel()) return (numModules() == inner_cabling_maxNumModulesPerPowerChain);
+    if (isBarrel()) return isBarrelLong_;
     else return false;
   }
 
@@ -73,6 +73,7 @@ private:
   std::string subDetectorName_;
   int layerDiskNumber_;
   int phiRef_;
+  bool isBarrelLong_;
   int ringQuarterIndex_;
   
   bool isBarrel_;

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -22,7 +22,7 @@ class PowerChain : public PropertyObject, public Buildable, public Identifiable<
   typedef std::vector<Module*> Container; 
 
 public:
-  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex);
+  PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex);
 
   // MODULES CONNECTED TO THE POWER CHAIN.
   const Container& modules() const { return modules_; }
@@ -42,7 +42,7 @@ public:
   const std::string subDetectorName() const { return subDetectorName_; }
   const int layerDiskNumber() const { return layerDiskNumber_; }
   const int phiRef() const { return phiRef_; }
-  const int ringQuarterIndex() const { return ringQuarterIndex_; }
+  const int halfRingIndex() const { return halfRingIndex_; }
 
   const bool isBarrel() const { return isBarrel_; }
   const int ringNumber() const { return ringNumber_; }
@@ -59,7 +59,7 @@ public:
 
 private:
   const PowerChainType computePowerChainType(const bool isBarrel, const int layerDiskNumber, const int ringNumber) const;
-  const int computePlotColor(const bool isBarrel, const bool isPositiveZEnd, const int phiRef, const int ringQuarterIndex) const;
+  const int computePlotColor(const bool isBarrel, const bool isPositiveZEnd, const int phiRef, const int halfRingIndex) const;
 
   void buildHvLine(const int powerChainId);
   const std::string computeHvLineName(const int powerChainId) const;
@@ -74,7 +74,7 @@ private:
   int layerDiskNumber_;
   int phiRef_;
   bool isLongBarrel_;
-  int ringQuarterIndex_;
+  int halfRingIndex_;
   
   bool isBarrel_;
   int ringNumber_;

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -46,7 +46,7 @@ public:
 
   const bool isBarrel() const { return isBarrel_; }
   const int ringNumber() const { return ringNumber_; }
-  const bool isSmallerAbsZRingSide() const { return isSmallerAbsZRingSide_; }
+  const bool isSmallerAbsZRingHalf() const { return isSmallerAbsZRingHalf_; }
 
   const PowerChainType powerChainType() const { return powerChainType_; }
 
@@ -78,7 +78,7 @@ private:
   
   bool isBarrel_;
   int ringNumber_;
-  bool isSmallerAbsZRingSide_;
+  bool isSmallerAbsZRingHalf_;
 
   PowerChainType powerChainType_;
 

--- a/include/InnerCabling/inner_cabling_constants.hh
+++ b/include/InnerCabling/inner_cabling_constants.hh
@@ -9,7 +9,7 @@
 
 // DESIGN
 // Maximum number of modules per serial power chain
-static const int inner_cabling_maxNumModulesPerPowerChain = 10;
+static const int inner_cabling_maxNumModulesPerPowerChain = 12;
 // Maximum number of ELinks per GBT
 static const int inner_cabling_maxNumELinksPerGBT = 7;
 // Maximum number of GBTs per bundle

--- a/include/InnerCabling/inner_cabling_constants.hh
+++ b/include/InnerCabling/inner_cabling_constants.hh
@@ -29,7 +29,11 @@ static const int inner_cabling_numELinksPerModuleForwardRing2 = 2;
 static const int inner_cabling_numELinksPerModuleForwardRing3 = 2;
 static const int inner_cabling_numELinksPerModuleForwardRing4 = 1;
 
-static const int inner_cabling_numELinksPerModuleEndcap = 1;
+static const int inner_cabling_numELinksPerModuleEndcapRing1 = 3;
+static const int inner_cabling_numELinksPerModuleEndcapRing2 = 2;
+static const int inner_cabling_numELinksPerModuleEndcapRing3 = 1;
+static const int inner_cabling_numELinksPerModuleEndcapRing4 = 1;
+static const int inner_cabling_numELinksPerModuleEndcapRing5 = 1;
 
 
 // MAX NUMBER OF POWER CHAINS PER FIBER BUNDLE, in TBPX

--- a/include/InnerCabling/inner_cabling_functions.hh
+++ b/include/InnerCabling/inner_cabling_functions.hh
@@ -20,9 +20,9 @@ namespace inner_cabling_functions {
   const bool isBarrel(const std::string subDetectorName);
   const int computeInnerTrackerQuarterIndex(const bool isPositiveZEnd, const bool isPositiveXSide);
   const int computeSubDetectorIndex(const std::string subDetectorName);
-  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingHalf);
+  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZHalfRing);
   const int computeRingNumber(const int halfRingIndex);
-  const bool isSmallerAbsZRingHalf(const int halfRingIndex);
+  const bool isSmallerAbsZHalfRing(const int halfRingIndex);
 
   // compute number of ELinks per module
   const int computeNumELinksPerModule(const std::string subDetectorName, const int layerOrRingNumber);

--- a/include/InnerCabling/inner_cabling_functions.hh
+++ b/include/InnerCabling/inner_cabling_functions.hh
@@ -20,9 +20,9 @@ namespace inner_cabling_functions {
   const bool isBarrel(const std::string subDetectorName);
   const int computeInnerTrackerQuarterIndex(const bool isPositiveZEnd, const bool isPositiveXSide);
   const int computeSubDetectorIndex(const std::string subDetectorName);
-  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingSide);
+  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingHalf);
   const int computeRingNumber(const int halfRingIndex);
-  const bool isSmallerAbsZRingSide(const int halfRingIndex);
+  const bool isSmallerAbsZRingHalf(const int halfRingIndex);
 
   // compute number of ELinks per module
   const int computeNumELinksPerModule(const std::string subDetectorName, const int layerOrRingNumber);

--- a/include/InnerCabling/inner_cabling_functions.hh
+++ b/include/InnerCabling/inner_cabling_functions.hh
@@ -20,9 +20,9 @@ namespace inner_cabling_functions {
   const bool isBarrel(const std::string subDetectorName);
   const int computeInnerTrackerQuarterIndex(const bool isPositiveZEnd, const bool isPositiveXSide);
   const int computeSubDetectorIndex(const std::string subDetectorName);
-  const int computeRingQuarterIndex(const int ringNumber, const bool isSmallerAbsZRingSide);
-  const int computeRingNumber(const int ringQuarterIndex);
-  const bool isSmallerAbsZRingSide(const int ringQuarterIndex);
+  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingSide);
+  const int computeRingNumber(const int halfRingIndex);
+  const bool isSmallerAbsZRingSide(const int halfRingIndex);
 
   // compute number of ELinks per module
   const int computeNumELinksPerModule(const std::string subDetectorName, const int layerOrRingNumber);

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -183,7 +183,7 @@ struct TypeInnerBundleTransparentColor { // Module-maintained InnerBundle color
 
 struct TypeInnerDTCTransparentColor { // Module-maintained InnerDTC color
   double operator()(const Module& m) {
-    bool isTransparent = (m.isPositiveZEnd() < 0);
+    bool isTransparent = (m.isPositiveZEnd() < 0 || !m.isPositiveXSide());
     return Palette::colorScrabble(m.innerDTCPlotColor(), isTransparent);
   }
 };

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -306,6 +306,7 @@ namespace insur {
     // Inner Tracker
     std::string createInnerTrackerModulesToDTCsCsv(const Tracker& tracker);
     std::string createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* myInnerCablingMap) ;
+    std::string createCMSSWInnerTrackerCablingMapCsv(const Tracker& tracker);
 
     TProfile* newProfile(TH1D* sourceHistogram, double xlow, double xup, int desiredNBins = 0);
     TProfile& newProfile(const TGraph& sourceGraph, double xlow, double xup, int nrebin = 1, int nBins = 0);

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -184,7 +184,7 @@ namespace insur {
   // TODO: make sure the following constants are only used in
   // mainConfigHandler
   static const std::string default_cabledOTName                  = "OT616";
-  static const std::string default_cabledITName                  = "IT404";
+  static const std::string default_cabledITName                  = "IT613";
   static const std::string default_mattabdir                     = "config";
   static const std::string default_mattabfile                    = "mattab.list";
   static const std::string default_chemicalElementsFile          = "chemical_elements.list";

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -653,7 +653,7 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
 	       << m.totalChannels() << ", ";
 
     std::stringstream powerChainInfo;
-    powerChainInfo << any2str(myPowerChain->isBarrelLong()) << ","
+    powerChainInfo << any2str(myPowerChain->isLongBarrel()) << ","
 		   << myPowerChain->myid() << ","
 		   << any2str(myPowerChain->powerChainType()) << ",";
 

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -683,3 +683,25 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
     else output_ << moduleInfo.str() << powerChainInfo.str() << std::endl;
   }
 }
+
+
+    //************************************//
+    //*               Visitor             //
+    //*     CMSSWInnerTrackerCablingMap   //
+    //*                                   //
+    //************************************//
+void CMSSWInnerTrackerCablingMapVisitor::preVisit() {
+  output_ << "Module DetId/U, DTC Id/U" << std::endl;
+}
+
+void CMSSWInnerTrackerCablingMapVisitor::visit(const Module& m) {
+  std::stringstream moduleInfo;
+  moduleInfo << m.myDetId() << ", ";
+  const InnerDTC* myDTC = m.getInnerDTC();
+  if (myDTC) {
+    std::stringstream DTCInfo;
+    DTCInfo << myDTC->myid();	 
+    output_ << moduleInfo.str() << DTCInfo.str() << std::endl;
+  }
+  else output_ << moduleInfo.str() << std::endl;
+}

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -110,9 +110,13 @@ const std::pair<int, int> InnerCablingMap::computeMaxNumModulesPerGBTInPowerChai
                            // This is becasue it makes the powering of the GBTs much easier.
   }
 
-  const int numELinks = numELinksPerModule * numModules;
+  const double maxNumModulesPerGBTExact = static_cast<double>(inner_cabling_maxNumELinksPerGBT) / numELinksPerModule;
+  const int maxNumModulesPerGBTInPowerChain = (fabs(maxNumModulesPerGBTExact - round(maxNumModulesPerGBTExact)) < inner_cabling_roundingTolerance ? 
+					       round(maxNumModulesPerGBTExact) 
+					       : std::floor(maxNumModulesPerGBTExact)
+					       );
 
-  const double numGBTsExact = static_cast<double>(numELinks) / inner_cabling_maxNumELinksPerGBT;
+  const double numGBTsExact = static_cast<double>(numModules) / maxNumModulesPerGBTInPowerChain;
   const int numGBTs = (fabs(numGBTsExact - round(numGBTsExact)) < inner_cabling_roundingTolerance ? 
 		       round(numGBTsExact) 
 		       : std::ceil(numGBTsExact)
@@ -122,11 +126,6 @@ const std::pair<int, int> InnerCablingMap::computeMaxNumModulesPerGBTInPowerChai
 			     + any2str(" modules, but found numGBTs == ") +  any2str(numGBTs) + any2str(", that's not enough!!")
 			     );
 
-  const double maxNumModulesPerGBTExact = static_cast<double>(numModules) / numGBTs;
-  const int maxNumModulesPerGBTInPowerChain = (fabs(maxNumModulesPerGBTExact - round(maxNumModulesPerGBTExact)) < inner_cabling_roundingTolerance ? 
-					       round(maxNumModulesPerGBTExact) 
-					       : std::ceil(maxNumModulesPerGBTExact)
-					       );
   // TO DO: MINOR ISSUE OF TAKING THE ceil IS THAT it doesnt handle optimally the (RARE) case where we have 3 + 2 + 2
   // Since it will lead to following repartition: 3 + 3 + 1
   // One could take the floor, and then look at the number of remaining modules in power chain.

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -69,7 +69,7 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
     const double numModulesPerGBTExact = gbtsInPowerChain.second;
 
     const int powerChainId = myPowerChain->myid();
-    const bool isBarrelLong = myPowerChain->isBarrelLong();
+    const bool isLongBarrel = myPowerChain->isLongBarrel();
     
 
     // Loops on all modules of the power chain
@@ -79,7 +79,7 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
       m->setNumELinks(numELinksPerModule);
 
       // COLLECT MODULE INFORMATION NEEDED TO BUILD GBT
-      const int ringRef = (isBarrelLong ? m->uniRef().ring - 1 : m->uniRef().ring - 2);
+      const int ringRef = (isLongBarrel ? m->uniRef().ring - 1 : m->uniRef().ring - 2);
       const int phiRefInPowerChain = m->getPhiRefInPowerChain();
       
       const std::pair<int, int> myGBTIndexes = computeGBTPhiIndex(isBarrel, ringRef, phiRefInPowerChain, numModulesPerGBTExact, numGBTsInPowerChain);

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -139,7 +139,7 @@ const std::pair<int, int> InnerCablingMap::computeGBTPhiIndex(const bool isBarre
 
   const int moduleRef = (isBarrel ? ringRef : phiRefInPowerChain);
 
-  if (maxNumModulesPerGBTInPowerChain == 0) logERROR(any2str("Found maxNumModulesPerGBTInPowerChain == 0."));
+  if (fabs(numModulesPerGBTExact) < inner_cabling_roundingTolerance) logERROR(any2str("Found numModulesPerGBTExact ~ 0."));
 
   const double myGBTIndexExact = moduleRef / numModulesPerGBTExact;
   int myGBTIndex = (fabs(myGBTIndexExact - round(myGBTIndexExact)) < inner_cabling_roundingTolerance ? 

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -234,7 +234,7 @@ void InnerCablingMap::connectGBTsToBundles(std::map<std::string, std::unique_ptr
     const int myBundleId = computeBundleId(isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, myBundleIndex);
 
     // BUILD BUNDLES AND STORE THEM
-    createAndStoreBundles(myGBT, bundles, myBundleId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, isAtSmallerAbsZDeeInDoubleDisk, myBundleIndex);    
+    createAndStoreBundles(myGBT, bundles, myBundleId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, myBundleIndex);    
   }
 
   // CHECK BUNDLES

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -225,16 +225,16 @@ void InnerCablingMap::connectGBTsToBundles(std::map<std::string, std::unique_ptr
     
     const int layerDiskNumber = myGBT->layerDiskNumber();
     const int powerChainPhiRef = myGBT->powerChainPhiRef();
-    const int ringNumber = myGBT->ringNumber();
+    const bool isAtSmallerAbsZDeeInDoubleDisk = myGBT->isAtSmallerAbsZDeeInDoubleDisk();
         
-    const int myBundleIndex = computeBundleIndex(subDetectorName, layerDiskNumber, powerChainPhiRef, ringNumber);
+    const int myBundleIndex = computeBundleIndex(subDetectorName, layerDiskNumber, powerChainPhiRef, isAtSmallerAbsZDeeInDoubleDisk);
 
     const bool isPositiveZEnd = myGBT->isPositiveZEnd();
     const bool isPositiveXSide = myGBT->isPositiveXSide();
     const int myBundleId = computeBundleId(isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, myBundleIndex);
 
     // BUILD BUNDLES AND STORE THEM
-    createAndStoreBundles(myGBT, bundles, myBundleId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, myBundleIndex);    
+    createAndStoreBundles(myGBT, bundles, myBundleId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, isAtSmallerAbsZDeeInDoubleDisk, myBundleIndex);    
   }
 
   // CHECK BUNDLES
@@ -245,7 +245,7 @@ void InnerCablingMap::connectGBTsToBundles(std::map<std::string, std::unique_ptr
 /*
  * Compute the index used to identify uniquely a Fiber Bundle.
  */
-const int InnerCablingMap::computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const int ringNumber) const {
+const int InnerCablingMap::computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const {
   int myBundleIndex = 0;
 
   if (subDetectorName == inner_cabling_tbpx) {
@@ -265,7 +265,7 @@ const int InnerCablingMap::computeBundleIndex(const std::string subDetectorName,
 		     );
   }
   else if (subDetectorName == inner_cabling_tfpx || subDetectorName == inner_cabling_tepx) {
-    myBundleIndex = (femod(ringNumber, 2) == 1 ? 0 : 1);
+    myBundleIndex = (!isAtSmallerAbsZDeeInDoubleDisk);
   }
   else logERROR("Unsupported detector name.");
 

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -218,7 +218,7 @@ const int ModulesToPowerChainsConnector::computePowerChainId(const bool isPositi
 /*  Create a powerChain, if it does not exist yet.
  *  Store it in the powerChains_ container.
  */
-PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZSideInDee) {
+PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZDeeInDoubleDisk, const bool isAtSmallerAbsZSideInDee) {
 
   PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex, isAtSmallerAbsZDeeInDoubleDisk, isAtSmallerAbsZSideInDee);
 

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -34,14 +34,14 @@ void ModulesToPowerChainsConnector::visit(BarrelModule& m) {
   const int halfNumRods = numRods_ / 2;
   const std::pair<bool, bool>& barrelModuleZEnd = computeBarrelModuleZEnd(m.uniRef().side, m.uniRef().ring, layerNumber_);
   const bool isPositiveZEnd = barrelModuleZEnd.first;
-  const bool isBarrelLong = barrelModuleZEnd.second;
+  const bool isLongBarrel = barrelModuleZEnd.second;
 
   const int phiUnitRef = inner_cabling_functions::computePhiUnitRef(rodPhi_, halfNumRods, isPositiveZEnd);
   const int modulePhiRefInPowerChain = femod(inner_cabling_functions::computePhiUnitRef(rodPhi_, numRods_, isPositiveZEnd), 2);
   m.setPhiRefInPowerChain(modulePhiRefInPowerChain);
 
   // BUILD POWER CHAIN IF NECESSARY, AND CONNECT MODULE TO POWER CHAIN
-  buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, barrelName_, layerNumber_, phiUnitRef, isBarrelLong);
+  buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, barrelName_, layerNumber_, phiUnitRef, isLongBarrel);
 }
 
 
@@ -130,9 +130,9 @@ const std::pair<bool, bool> ModulesToPowerChainsConnector::computeBarrelModuleZE
   }
 
   // The module is on the long barrel (Z) end <-> the central module is connected to the same (Z) end.
-  const bool isBarrelLong = (isPositiveZEnd == isBarrelCentralModuleAtPositiveZEnd);
+  const bool isLongBarrel = (isPositiveZEnd == isBarrelCentralModuleAtPositiveZEnd);
 
-  return std::make_pair(isPositiveZEnd, isBarrelLong);
+  return std::make_pair(isPositiveZEnd, isLongBarrel);
 }
 
 
@@ -181,7 +181,7 @@ const std::pair<int, int> ModulesToPowerChainsConnector::computeForwardModulePhi
  * Then, the bundle is created, and stored in the bundles_ or negPowerChains_ containers.
  * Lastly, each module is connected to its bundle, and vice-versa.
  */
-void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex) {
+void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex) {
   // COMPUTE POWER CHAIN ID
   const int powerChainId = computePowerChainId(isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, ringQuarterIndex);
 
@@ -189,7 +189,7 @@ void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<
   PowerChain* powerChain = nullptr;
   auto found = powerChains.find(powerChainId);
   if (found == powerChains.end()) {
-    powerChain = createAndStorePowerChain(powerChains, powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isBarrelLong, ringQuarterIndex);
+    powerChain = createAndStorePowerChain(powerChains, powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, ringQuarterIndex);
   }
   else {
     powerChain = found->second;
@@ -215,9 +215,9 @@ const int ModulesToPowerChainsConnector::computePowerChainId(const bool isPositi
 /*  Create a powerChain, if it does not exist yet.
  *  Store it in the powerChains_ container.
  */
-PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex) {
+PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex) {
 
-  PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isBarrelLong, ringQuarterIndex);
+  PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, ringQuarterIndex);
 
   powerChains.insert(std::make_pair(powerChainId, powerChain));
  

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -76,7 +76,7 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const double modCenterX = m.center().X();
   const bool isPositiveXSide = computeXSide(modCenterX);
 
-  const bool isSmallerAbsZRingSide = m.isSmallerAbsZModuleInRing();
+  const bool isSmallerAbsZRingHalf = m.isSmallerAbsZModuleInRing();
   
   const double modPhi = m.center().Phi();
   const std::pair<int, int> phiRefs = computeForwardModulePhiPowerChain(modPhi, numModulesInRing_, isPositiveZEnd);
@@ -84,7 +84,7 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const int modulePhiRefInPowerChain = phiRefs.second;
   m.setPhiRefInPowerChain(modulePhiRefInPowerChain);
 
-  const int halfRingIndex = inner_cabling_functions::computeHalfRingIndex(ringNumber_, isSmallerAbsZRingSide);
+  const int halfRingIndex = inner_cabling_functions::computeHalfRingIndex(ringNumber_, isSmallerAbsZRingHalf);
 
   // BUILD POWER CHAIN IF NECESSARY, AND CONNECT MODULE TO POWER CHAIN
   buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, false, halfRingIndex);

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -76,7 +76,7 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const double modCenterX = m.center().X();
   const bool isPositiveXSide = computeXSide(modCenterX);
 
-  const bool isSmallerAbsZRingHalf = m.isSmallerAbsZModuleInRing();
+  const bool isSmallerAbsZHalfRing = m.isSmallerAbsZModuleInRing();
   
   const double modPhi = m.center().Phi();
   const std::pair<int, int> phiRefs = computeForwardModulePhiPowerChain(modPhi, numModulesInRing_, isPositiveZEnd);
@@ -84,7 +84,7 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const int modulePhiRefInPowerChain = phiRefs.second;
   m.setPhiRefInPowerChain(modulePhiRefInPowerChain);
 
-  const int halfRingIndex = inner_cabling_functions::computeHalfRingIndex(ringNumber_, isSmallerAbsZRingHalf);
+  const int halfRingIndex = inner_cabling_functions::computeHalfRingIndex(ringNumber_, isSmallerAbsZHalfRing);
 
   // BUILD POWER CHAIN IF NECESSARY, AND CONNECT MODULE TO POWER CHAIN
   buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, false, halfRingIndex);

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -84,10 +84,10 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   const int modulePhiRefInPowerChain = phiRefs.second;
   m.setPhiRefInPowerChain(modulePhiRefInPowerChain);
 
-  const int ringQuarterIndex = inner_cabling_functions::computeRingQuarterIndex(ringNumber_, isSmallerAbsZRingSide);
+  const int halfRingIndex = inner_cabling_functions::computeHalfRingIndex(ringNumber_, isSmallerAbsZRingSide);
 
   // BUILD POWER CHAIN IF NECESSARY, AND CONNECT MODULE TO POWER CHAIN
-  buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, false, ringQuarterIndex);
+  buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, false, halfRingIndex);
 }
 
 
@@ -181,15 +181,15 @@ const std::pair<int, int> ModulesToPowerChainsConnector::computeForwardModulePhi
  * Then, the bundle is created, and stored in the bundles_ or negPowerChains_ containers.
  * Lastly, each module is connected to its bundle, and vice-versa.
  */
-void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex) {
+void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex) {
   // COMPUTE POWER CHAIN ID
-  const int powerChainId = computePowerChainId(isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, ringQuarterIndex);
+  const int powerChainId = computePowerChainId(isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, halfRingIndex);
 
   // CREATE POWER CHAIN IF NECESSARY
   PowerChain* powerChain = nullptr;
   auto found = powerChains.find(powerChainId);
   if (found == powerChains.end()) {
-    powerChain = createAndStorePowerChain(powerChains, powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, ringQuarterIndex);
+    powerChain = createAndStorePowerChain(powerChains, powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex);
   }
   else {
     powerChain = found->second;
@@ -202,12 +202,12 @@ void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<
 
 /* Compute the Id associated to each bundle.
  */
-const int ModulesToPowerChainsConnector::computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex) const {
+const int ModulesToPowerChainsConnector::computePowerChainId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int halfRingIndex) const {
 
   const int innerTrackerQuarterIndex = inner_cabling_functions::computeInnerTrackerQuarterIndex(isPositiveZEnd, isPositiveXSide);
   const int subdetectorIndex = inner_cabling_functions::computeSubDetectorIndex(subDetectorName);
 
-  const int powerChainId = innerTrackerQuarterIndex * 10000 + subdetectorIndex * 1000 + layerDiskNumber * 100 + ringQuarterIndex * 10 + phiRef;
+  const int powerChainId = innerTrackerQuarterIndex * 10000 + subdetectorIndex * 1000 + layerDiskNumber * 100 + halfRingIndex * 10 + phiRef;
   return powerChainId;
 }
 
@@ -215,9 +215,9 @@ const int ModulesToPowerChainsConnector::computePowerChainId(const bool isPositi
 /*  Create a powerChain, if it does not exist yet.
  *  Store it in the powerChains_ container.
  */
-PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex) {
+PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex) {
 
-  PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, ringQuarterIndex);
+  PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex);
 
   powerChains.insert(std::make_pair(powerChainId, powerChain));
  

--- a/src/InnerCabling/ModulesToPowerChainsConnector.cc
+++ b/src/InnerCabling/ModulesToPowerChainsConnector.cc
@@ -85,9 +85,12 @@ void ModulesToPowerChainsConnector::visit(EndcapModule& m) {
   m.setPhiRefInPowerChain(modulePhiRefInPowerChain);
 
   const int halfRingIndex = inner_cabling_functions::computeHalfRingIndex(ringNumber_, isSmallerAbsZHalfRing);
+  const bool isAtSmallerAbsZDeeInDoubleDisk = m.isAtSmallerAbsZDeeInDoubleDisk();
+  const bool isAtSmallerAbsZSideInDee = m.isAtSmallerAbsZSideInDee();
 
   // BUILD POWER CHAIN IF NECESSARY, AND CONNECT MODULE TO POWER CHAIN
-  buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, false, halfRingIndex);
+  const bool isLongBarrel = false;
+  buildPowerChain(m, powerChains_, isPositiveZEnd, isPositiveXSide, endcapName_, diskNumber_, powerChainPhiRef, isLongBarrel, halfRingIndex, isAtSmallerAbsZDeeInDoubleDisk, isAtSmallerAbsZSideInDee);
 }
 
 
@@ -181,7 +184,7 @@ const std::pair<int, int> ModulesToPowerChainsConnector::computeForwardModulePhi
  * Then, the bundle is created, and stored in the bundles_ or negPowerChains_ containers.
  * Lastly, each module is connected to its bundle, and vice-versa.
  */
-void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex) {
+void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<int, PowerChain*>& powerChains, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZDeeInDoubleDisk, const bool isAtSmallerAbsZSideInDee) {
   // COMPUTE POWER CHAIN ID
   const int powerChainId = computePowerChainId(isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, halfRingIndex);
 
@@ -189,7 +192,7 @@ void ModulesToPowerChainsConnector::buildPowerChain(DetectorModule& m, std::map<
   PowerChain* powerChain = nullptr;
   auto found = powerChains.find(powerChainId);
   if (found == powerChains.end()) {
-    powerChain = createAndStorePowerChain(powerChains, powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex);
+    powerChain = createAndStorePowerChain(powerChains, powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex, isAtSmallerAbsZDeeInDoubleDisk, isAtSmallerAbsZSideInDee);
   }
   else {
     powerChain = found->second;
@@ -215,9 +218,9 @@ const int ModulesToPowerChainsConnector::computePowerChainId(const bool isPositi
 /*  Create a powerChain, if it does not exist yet.
  *  Store it in the powerChains_ container.
  */
-PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex) {
+PowerChain* ModulesToPowerChainsConnector::createAndStorePowerChain(std::map<int, PowerChain*>& powerChains, const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZSideInDee) {
 
-  PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex);
+  PowerChain* powerChain = new PowerChain(powerChainId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, phiRef, isLongBarrel, halfRingIndex, isAtSmallerAbsZDeeInDoubleDisk, isAtSmallerAbsZSideInDee);
 
   powerChains.insert(std::make_pair(powerChainId, powerChain));
  

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -9,7 +9,9 @@ PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const 
   layerDiskNumber_(layerDiskNumber),
   phiRef_(phiRef),
   isLongBarrel_(isLongBarrel),
-  halfRingIndex_(halfRingIndex)
+  halfRingIndex_(halfRingIndex),
+  isAtSmallerAbsZDeeInDoubleDisk_(isAtSmallerAbsZDeeInDoubleDisk),
+  isAtSmallerAbsZSideInDee_(isAtSmallerAbsZSideInDee)
 {
   myid(powerChainId);
   isBarrel_ = inner_cabling_functions::isBarrel(subDetectorName);

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -2,12 +2,13 @@
 #include "InnerCabling/HvLine.hh"
 
 
-PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const int ringQuarterIndex) :
+PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex) :
   isPositiveZEnd_(isPositiveZEnd),
   isPositiveXSide_(isPositiveXSide),
   subDetectorName_(subDetectorName),
   layerDiskNumber_(layerDiskNumber),
   phiRef_(phiRef),
+  isBarrelLong_(isBarrelLong),
   ringQuarterIndex_(ringQuarterIndex)
 {
   myid(powerChainId);

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -2,7 +2,7 @@
 #include "InnerCabling/HvLine.hh"
 
 
-PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex) :
+PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex, const bool isAtSmallerAbsZDeeInDoubleDisk, const bool isAtSmallerAbsZSideInDee) :
   isPositiveZEnd_(isPositiveZEnd),
   isPositiveXSide_(isPositiveXSide),
   subDetectorName_(subDetectorName),

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -14,7 +14,7 @@ PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const 
   myid(powerChainId);
   isBarrel_ = inner_cabling_functions::isBarrel(subDetectorName);
   ringNumber_ = inner_cabling_functions::computeRingNumber(halfRingIndex);
-  isSmallerAbsZRingHalf_ = inner_cabling_functions::isSmallerAbsZRingHalf(halfRingIndex);
+  isSmallerAbsZHalfRing_ = inner_cabling_functions::isSmallerAbsZHalfRing(halfRingIndex);
 
   powerChainType_ = computePowerChainType(isBarrel_, layerDiskNumber, ringNumber_);
 

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -2,13 +2,13 @@
 #include "InnerCabling/HvLine.hh"
 
 
-PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isBarrelLong, const int ringQuarterIndex) :
+PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex) :
   isPositiveZEnd_(isPositiveZEnd),
   isPositiveXSide_(isPositiveXSide),
   subDetectorName_(subDetectorName),
   layerDiskNumber_(layerDiskNumber),
   phiRef_(phiRef),
-  isBarrelLong_(isBarrelLong),
+  isLongBarrel_(isLongBarrel),
   ringQuarterIndex_(ringQuarterIndex)
 {
   myid(powerChainId);
@@ -36,7 +36,7 @@ void PowerChain::addModule(Module* m) {
 
 
 /*
- * Compute wheter a power chain is 4 Ampere or 8 Ampere.
+ * Compute whether a power chain is 4 Ampere or 8 Ampere.
  * NB: WOULD BE NICER TO COMPUTE THIS AS A FUNCTION OF MODULE TYPE (1x2 or 2x2)
  */
 const PowerChainType PowerChain::computePowerChainType(const bool isBarrel, const int layerDiskNumber, const int ringNumber) const {

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -2,23 +2,23 @@
 #include "InnerCabling/HvLine.hh"
 
 
-PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int ringQuarterIndex) :
+PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int phiRef, const bool isLongBarrel, const int halfRingIndex) :
   isPositiveZEnd_(isPositiveZEnd),
   isPositiveXSide_(isPositiveXSide),
   subDetectorName_(subDetectorName),
   layerDiskNumber_(layerDiskNumber),
   phiRef_(phiRef),
   isLongBarrel_(isLongBarrel),
-  ringQuarterIndex_(ringQuarterIndex)
+  halfRingIndex_(halfRingIndex)
 {
   myid(powerChainId);
   isBarrel_ = inner_cabling_functions::isBarrel(subDetectorName);
-  ringNumber_ = inner_cabling_functions::computeRingNumber(ringQuarterIndex);
-  isSmallerAbsZRingSide_ = inner_cabling_functions::isSmallerAbsZRingSide(ringQuarterIndex);
+  ringNumber_ = inner_cabling_functions::computeRingNumber(halfRingIndex);
+  isSmallerAbsZRingSide_ = inner_cabling_functions::isSmallerAbsZRingSide(halfRingIndex);
 
   powerChainType_ = computePowerChainType(isBarrel_, layerDiskNumber, ringNumber_);
 
-  plotColor_ = computePlotColor(isBarrel_, isPositiveZEnd, phiRef, ringQuarterIndex);
+  plotColor_ = computePlotColor(isBarrel_, isPositiveZEnd, phiRef, halfRingIndex);
 
   // BUILD HVLINE, TO WHICH THE MODULES OF THE POWER CHAIN ARE ALL CONNECTED
   buildHvLine(powerChainId);
@@ -59,7 +59,7 @@ const PowerChainType PowerChain::computePowerChainType(const bool isBarrel, cons
  * Compute power chain color on website.
  * Power chains next to each other in space, must be of different colors.
  */
-const int PowerChain::computePlotColor(const bool isBarrel, const bool isPositiveZEnd, const int phiRef, const int ringQuarterIndex) const {
+const int PowerChain::computePlotColor(const bool isBarrel, const bool isPositiveZEnd, const int phiRef, const int halfRingIndex) const {
   int plotColor = 0;
 
   const int plotPhi = femod(phiRef, 2);
@@ -69,7 +69,7 @@ const int PowerChain::computePlotColor(const bool isBarrel, const bool isPositiv
     plotColor = plotZEnd * 2 + plotPhi + 6;
   }
   else {
-    const int plotRingQuarter = femod(ringQuarterIndex, 6);
+    const int plotRingQuarter = femod(halfRingIndex, 6);
     plotColor = plotRingQuarter * 2 + plotPhi + 1;
   }
 

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -14,7 +14,7 @@ PowerChain::PowerChain(const int powerChainId, const bool isPositiveZEnd, const 
   myid(powerChainId);
   isBarrel_ = inner_cabling_functions::isBarrel(subDetectorName);
   ringNumber_ = inner_cabling_functions::computeRingNumber(halfRingIndex);
-  isSmallerAbsZRingSide_ = inner_cabling_functions::isSmallerAbsZRingSide(halfRingIndex);
+  isSmallerAbsZRingHalf_ = inner_cabling_functions::isSmallerAbsZRingHalf(halfRingIndex);
 
   powerChainType_ = computePowerChainType(isBarrel_, layerDiskNumber, ringNumber_);
 

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -176,7 +176,17 @@ namespace inner_cabling_functions {
     }
     // tepx
     else if (subDetectorName == inner_cabling_tepx) {
-      numELinksPerModule = inner_cabling_numELinksPerModuleEndcap;
+      if (layerOrRingNumber == 1) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing1;
+      else if (layerOrRingNumber == 2) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing2;
+      else if (layerOrRingNumber == 3) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing3;
+      else if (layerOrRingNumber == 4) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing4;
+      else if (layerOrRingNumber == 5) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing5;
+      else { 
+	logERROR(any2str("Found ring number ") + any2str(layerOrRingNumber)
+		 + any2str(" in ") + any2str(inner_cabling_tepx)
+		 + any2str(". This is not supported.")
+		 );
+      }
     }
     // other
     else { 

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -113,13 +113,13 @@ namespace inner_cabling_functions {
 
 
   /*
-   * A given IT ring is divided by (X) side AND per (Z) side: hence notion of ring quarter.
-   * Each ring quarter is identified by a unique index.
+   * This identifies the ring number (associated to a given radius) + the (Z) side of the ring on which the module is located.
+   * The '(Z) side of a ring' identifies whether a module is at the low |Z| or at the high |Z| within the ring.
    */
-  const int computeRingQuarterIndex(const int ringNumber, const bool isSmallerAbsZRingSide) {
+  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingSide) {
     const int isSmallerAbsZRingSideIndex = (!isSmallerAbsZRingSide);
-    const int ringQuarterIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZRingSideIndex);
-    return ringQuarterIndex;
+    const int halfRingIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZRingSideIndex);
+    return halfRingIndex;
   }
 
 
@@ -127,8 +127,8 @@ namespace inner_cabling_functions {
    * Retrieve the ring index from the ring quarter idex.
    * This is possible because a ring quarter is a part of a ring.
    */
-  const int computeRingNumber(const int ringQuarterIndex) {
-    const int ringNumber = 1 + ringQuarterIndex / 2;
+  const int computeRingNumber(const int halfRingIndex) {
+    const int ringNumber = 1 + halfRingIndex / 2;
     return ringNumber;
   }
 
@@ -136,8 +136,8 @@ namespace inner_cabling_functions {
   /*
    * Retrieve, from the index, whether one is on one ring (Z) side or the other.
    */
-  const bool isSmallerAbsZRingSide(const int ringQuarterIndex) {
-    const bool isSmallerAbsZRingSide = (ringQuarterIndex % 2 ? false : true);
+  const bool isSmallerAbsZRingSide(const int halfRingIndex) {
+    const bool isSmallerAbsZRingSide = (halfRingIndex % 2 ? false : true);
     return isSmallerAbsZRingSide;
   }
 

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -81,6 +81,10 @@ namespace inner_cabling_functions {
 
   /*
    * Split IT per (Z) end and (X) side: hence per quarter.
+   * 1: (+X) side, (+Z) end
+   * 2: (-X) side, (+Z) end
+   * 3: (+X) side, (-Z) end
+   * 4: (-X) side, (-Z) end
    */
   const int computeInnerTrackerQuarterIndex(const bool isPositiveZEnd, const bool isPositiveXSide) {
     int innerTrackerQuarterIndex = 0;

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -116,9 +116,9 @@ namespace inner_cabling_functions {
    * This identifies the ring number (associated to a given radius) + the (Z) side of the ring on which the module is located.
    * The '(Z) side of a ring' identifies whether a module is at the low |Z| or at the high |Z| within the ring.
    */
-  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingHalf) {
-    const int isSmallerAbsZRingHalfIndex = (!isSmallerAbsZRingHalf);
-    const int halfRingIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZRingHalfIndex);
+  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZHalfRing) {
+    const int isSmallerAbsZHalfRingIndex = (!isSmallerAbsZHalfRing);
+    const int halfRingIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZHalfRingIndex);
     return halfRingIndex;
   }
 
@@ -136,9 +136,9 @@ namespace inner_cabling_functions {
   /*
    * Retrieve, from the index, whether one is on one ring (Z) side or the other.
    */
-  const bool isSmallerAbsZRingHalf(const int halfRingIndex) {
-    const bool isSmallerAbsZRingHalf = (halfRingIndex % 2 ? false : true);
-    return isSmallerAbsZRingHalf;
+  const bool isSmallerAbsZHalfRing(const int halfRingIndex) {
+    const bool isSmallerAbsZHalfRing = (halfRingIndex % 2 ? false : true);
+    return isSmallerAbsZHalfRing;
   }
 
 

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -116,9 +116,9 @@ namespace inner_cabling_functions {
    * This identifies the ring number (associated to a given radius) + the (Z) side of the ring on which the module is located.
    * The '(Z) side of a ring' identifies whether a module is at the low |Z| or at the high |Z| within the ring.
    */
-  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingSide) {
-    const int isSmallerAbsZRingSideIndex = (!isSmallerAbsZRingSide);
-    const int halfRingIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZRingSideIndex);
+  const int computeHalfRingIndex(const int ringNumber, const bool isSmallerAbsZRingHalf) {
+    const int isSmallerAbsZRingHalfIndex = (!isSmallerAbsZRingHalf);
+    const int halfRingIndex = (ringNumber < 1 ? 0 : (ringNumber - 1) * 2 + isSmallerAbsZRingHalfIndex);
     return halfRingIndex;
   }
 
@@ -136,9 +136,9 @@ namespace inner_cabling_functions {
   /*
    * Retrieve, from the index, whether one is on one ring (Z) side or the other.
    */
-  const bool isSmallerAbsZRingSide(const int halfRingIndex) {
-    const bool isSmallerAbsZRingSide = (halfRingIndex % 2 ? false : true);
-    return isSmallerAbsZRingSide;
+  const bool isSmallerAbsZRingHalf(const int halfRingIndex) {
+    const bool isSmallerAbsZRingHalf = (halfRingIndex % 2 ? false : true);
+    return isSmallerAbsZRingHalf;
   }
 
 

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -113,7 +113,7 @@ namespace inner_cabling_functions {
 
 
   /*
-   * A given IT ring is divided by (X) side AND per dee side: hence notion of ring quarter.
+   * A given IT ring is divided by (X) side AND per (Z) side: hence notion of ring quarter.
    * Each ring quarter is identified by a unique index.
    */
   const int computeRingQuarterIndex(const int ringNumber, const bool isSmallerAbsZRingSide) {

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -211,7 +211,7 @@ namespace insur {
    * Build an optical cabling map, which connects each module to a bundle, cable, DTC. 
    * Can actually be reused for power cables routing.
    * Please note that this is independant from any cable Material Budget consideration, which is done indepedently.
-   * The underlying cabling was designed for IT404, and will not work for any other layout.
+   * The underlying cabling was designed for IT613, and will not work for any other layout.
    */
   bool Squid::buildInnerCablingMap(const bool innerCablingOption) {
     startTaskClock("Building optical and power cabling map in the Inner Tracker.");
@@ -540,11 +540,11 @@ namespace insur {
 
 
   /**
-   * Add the Outer Tracker optical cabling map to the website.
+   * Add the Inner Tracker optical cabling map to the website.
    */
   bool Squid::reportInnerCablingMapSite(const bool innerCablingOption, const std::string layoutName) {
     startTaskClock("Creating IT Cabling map report.");
-    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT404 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT613 only. Forcing it on another layout is at your own risks (could require adaptations).");
     if (px) {
       // CREATE REPORT ON WEBSITE.
       v.innerCablingSummary(pixelAnalyzer, *px, site);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -9049,7 +9049,7 @@ namespace insur {
 	      std::stringstream powerChainInfo;
 	      powerChainInfo << myPowerChain->myid() << ","
 			     << any2str(myPowerChain->powerChainType()) << ","
-			     << any2str(myPowerChain->isBarrelLong()) << ",";
+			     << any2str(myPowerChain->isLongBarrel()) << ",";
 
 	      const std::vector<Module*>& myModules = myGBT->modules();
 	      for (const auto& module : myModules) {

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1514,7 +1514,7 @@ namespace insur {
       bothSidesName->setContent(0, 0, "Both cabling sides, summary:");
       filesContent->addItem(bothSidesName);
       // CMSSW MODULES DETIDS TO DTC IDS
-      myTextFile = new RootWTextFile(Form("CMSSWCablingMap%s.csv", name.c_str()), "CMMSW: Modules DetIds to DTCs Ids");
+      myTextFile = new RootWTextFile(Form("CMSSWCablingMap%s.csv", name.c_str()), "CMSSW: Modules DetIds to DTCs Ids");
       myTextFile->addText(createCMSSWOuterTrackerCablingMapCsv(tracker));
       filesContent->addItem(myTextFile);
 
@@ -1901,6 +1901,10 @@ namespace insur {
       // DTCs to modules
       myTextFile = new RootWTextFile(Form("%sTrackerDTCsToModules.csv", name.c_str()), "DTCs to modules");
       myTextFile->addText(createInnerTrackerDTCsToModulesCsv(myInnerCablingMap));
+      filesContent->addItem(myTextFile);
+      // CMSSW modules DetIds to DTC Ids
+      myTextFile = new RootWTextFile(Form("CMSSWCablingMap%s.csv", name.c_str()), "CMSSW: Modules DetIds to DTCs Ids");
+      myTextFile->addText(createCMSSWInnerTrackerCablingMapCsv(tracker));
       filesContent->addItem(myTextFile);
 
 
@@ -9075,6 +9079,16 @@ namespace insur {
     if (myDTCs.size() == 0) dtcsToModulesCsv << std::endl;
 
     return dtcsToModulesCsv.str();
+  }
+
+
+  /* Create csv file (Inner Tracker), summary on both cabling sides. Info needed by CMSSW: Modules DetIds to DTCIds.
+   */
+  std::string Vizard::createCMSSWInnerTrackerCablingMapCsv(const Tracker& tracker) {
+    CMSSWInnerTrackerCablingMapVisitor v;
+    v.preVisit();
+    tracker.accept(v);
+    return v.output();
   }
 
 


### PR DESCRIPTION
Adaptations to have the IT cabling map automatically computed on IT 613, which is now the default layout for the IT cabling map (instead of IT 404).

All results at:
http://ghugo.web.cern.ch/ghugo/layouts/IT_cabling/OT616_200_IT613/cablingInner.html 

Adaptations:
- **Changed number of e-links / module in TEPX Rings 1 and 2** (due to 2x2 modules instead of 1x2 modules, but also because of data rate in TEPX Ring 1).
- **Changed total number of modules which can be connected to the same serial power chain** (from 10 to 12).
- **Reimplemented isLongBarrel()**.
There was a regression. Now made it independent from the number of modules in a serial power chain.
- **Reimplemented intensity of current in serial power chain**.
There was a regression. Was previously dependent on ringNumber, now made it directly dependent on the module type (1x2 or 2x2 module).
- **Reimplemented GBTs assignment**. 
There was a (known) edge case on IT 612 that made the modules grouping into GBTs not uniform enough.
For example, for the modules grouping into GBTs: was getting (3+3+1) distribution within a given serial power chain, while we want (3+2+2).
- **Reimplemented TFPX and TEPX groupings into MFBs**.
The previous code was based on ring number, which is not ok with the new ring paradigm.
Instead, what we want to know is which dee the module is on.
Unfortunately, this info was not available at the geo level, so appropriate member functions providing dee info were added there as well.
- **Fixed coloring of DTC on double-disks on website**.
So that the color scheme is actually unique.
- **Added CMSSW Module DetId <-> IT DTC Id file**.


Selected results:
**IT 404:**
* _Modules colored by their connections to serial power chains._
The alternation of colors show the alternation of GBTs.
Each plot has 2 dees (one dee per (X) side).
One (Z) side of the 2 dees:
![O_img122](https://user-images.githubusercontent.com/11192654/60034795-a39c1500-96ab-11e9-8e45-2fa056fdb1b4.png)
The other (Z) side of the 2 dees:
![O_img123](https://user-images.githubusercontent.com/11192654/60034799-a72f9c00-96ab-11e9-9243-e043ba7673a5.png)
* _Modules colored by their connections to MFBs._
The plot has a double-disk.
![o_img129](https://user-images.githubusercontent.com/11192654/60034804-aa2a8c80-96ab-11e9-9df1-60a469144d47.png)

**IT 613:**
* _Modules colored by their connections to serial power chains._
The alternation of colors show the alternation of GBTs.
Each plot has 2 dees (one dee per (X) side).
One (Z) side of the 2 dees:
![img140](https://user-images.githubusercontent.com/11192654/60034824-b31b5e00-96ab-11e9-8719-2aec4d6ac535.png)
The other (Z) side of the 2 dees:
![img141](https://user-images.githubusercontent.com/11192654/60034827-b57db800-96ab-11e9-8ad4-5a9be1e578ec.png)
* _Modules colored by their connections to MFBs._
The plot has a double-disk.
![img147](https://user-images.githubusercontent.com/11192654/60034833-b878a880-96ab-11e9-870a-99532e04b3c1.png)

