### PR TITLE
Riccardo s new parametrization: lower threshold: 1500 e- -> 1000 e-

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Resolutions/100x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/Resolutions/100x100
@@ -1,30 +1,32 @@
 // Parametrization by Riccardo del Burgo.
 // Simulation parameters:
 // sensor thickness: 150 um
-// threshold= 1500 e-
+// threshold: 1000 e-
+// digitization (4 bits)
+// voltage: 400V
 // gaussian noise: μ = 0 e-, σ = 120 e-
-// μRH= 0.1078
+// μRH: 0.053
 
 // pitch in X = 100 um. 
-resolutionLocalXParam0 1.20601e-02       // mm
-resolutionLocalXParam1 2.28337e-03       // mm
-resolutionLocalXParam2 4.08651e-03       // mm
-resolutionLocalXParam3 8.26078e+00        
-resolutionLocalXParam4 -2.91486e+00     
-resolutionLocalXParam5  7.01211e+06      // mm
-resolutionLocalXParam6 -1.04395e+01      
-resolutionLocalXParam7 1.67015e+00      
-resolutionLocalXParam8 -6.14105e-03      // mm
-resolutionLocalXParam9 8.40081e-01      
+resolutionLocalXParam0 22.4684e-03       // mm
+resolutionLocalXParam1 5.91399e-03       // mm
+resolutionLocalXParam2 9.77838e-03       // mm
+resolutionLocalXParam3 5.14923        
+resolutionLocalXParam4 93.3833    
+resolutionLocalXParam5 -3.5427e-03       // mm
+resolutionLocalXParam6 1.39766     
+resolutionLocalXParam7 -0.156411   
+resolutionLocalXParam8 -19.0808e-03      // mm
+resolutionLocalXParam9 1.50209   
 
 // pitch in Y = 100 um.
-resolutionLocalYParam0 1.20601e-02       // mm
-resolutionLocalYParam1 2.28337e-03       // mm
-resolutionLocalYParam2 4.08651e-03       // mm
-resolutionLocalYParam3 8.26078e+00        
-resolutionLocalYParam4 -2.91486e+00     
-resolutionLocalYParam5  7.01211e+06      // mm
-resolutionLocalYParam6 -1.04395e+01      
-resolutionLocalYParam7 1.67015e+00      
-resolutionLocalYParam8 -6.14105e-03      // mm
-resolutionLocalYParam9 8.40081e-01 
+resolutionLocalYParam0 22.4684e-03       // mm
+resolutionLocalYParam1 5.91399e-03       // mm
+resolutionLocalYParam2 9.77838e-03       // mm
+resolutionLocalYParam3 5.14923        
+resolutionLocalYParam4 93.3833    
+resolutionLocalYParam5 -3.5427e-03       // mm
+resolutionLocalYParam6 1.39766     
+resolutionLocalYParam7 -0.156411   
+resolutionLocalYParam8 -19.0808e-03      // mm
+resolutionLocalYParam9 1.50209 

--- a/config/stdinclude/CMS_Phase2/Pixel/Resolutions/25x100
+++ b/config/stdinclude/CMS_Phase2/Pixel/Resolutions/25x100
@@ -1,30 +1,32 @@
 // Parametrization by Riccardo del Burgo.
 // Simulation parameters:
 // sensor thickness: 150 um
-// threshold= 1500 e-
+// threshold: 1000 e-
+// digitization (4 bits)
+// voltage: 400V
 // gaussian noise: μ = 0 e-, σ = 120 e-
-// μRH= 0.1078
+// μRH: 0.053
 
 // pitch in X = 25 um. 
-resolutionLocalXParam0 -1.65887e-03      // mm
-resolutionLocalXParam1 -2.22576e-03      // mm
-resolutionLocalXParam2 1.17684e-02       // mm
-resolutionLocalXParam3 2.10522e+00      
-resolutionLocalXParam4 1.61396e+00      
-resolutionLocalXParam5 1.40810e-02       // mm
-resolutionLocalXParam6 -1.18373e-01       
-resolutionLocalXParam7 1.08128e-01      
-resolutionLocalXParam8 2.04617e-02       // mm
-resolutionLocalXParam9 7.24302e-01      
+resolutionLocalXParam0 68.51e-03         // mm
+resolutionLocalXParam1 15.6923e-03       // mm
+resolutionLocalXParam2 667.507e-03       // mm
+resolutionLocalXParam3 -0.013986      
+resolutionLocalXParam4 102.184       
+resolutionLocalXParam5 -8.50693e+03      // mm
+resolutionLocalXParam6 -0.391975      
+resolutionLocalXParam7 0.0742621      
+resolutionLocalXParam8 -51.5195e-03      // mm
+resolutionLocalXParam9 0.695858
 
 // pitch in Y = 100 um.
-resolutionLocalYParam0 1.36198e-02       // mm
-resolutionLocalYParam1 2.69508e-03       // mm
-resolutionLocalYParam2 2.07958e-03       // mm
-resolutionLocalYParam3 8.80011e+00      
-resolutionLocalYParam4 -3.82634e+00      
-resolutionLocalYParam5 1.66384e-02       // mm
-resolutionLocalYParam6 2.60254e-02      
-resolutionLocalYParam7 2.39881e-01      
-resolutionLocalYParam8 -7.20557e-03      // mm
-resolutionLocalYParam9 4.02918e-01
+resolutionLocalYParam0 22.4684e-03       // mm
+resolutionLocalYParam1 5.91399e-03       // mm
+resolutionLocalYParam2 9.77838e-03       // mm
+resolutionLocalYParam3 5.14923        
+resolutionLocalYParam4 93.3833    
+resolutionLocalYParam5 -3.5427e-03       // mm
+resolutionLocalYParam6 1.39766     
+resolutionLocalYParam7 -0.156411   
+resolutionLocalYParam8 -19.0808e-03      // mm
+resolutionLocalYParam9 1.50209 

