### PR TITLE
Add IT 614: TBPX portcards placed between TFPX disks 6 and 7.

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
@@ -1,0 +1,38 @@
+// TBPX second-conversion stations (service cylinder)
+// twisted pairs -> GBT
+
+
+// conversion station length: 43 mm
+// distance between conversion stations: 3 mm
+
+Station {
+  stationName BPIX1
+  type second
+  minZ 900.00
+  maxZ 943.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+
+Station {
+  stationName BPIX2
+  type second
+  minZ 946.00
+  maxZ 989.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+
+Station {
+  stationName BPIX3
+  type second
+  minZ 992.00
+  maxZ 1035.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+
+Station {
+  stationName BPIX4
+  type second
+  minZ 1038.00
+  maxZ 1081.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
@@ -1,0 +1,62 @@
+// TFPX second-conversion stations (service cylinder)
+// twisted pairs -> GBT
+
+// distance from disk center: 13 mm
+// conversion station length: 43 mm
+
+Station {
+  stationName FPIX1
+  type second
+  minZ 263.00
+  maxZ 306.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX2
+  type second
+  minZ 332.76
+  maxZ 375.76
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX3
+  type second
+  minZ 421.99
+  maxZ 464.99
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX4
+  type second
+  minZ 536.11
+  maxZ 579.11
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX5
+  type second
+  minZ 682.08
+  maxZ 725.08
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX6
+  type second
+  minZ 853.78
+  maxZ 896.78
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX7
+  type second
+  minZ 1122.57
+  maxZ 1165.57
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX8
+  type second
+  minZ 1413.00
+  maxZ 1456.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_1_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_1_4.cfg
@@ -1,0 +1,66 @@
+  Barrel PXB {
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
+    
+    zOverlap -1.3 // 1.3mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity 1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      numRods 12
+    }
+    Layer 2 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+    }
+    Layer 3 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+    }
+    Layer 4 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_4.cfg
@@ -1,0 +1,71 @@
+  Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2 
+    bigDelta 4 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+    Disk 1 { placeZ 250.00 }
+    Disk 2 { placeZ 319.76 }
+    Disk 3 { placeZ 408.99 }
+    Disk 4 { placeZ 523.11 }
+    Disk 5 { placeZ 669.08 }
+    Disk 6 { placeZ 840.78 }     // -15 mm, optimal was: Z = 855.78 mm
+    Disk 7 { placeZ 1109.57 }    // +15 mm, optimal was: Z = 1094.57 mm
+    Disk 8 { placeZ 1400.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_4.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_1_4.cfg
+  @include ../Pixel_V6/FPIX1_6_1_4.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}


### PR DESCRIPTION
Same as IT 613 but with:
Disk 6 : -15 mm.
Disk 7: + 15mm.
TBPX conversion stations placed between Disk 6 and Disk 7.

**IT 613:**
![2](https://user-images.githubusercontent.com/11192654/66380986-be736a80-e9b8-11e9-89a8-2846abf27d66.png)


**IT 614:**
![matMapR001](https://user-images.githubusercontent.com/11192654/66380871-83713700-e9b8-11e9-87c8-d5bbb429bd80.png)