### PR TITLE
Introduce a generic vectorial formula to compute track incident angles. 

### DIFF
--- a/include/CoordinateOperations.hh
+++ b/include/CoordinateOperations.hh
@@ -5,56 +5,41 @@
  *      Author: stefano
  */
 
-#ifndef CORDINATEOPERATIONS_H_
-#define CORDINATEOPERATIONS_H_
+#ifndef CORDINATEOPERATIONS_H
+#define CORDINATEOPERATIONS_H
 
-#include <Math/Vector3Dfwd.h>
 #include <vector>
+#include <Math/Vector3Dfwd.h>
+#include <TVector3.h>
 #include "Polygon3d.hh"
 #include "global_funcs.hh"
 
 using ROOT::Math::XYZVector;
 
+
 namespace CoordinateOperations {
 
-/*
-  template<class Polygon> std::vector<XYZVector> computeDistanceVectors(const Polygon& polygon) {
-    std::vector<XYZVector> distanceVectors;
-    auto vertex0 = polygon.begin();
-    for(auto vertex1 = polygon.begin()+1; vertex1 != polygon.end(); vertex0 = vertex1++) {
-      XYZVector directionVector = (*vertex0 - *vertex1).Unit();
-      if (vertex0->Dot(directionVector) >= 0.0) {
-        distanceVectors.push_back(*vertex0);
-      }else if (vertex1->Dot(directionVector) <= 0.0) {
-        distanceVectors.push_back(*vertex1);
-      } else {
-
-        XYZVector appo = *vertex0 - (vertex0->Dot(directionVector) * directionVector);
-
-        distanceVectors.push_back(appo);
-      }
-    }
-    return distanceVectors;
+  /*
+   * Convert XYZVector or Polar3DVector into a TVector. 
+   * TVector is much more generic, and allows Angle() operation for example, which are not permitted with the old coord classes.
+   */
+  template<class CoordVector> const TVector3 convertCoordVectorToTVector3(const CoordVector& v) {
+    return TVector3(v.X(), v.Y(), v.Z());
   }
-*/
 
-/**
- * Compute the polygon whose vertices are all the middles of the edges of the polygon sepcified as a parameter.
- */
-  template<class Polygon> Polygon* computeMidPolygon(const Polygon& polygon) {
-    Polygon* midPoly = new Polygon();
 
-    XYZVector v0 = polygon.getVertex(0);
-    for (int i = 1; i < polygon.getNumSides() + 1; i++) {
-      XYZVector v1 = polygon.getVertex(i % polygon.getNumSides());
-      XYZVector vMid = (v0 + v1) / 2.;
-      *midPoly << vMid;
-      v0 = v1;   
-    }
-    return midPoly;
+  /*
+   * Returns projection of v1 on the plane which has v2 as a normal.
+   * WARNING!! Here, v2 needs to be unitary: ||v2|| = 1.
+   * || || used is the euclidian norm on R3.
+   */
+  template<class GeoVector> GeoVector projectv1OnPlaneOfNormalUnitv2(const GeoVector& v1, const GeoVector& v2) {
+    return (v1 - v1.Dot(v2) * v2);
   }
+
 
   XYZVector computeDistanceVector(const XYZVector& v0, const XYZVector& v1); // minimum distance vector (from the origin) of the segment defined by v0 and v1
+
   template<class Polygon> std::vector<XYZVector> computeDistanceVectors(const Polygon& polygon) {
     std::vector<XYZVector> distanceVectors;
     XYZVector v0 = polygon.getVertex(0);
@@ -91,6 +76,24 @@ namespace CoordinateOperations {
     return p;
   }
 
+
+  /**
+   * Compute the polygon whose vertices are all the middles of the edges of the polygon sepcified as a parameter.
+   */
+  template<class Polygon> Polygon* computeMidPolygon(const Polygon& polygon) {
+    Polygon* midPoly = new Polygon();
+
+    XYZVector v0 = polygon.getVertex(0);
+    for (int i = 1; i < polygon.getNumSides() + 1; i++) {
+      XYZVector v1 = polygon.getVertex(i % polygon.getNumSides());
+      XYZVector vMid = (v0 + v1) / 2.;
+      *midPoly << vMid;
+      v0 = v1;   
+    }
+    return midPoly;
+  }
+
+
 /**
  * Compute the envelope polygon (2n vertices) from a polygon (n vertices) specified as a parameter.
  * param basePolygon
@@ -121,4 +124,4 @@ namespace CoordinateOperations {
 
 
 
-#endif /* CORDINATEOPERATIONS_H_ */
+#endif /* CORDINATEOPERATIONS_H */

--- a/include/CoordinateOperations.hh
+++ b/include/CoordinateOperations.hh
@@ -32,6 +32,8 @@ namespace CoordinateOperations {
    * Returns projection of v1 on the plane which has v2 as a normal.
    * WARNING!! Here, v2 needs to be unitary: ||v2|| = 1.
    * || || used is the euclidian norm on R3.
+   * Dot is the scalar product associated to || ||.
+   * NB: Very weird that this is not provided by default, v1.Perp(v2) provides a scalar but not a vector.
    */
   template<class GeoVector> GeoVector projectv1OnPlaneOfNormalUnitv2(const GeoVector& v1, const GeoVector& v2) {
     return (v1 - v1.Dot(v2) * v2);

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -330,19 +330,19 @@ public:
   double minTheta() const { return MIN(basePoly().getVertex(0).Theta(), basePoly().getVertex(2).Theta()); }
   double thetaAperture() const { return maxTheta() - minTheta(); }
 
-  // IT MODULES ONLY!! FOR OT MODULES, THIS WAS NOT STUDIED!!!!
-  // Get CMSSW local X orientation on sensor plane. Ie, for barrel modules, the Lorentz drift orientation!!
-  // NB: The direction is correct but the sense might be the opposite in TFPX / TEPX, but does not matter, as there is no drift there.
+  // Get local X orientation on sensor plane. Ie, for barrel modules, the Lorentz drift orientation!!
+  // NB: This is not garanteed at all to match CMSSW frame of reference orientation, which is independent.
   const TVector3 getLocalX() const {
-    const XYZVector& nonOrientedLocalX = basePoly().getVertex(3) - basePoly().getVertex(0);
-    const XYZVector& orientedLocalX = (!flipped() ? nonOrientedLocalX : -nonOrientedLocalX); // a flip operation does not move the polygon vertexes, hence desserves special treatment.
-    return CoordinateOperations::convertCoordVectorToTVector3(orientedLocalX).Unit();
+    XYZVector localX = basePoly().getVertex(3) - basePoly().getVertex(0);
+    if (flipped()) { localX *= -1; } // a flip operation does not move the polygon vertexes, hence desserves special treatment.
+    if ( fabs(tiltAngle() - M_PI/2.) < insur::geom_zero || !isPixelModule() ) { localX *= -1; }
+    return CoordinateOperations::convertCoordVectorToTVector3(localX).Unit();
   }
-  // IT MODULES ONLY!! FOR OT MODULES, THIS WAS NOT STUDIED!!!!
-  // Get CMSSW local Y orientation on sensor plane.
-  // NB: The direction is correct but the sense might be the opposite in TFPX / TEPX, but does not matter.
+  // Get local Y orientation on sensor plane.
+  // NB: This is not garanteed at all to match CMSSW frame of reference orientation, which is independent.
   const TVector3 getLocalY() const { 
-    const XYZVector& localY = basePoly().getVertex(0) - basePoly().getVertex(1);
+    XYZVector localY = basePoly().getVertex(0) - basePoly().getVertex(1);
+    if ( fabs(tiltAngle() - M_PI/2.) < insur::geom_zero || !isPixelModule() ) { localY *= -1; }
     return CoordinateOperations::convertCoordVectorToTVector3(localY).Unit();
   }
 

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -255,13 +255,13 @@ public:
   // RETURN LOCAL SPATIAL RESOLUTION
   // This resolution is either nominal, either from parametrization.
   const double resolutionLocalX(const TVector3& trackDirection) const;
-  const double resolutionLocalY(const double theta) const;
+  const double resolutionLocalY(const TVector3& trackDirection) const;
 
   // Used to compute local parametrized spatial resolution.
   const bool hasAnyResolutionLocalXParam() const;
   const bool hasAnyResolutionLocalYParam() const;
   const double alpha(const TVector3& trackDirection) const;
-  const double beta(const double theta) const;
+  const double beta(const TVector3& trackDirection) const;
  
   // STATISTICS ON LOCAL SPATIAL RESOLUTION
   accumulator_set<double, features<tag::count, tag::mean, tag::variance, tag::sum, tag::moment<2>>> rollingParametrizedResolutionLocalX;
@@ -429,7 +429,7 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
 protected:
   // Used to compute local parametrized spatial resolution.
   virtual const double calculateParameterizedResolutionLocalX(const TVector3& trackDirection) const;
-  virtual const double calculateParameterizedResolutionLocalY(const double theta) const;
+  virtual const double calculateParameterizedResolutionLocalY(const TVector3& trackDirection) const;
   const double calculateParameterizedResolutionLocalAxis(const double fabsTanDeepAngle, const bool isLocalXAxis) const;
 
   MaterialObject materialObject_;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -254,13 +254,13 @@ public:
 
   // RETURN LOCAL SPATIAL RESOLUTION
   // This resolution is either nominal, either from parametrization.
-  const double resolutionLocalX(const double phi) const;
+  const double resolutionLocalX(const TVector3& trackDirection) const;
   const double resolutionLocalY(const double theta) const;
 
   // Used to compute local parametrized spatial resolution.
   const bool hasAnyResolutionLocalXParam() const;
   const bool hasAnyResolutionLocalYParam() const;
-  const double alpha(const double trackPhi) const;
+  const double alpha(const TVector3& trackDirection) const;
   const double beta(const double theta) const;
  
   // STATISTICS ON LOCAL SPATIAL RESOLUTION
@@ -329,6 +329,22 @@ public:
   double maxTheta() const { return MAX(basePoly().getVertex(0).Theta(), basePoly().getVertex(2).Theta()); }
   double minTheta() const { return MIN(basePoly().getVertex(0).Theta(), basePoly().getVertex(2).Theta()); }
   double thetaAperture() const { return maxTheta() - minTheta(); }
+
+  // IT MODULES ONLY!! FOR OT MODULES, THIS WAS NOT STUDIED!!!!
+  // Get CMSSW local X orientation on sensor plane. Ie, for barrel modules, the Lorentz drift orientation!!
+  // NB: The direction is correct but the sense might be the opposite in TFPX / TEPX, but does not matter, as there is no drift there.
+  const TVector3 getLocalX() const {
+    const XYZVector& nonOrientedLocalX = basePoly().getVertex(3) - basePoly().getVertex(0);
+    const XYZVector& orientedLocalX = (!flipped() ? nonOrientedLocalX : -nonOrientedLocalX); // a flip operation does not move the polygon vertexes, hence desserves special treatment.
+    return CoordinateOperations::convertCoordVectorToTVector3(orientedLocalX).Unit();
+  }
+  // IT MODULES ONLY!! FOR OT MODULES, THIS WAS NOT STUDIED!!!!
+  // Get CMSSW local Y orientation on sensor plane.
+  // NB: The direction is correct but the sense might be the opposite in TFPX / TEPX, but does not matter.
+  const TVector3 getLocalY() const { 
+    const XYZVector& localY = basePoly().getVertex(0) - basePoly().getVertex(1);
+    return CoordinateOperations::convertCoordVectorToTVector3(localY).Unit();
+  }
 
   const Sensors& sensors() const { return sensors_; }
   const MaterialObject& materialObject() const { return materialObject_; }
@@ -412,7 +428,7 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
 
 protected:
   // Used to compute local parametrized spatial resolution.
-  virtual const double calculateParameterizedResolutionLocalX(const double phi) const;
+  virtual const double calculateParameterizedResolutionLocalX(const TVector3& trackDirection) const;
   virtual const double calculateParameterizedResolutionLocalY(const double theta) const;
   const double calculateParameterizedResolutionLocalAxis(const double fabsTanDeepAngle, const bool isLocalXAxis) const;
 

--- a/include/Hit.hh
+++ b/include/Hit.hh
@@ -159,6 +159,7 @@ protected:
 
 private:
   
+  const TVector3 getTrackDirection() const;
   double getTrackPhi();
   double getTrackTheta();
 

--- a/include/Track.hh
+++ b/include/Track.hh
@@ -74,7 +74,7 @@ public:
   void addEfficiency();
 
   //! Set track polar angle - theta, azimuthal angle - phi, particle transverse momentum - pt (signed: + -> particle in-out, - -> particle out-in)
-  const Polar3DVector& setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt);
+  const TVector3& setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt);
 
   //! Set track origin
   void setOrigin(const XYZVector& origin) { m_origin = origin; }
@@ -173,7 +173,7 @@ public:
   double getRho(double zPos) const    { return (getRadius(zPos)!=0 ? 1/getRadius(zPos) : 0);}
   double getRadius(double zPos) const { return fabs(m_pt / (0.3 * getMagField(zPos))); }
 
-  const Polar3DVector& getDirection() const { return m_direction; }
+  const TVector3& getDirection() const { return m_direction; }
   const XYZVector&     getOrigin() const    { return m_origin; }
 
   //! TODO: Document!!! Originally part of hit.cc class
@@ -271,8 +271,8 @@ protected:
   double m_eta;               //!< Automatically calculated from eta at [0,0]
   double m_pt;                //!< Particle transverse momentum (assuming B = fce of z only -> pT doesn't change along the path, only radius changes), pT sign: + -> particle traverses inside-out, - -> particle traverses outside-in
 
-  Polar3DVector  m_direction; //!< Track parameters as a 3-vector: R, theta, phi
-  XYZVector      m_origin;    //!< Track origin as a 3-vector: X, Y, Z TODO: For tracking model origin assumed to be at [0,0,0]
+  TVector3  m_direction;      //!< Track parameters as a 3D-vector. Can access Theta(), Phi().
+  XYZVector m_origin;         //!< Track origin as a 3-vector: X, Y, Z TODO: For tracking model origin assumed to be at [0,0,0]
 
   bool   m_reSortHits;        //!< Caching whether necessary to resort hits (sorting will be done again if a new hit added or direction changed)
   bool   m_covRPhiDone;       //!< Caching whether errors in R-Phi already calculated (will be recalculated, if direction of propagation changed, or added new hit etc.)

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2251,9 +2251,10 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 		const auto& hitModule = (*iHit)->getHitModule();
 		// If any parameter for resolution on local X coordinate specified for hitModule, fill maps and distributions
 		if (hitModule->hasAnyResolutionLocalXParam()) {
+		  const TVector3& trackDirection = myTrack->getDirection();
 		  double trackPhi = myTrack->getPhi();
-		  double cotAlpha = 1./tan(hitModule->alpha(trackPhi));
-		  double resolutionLocalX = hitModule->resolutionLocalX(trackPhi)/Units::um; // um
+		  double cotAlpha = 1./tan(hitModule->alpha(trackDirection));
+		  double resolutionLocalX = hitModule->resolutionLocalX(trackDirection)/Units::um; // um
 		  if ( hitModule->subdet() == BARREL ) {
 		    trackPhiBarrelDistribution_[myTag].Fill(femod(trackPhi, 2.*M_PI));
 		    incidentAngleLocalXBarrelDistribution_[myTag].Fill(cotAlpha);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2249,11 +2249,13 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 	      if ((*iHit)->isActive() && (*iHit)->getHitModule()) {
 		
 		const auto& hitModule = (*iHit)->getHitModule();
+
+		const TVector3& trackDirection = myTrack->getDirection();
+
 		// If any parameter for resolution on local X coordinate specified for hitModule, fill maps and distributions
 		if (hitModule->hasAnyResolutionLocalXParam()) {
-		  // trackPhi is misleading, as actually the dependency is also in eta (in TFPX and TEPX).
-		  double trackPhi = myTrack->getPhi();
-		  const TVector3& trackDirection = myTrack->getDirection();
+		  // trackPhi is misleading, as actually the dependency is also in eta (in the forward).
+		  double trackPhi = myTrack->getPhi();		  
 		  double cotAlpha = 1./tan(hitModule->alpha(trackDirection));
 		  double resolutionLocalX = hitModule->resolutionLocalX(trackDirection)/Units::um; // um
 		  if ( hitModule->subdet() == BARREL ) {
@@ -2271,10 +2273,10 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 		}
 		// If any parameter for resolution on local Y coordinate specified for hitModule, fill maps and distributions
 		if (hitModule->hasAnyResolutionLocalYParam()) {
+		  // trackEta is misleading, as actually the dependency is also in track vector's phi (in both barrel and forward).
 		  double trackEta = myTrack->getEta();
-		  double trackTheta = myTrack->getTheta();
-		  double absCotBeta = fabs(1./tan(hitModule->beta(trackTheta)));
-		  double resolutionLocalY = hitModule->resolutionLocalY(trackTheta)/Units::um; // um
+		  double absCotBeta = fabs(1./tan(hitModule->beta(trackDirection)));
+		  double resolutionLocalY = hitModule->resolutionLocalY(trackDirection)/Units::um; // um
 		  if ( hitModule->subdet() == BARREL ) {
 		    trackEtaBarrelDistribution_[myTag].Fill(trackEta);
 		    incidentAngleLocalYBarrelDistribution_[myTag].Fill(absCotBeta);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2112,8 +2112,8 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 
       const double incidentAngleXBarrelMin = -0.6;
       const double incidentAngleXBarrelMax = 0.6;
-      const double incidentAngleXEndcapsMin = -0.3;
-      const double incidentAngleXEndcapsMax = 0.3;
+      const double incidentAngleXEndcapsMin = -0.1;
+      const double incidentAngleXEndcapsMax = 0.1;
       const double incidentAngleYBarrelMin = 0.;
       const double incidentAngleYBarrelMax = 10.;
       const double incidentAngleYEndcapsMin = 0.;
@@ -2251,8 +2251,9 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 		const auto& hitModule = (*iHit)->getHitModule();
 		// If any parameter for resolution on local X coordinate specified for hitModule, fill maps and distributions
 		if (hitModule->hasAnyResolutionLocalXParam()) {
-		  const TVector3& trackDirection = myTrack->getDirection();
+		  // trackPhi is misleading, as actually the dependency is also in eta (in TFPX and TEPX).
 		  double trackPhi = myTrack->getPhi();
+		  const TVector3& trackDirection = myTrack->getDirection();
 		  double cotAlpha = 1./tan(hitModule->alpha(trackDirection));
 		  double resolutionLocalX = hitModule->resolutionLocalX(trackDirection)/Units::um; // um
 		  if ( hitModule->subdet() == BARREL ) {

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2112,8 +2112,8 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 
       const double incidentAngleXBarrelMin = -0.6;
       const double incidentAngleXBarrelMax = 0.6;
-      const double incidentAngleXEndcapsMin = -0.3;
-      const double incidentAngleXEndcapsMax = 0.3;
+      const double incidentAngleXEndcapsMin = -0.1;
+      const double incidentAngleXEndcapsMax = 0.1;
       const double incidentAngleYBarrelMin = 0.;
       const double incidentAngleYBarrelMax = 10.;
       const double incidentAngleYEndcapsMin = 0.;

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2112,8 +2112,8 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
 
       const double incidentAngleXBarrelMin = -0.6;
       const double incidentAngleXBarrelMax = 0.6;
-      const double incidentAngleXEndcapsMin = -0.1;
-      const double incidentAngleXEndcapsMax = 0.1;
+      const double incidentAngleXEndcapsMin = -0.3;
+      const double incidentAngleXEndcapsMax = 0.3;
       const double incidentAngleYBarrelMin = 0.;
       const double incidentAngleYBarrelMax = 10.;
       const double incidentAngleYEndcapsMin = 0.;

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2110,8 +2110,8 @@ void Analyzer::calculateGraphsConstP(const int& parameter,
       const double resoYMin = 0.;
       const double resoYMax = 60.;
 
-      const double incidentAngleXBarrelMin = -0.3;
-      const double incidentAngleXBarrelMax = 0.3;
+      const double incidentAngleXBarrelMin = -0.6;
+      const double incidentAngleXBarrelMax = 0.6;
       const double incidentAngleXEndcapsMin = -0.3;
       const double incidentAngleXEndcapsMax = 0.3;
       const double incidentAngleYBarrelMin = 0.;

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -518,16 +518,19 @@ const bool DetectorModule::hasAnyResolutionLocalYParam() const {
 /*
  * Compute the alpha incident angle.
  * See README for definition of alpha angle.
- * alpha = (X, track) (oriented angle between 2 vectors).
+ * alpha = (X, track) (oriented angle between the 2 vectors).
  * X is the vector of the Lorentz drift and track is the vector of the track.
  */
 const double DetectorModule::alpha(const double trackPhi) const {
-  double deltaPhi = trackPhi - (center().Phi() + skewAngle());
-  if (fabs(deltaPhi) > M_PI/2.) {
-    if (deltaPhi < 0.) deltaPhi += 2.*M_PI;
-    else deltaPhi -= 2.*M_PI;
+  const double sensorNormalToTrackDeltaPhi = trackPhi - (center().Phi() + skewAngle());
+
+  const double sensorXToTrackDeltaPhi = (!flipped() ? M_PI / 2. + sensorNormalToTrackDeltaPhi : M_PI / 2. - sensorNormalToTrackDeltaPhi);
+
+  const double alpha = femod(sensorXToTrackDeltaPhi, 2.*M_PI);
+
+  if (alpha >= M_PI) { 
+    logERROR("alpha angle should be in ]0 180[, but found alpha = " + any2str(alpha * 180. / M_PI)); 
   }
-  const double alpha = deltaPhi + M_PI / 2.;
   return alpha;
 }
 

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -542,7 +542,7 @@ const double DetectorModule::alpha(const TVector3& trackDirection) const {
 
   /* Keep old formula.
      This is only true in (CMS_X, CMS_Y) plane.
-     This is a projection of the new formula onto the (CMS_X, CMS_Y) plane.
+     This is a projection of the new formula onto the (CMS_X, CMS_Y) plane (perfect match).
 
      const double trackPhi = trackDirection.Phi();
 
@@ -565,7 +565,9 @@ const double DetectorModule::alpha(const TVector3& trackDirection) const {
  * This depends on the theta-angle of the track and the tilt angle of the Module.
  */
 const double DetectorModule::beta(const double theta) const { 
-  return theta + tiltAngle(); 
+  const double beta = theta + tiltAngle();
+  const double orientedBeta = (fabs(tiltAngle() - M_PI/2.) < insur::geom_zero ? beta : (M_PI - beta));
+  return orientedBeta;
 }
 
 

--- a/src/Hit.cc
+++ b/src/Hit.cc
@@ -178,7 +178,7 @@ void Hit::fillModuleLocalResolutionStats() {
   } else {
     if (m_hitModule) {
       // Compute hit module local resolution.
-      const double resolutionLocalX = m_hitModule->resolutionLocalX(getTrackPhi());
+      const double resolutionLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
       const double resolutionLocalY = m_hitModule->resolutionLocalY(getTrackTheta());
       
       // Fill the module statistics.
@@ -205,6 +205,19 @@ int Hit::getLayerOrDiscID() const {
 
   if (m_hitModule && m_hitModule->getConstModuleCap()!=nullptr) return m_hitModule->getConstModuleCap()->getLayerOrDiscID(); else return -1;
 }
+
+
+/**
+ * Get the track vector.
+ */
+const TVector3 Hit::getTrackDirection() const {
+
+  if (m_track==nullptr) {
+    logWARNING("Hit::getTrackDirection -> no track assigned, will return zero!");
+    return TVector3();
+  }
+  return m_track->getDirection();
+};
 
 
 /**
@@ -274,7 +287,7 @@ double Hit::getResolutionRphi(double trackRadius) {
       double B         = A/sqrt(1-A*A);
       double tiltAngle = m_hitModule->tiltAngle();
       double skewAngle = m_hitModule->skewAngle();
-      const double resLocalX = m_hitModule->resolutionLocalX(getTrackPhi());
+      const double resLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
       const double resLocalY = m_hitModule->resolutionLocalY(getTrackTheta());
 
       // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
@@ -326,7 +339,7 @@ double Hit::getResolutionZ(double trackRadius) {
         double D         = m_track->getCotgTheta()/sqrt(1-A*A);
         double tiltAngle = m_hitModule->tiltAngle();
         double skewAngle = m_hitModule->skewAngle();
-        const double resLocalX = m_hitModule->resolutionLocalX(getTrackPhi());
+        const double resLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
         const double resLocalY = m_hitModule->resolutionLocalY(getTrackTheta());
 
         // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)

--- a/src/Hit.cc
+++ b/src/Hit.cc
@@ -179,7 +179,7 @@ void Hit::fillModuleLocalResolutionStats() {
     if (m_hitModule) {
       // Compute hit module local resolution.
       const double resolutionLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
-      const double resolutionLocalY = m_hitModule->resolutionLocalY(getTrackTheta());
+      const double resolutionLocalY = m_hitModule->resolutionLocalY(getTrackDirection());
       
       // Fill the module statistics.
       if (m_hitModule->hasAnyResolutionLocalXParam()) m_hitModule->rollingParametrizedResolutionLocalX(resolutionLocalX);
@@ -288,7 +288,7 @@ double Hit::getResolutionRphi(double trackRadius) {
       double tiltAngle = m_hitModule->tiltAngle();
       double skewAngle = m_hitModule->skewAngle();
       const double resLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
-      const double resLocalY = m_hitModule->resolutionLocalY(getTrackTheta());
+      const double resLocalY = m_hitModule->resolutionLocalY(getTrackDirection());
 
       // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
       double resolutionRPhi = sqrt(pow((B*sin(skewAngle)*cos(tiltAngle) + cos(skewAngle)) * resLocalX,2) + pow(B*sin(tiltAngle) * resLocalY,2));
@@ -340,7 +340,7 @@ double Hit::getResolutionZ(double trackRadius) {
         double tiltAngle = m_hitModule->tiltAngle();
         double skewAngle = m_hitModule->skewAngle();
         const double resLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
-        const double resLocalY = m_hitModule->resolutionLocalY(getTrackTheta());
+        const double resLocalY = m_hitModule->resolutionLocalY(getTrackDirection());
 
         // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
         double resolutionZ = sqrt(pow(((D*cos(tiltAngle) + sin(tiltAngle))*sin(skewAngle)) * resLocalX,2) + pow((D*sin(tiltAngle) + cos(tiltAngle)) * resLocalY,2));

--- a/src/Track.cc
+++ b/src/Track.cc
@@ -503,7 +503,7 @@ void Track::addEfficiency() {
 // Set track polar angle - theta, azimuthal angle - phi, particle transverse momentum - pt
 // (magnetic field obtained automatically from SimParms singleton class)Setter for the track azimuthal angle.
 //
-const Polar3DVector& Track::setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt) {
+const TVector3& Track::setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt) {
 
   m_theta     = newTheta;
   m_cotgTheta = 1/tan(newTheta);
@@ -511,8 +511,10 @@ const Polar3DVector& Track::setThetaPhiPt(const double& newTheta, const double& 
   m_phi       = newPhi;
   m_pt        = newPt;
 
-  if (m_pt>=0) m_direction.SetCoordinates(+1, m_theta, m_phi); // Particle inside-out
-  else         m_direction.SetCoordinates(-1, m_theta, m_phi); // Particle outside-in
+  Polar3DVector polarDirection;
+  if (m_pt>=0) polarDirection.SetCoordinates(+1, m_theta, m_phi); // Particle inside-out
+  else         polarDirection.SetCoordinates(-1, m_theta, m_phi); // Particle outside-in
+  m_direction = CoordinateOperations::convertCoordVectorToTVector3(polarDirection);
 
   // Clear all previously assigned hits -> hits need to be recalculated
   m_hits.clear();


### PR DESCRIPTION
Introduce a generic vectorial formula to compute track incident angles alpha and beta.
The new formula extends the old formulae, which were only 'projections' of the generic formula into planes.

alpha and beta angles are from Fig. 9 from [1].

This allow to have the incident angles directly computed for any sensor orientation in space. 
Notably, here, this allows to have correct calculation of the incident angles in the case of skewed ladders (was in the to-do list).

This new, more generic formula, also ends up being more accurate. It reveals dependencies which were not thought of in the following cases:
- alpha calculation (in the forward).
- beta angle depends mostly on track vector's theta, but actually depends on track vector's phi as well! (everywhere).

[1] https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=5401774&tag=1 

NB: TO DO:
The skew angle is still not taken into account in:
- Material Budget calculation: incident angle not corrected.
- Zbynek s formulae in Hit.cc and Track.cc with skewAngle: they should be checked, no guarantee they are correct.