--- a/config/stdinclude/CMS_Phase2/Pixel/Resolutions/50x200
+++ b/config/stdinclude/CMS_Phase2/Pixel/Resolutions/50x200
@@ -1,21 +1,23 @@
 // Parametrization by Riccardo del Burgo.
 // Simulation parameters:
 // sensor thickness: 150 um
-// threshold= 1500 e-
+// threshold: 1000 e-
+// digitization (4 bits)
+// voltage: 400V
 // gaussian noise: μ = 0 e-, σ = 120 e-
-// μRH= 0.1078
+// μRH: 0.053
 
 // pitch in X = 50 um. 
-resolutionLocalXParam0 4.38042e-03       // mm
-resolutionLocalXParam1 5.28181e-04       // mm
-resolutionLocalXParam2 1.02281e-02       // mm
-resolutionLocalXParam3 4.07999e+00        
-resolutionLocalXParam4 3.58267e-01      
-resolutionLocalXParam5 2.26739e-03       // mm
-resolutionLocalXParam6 5.92233e-01      
-resolutionLocalXParam7 9.11718e-02      
-resolutionLocalXParam8 2.15336e-03       // mm
-resolutionLocalXParam9 2.33211e+00      
+resolutionLocalXParam0 2.29655e-03       // mm
+resolutionLocalXParam1 0.965899e-03      // mm
+resolutionLocalXParam2 0.584699e-03      // mm
+resolutionLocalXParam3 17.0856       
+resolutionLocalXParam4 84.566      
+resolutionLocalXParam5 12.4695e-03       // mm
+resolutionLocalXParam6 -0.0643059      
+resolutionLocalXParam7 0.168662    
+resolutionLocalXParam8 1.87998e-03       // mm
+resolutionLocalXParam9 0.514452     
 
 // pitch in Y = 200 um.
 resolutionLocalYParam0 1.44629e-02       // mm

--- a/config/stdinclude/CMS_Phase2/Pixel/Resolutions/50x50
+++ b/config/stdinclude/CMS_Phase2/Pixel/Resolutions/50x50
@@ -1,30 +1,32 @@
 // Parametrization by Riccardo del Burgo.
 // Simulation parameters:
 // sensor thickness: 150 um
-// threshold= 1500 e-
+// threshold: 1000 e-
+// digitization (4 bits)
+// voltage: 400V
 // gaussian noise: μ = 0 e-, σ = 120 e-
-// μRH= 0.1078
+// μRH: 0.053
 
 // pitch in X = 50 um. 
-resolutionLocalXParam0 7.04191e-03       // mm
-resolutionLocalXParam1 1.33381e-03       // mm
-resolutionLocalXParam2 5.74344e-03       // mm
-resolutionLocalXParam3 7.95657e+00       
-resolutionLocalXParam4 -2.38146e-01      
-resolutionLocalXParam5 -4.29611e-03      // mm
-resolutionLocalXParam6 7.95251e-01      
-resolutionLocalXParam7 1.33906e-01      
-resolutionLocalXParam8 4.05193e-04       // mm
-resolutionLocalXParam9 1.50022e+00      
+resolutionLocalXParam0 2.29655e-03       // mm
+resolutionLocalXParam1 0.965899e-03      // mm
+resolutionLocalXParam2 0.584699e-03      // mm
+resolutionLocalXParam3 17.0856       
+resolutionLocalXParam4 84.566      
+resolutionLocalXParam5 12.4695e-03       // mm
+resolutionLocalXParam6 -0.0643059      
+resolutionLocalXParam7 0.168662    
+resolutionLocalXParam8 1.87998e-03       // mm
+resolutionLocalXParam9 0.514452    
 
 // pitch in Y = 50 um.
-resolutionLocalYParam0 7.04191e-03       // mm
-resolutionLocalYParam1 1.33381e-03       // mm
-resolutionLocalYParam2 5.74344e-03       // mm
-resolutionLocalYParam3 7.95657e+00       
-resolutionLocalYParam4 -2.38146e-01      
-resolutionLocalYParam5 -4.29611e-03      // mm
-resolutionLocalYParam6 7.95251e-01      
-resolutionLocalYParam7 1.33906e-01      
-resolutionLocalYParam8 4.05193e-04       // mm
-resolutionLocalYParam9 1.50022e+00      
+resolutionLocalYParam0 2.29655e-03       // mm
+resolutionLocalYParam1 0.965899e-03      // mm
+resolutionLocalYParam2 0.584699e-03      // mm
+resolutionLocalYParam3 17.0856       
+resolutionLocalYParam4 84.566      
+resolutionLocalYParam5 12.4695e-03       // mm
+resolutionLocalYParam6 -0.0643059      
+resolutionLocalYParam7 0.168662    
+resolutionLocalYParam8 1.87998e-03       // mm
+resolutionLocalYParam9 0.514452    


### PR DESCRIPTION
No major diff, reso slightly improved (since lower threshold).

IMPORTANT: param for 50x200 not updated.

Before PR:
- http://ghugo.web.cern.ch/ghugo/layouts/test/OT616_IT614_old_reso/layoutpixel.html 
After PR:
- http://ghugo.web.cern.ch/ghugo/layouts/test/OT616_IT614_new_reso/layoutpixel.html