### PR TITLE
Add latest TFPX

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_616
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_616
@@ -1,0 +1,38 @@
+// TBPX second-conversion stations (service cylinder)
+// twisted pairs -> GBT
+
+
+// conversion station length: 43 mm
+// distance between conversion stations: 3 mm
+
+Station {
+  stationName BPIX1
+  type second
+  minZ 925.00
+  maxZ 968.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+
+Station {
+  stationName BPIX2
+  type second
+  minZ 971.00
+  maxZ 914.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+
+Station {
+  stationName BPIX3
+  type second
+  minZ 1017.00
+  maxZ 1060.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+
+Station {
+  stationName BPIX4
+  type second
+  minZ 1063.00
+  maxZ 1106.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_616
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_616
@@ -17,7 +17,7 @@ Station {
   stationName BPIX2
   type second
   minZ 971.00
-  maxZ 914.00
+  maxZ 1014.00
   @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
 }
 

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_615
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_615
@@ -1,0 +1,62 @@
+// TFPX second-conversion stations (service cylinder)
+// twisted pairs -> GBT
+
+// distance from disk center: 13 mm
+// conversion station length: 43 mm
+
+Station {
+  stationName FPIX1
+  type second
+  minZ 266.00
+  maxZ 309.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX2
+  type second
+  minZ 335.95
+  maxZ 378.95
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX3
+  type second
+  minZ 425.23
+  maxZ 468.23
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX4
+  type second
+  minZ 539.20
+  maxZ 582.20
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX5
+  type second
+  minZ 684.68
+  maxZ 727.68
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX6
+  type second
+  minZ 855.38
+  maxZ 898.38
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX7
+  type second
+  minZ 1122.42
+  maxZ 1165.42
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX8
+  type second
+  minZ 1410.00
+  maxZ 1453.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_616
+++ b/config/stdinclude/CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_616
@@ -1,0 +1,62 @@
+// TFPX second-conversion stations (service cylinder)
+// twisted pairs -> GBT
+
+// distance from disk center: 13 mm
+// conversion station length: 43 mm
+
+Station {
+  stationName FPIX1
+  type second
+  minZ 291.00
+  maxZ 334.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX2
+  type second
+  minZ 360.95
+  maxZ 403.95
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX3
+  type second
+  minZ 450.23
+  maxZ 493.23
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX4
+  type second
+  minZ 564.20
+  maxZ 607.20
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX5
+  type second
+  minZ 709.68
+  maxZ 752.68
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX6
+  type second
+  minZ 880.38
+  maxZ 923.38
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX7
+  type second
+  minZ 1147.42
+  maxZ 1190.42
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}
+Station {
+  stationName FPIX8
+  type second
+  minZ 1435.00
+  maxZ 1478.00
+  @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/conversion
+}

--- a/geometries/CMS_Phase2/OT616_IT615.cfg
+++ b/geometries/CMS_Phase2/OT616_IT615.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V616.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_5.cfg

--- a/geometries/CMS_Phase2/OT616_IT616.cfg
+++ b/geometries/CMS_Phase2/OT616_IT616.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V616.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_6.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_1_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_1_6.cfg
@@ -1,0 +1,66 @@
+  Barrel PXB {
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_616
+    
+    zOverlap -1.3 // 1.3mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity 1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      numRods 12
+    }
+    Layer 2 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+    }
+    Layer 3 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+    }
+    Layer 4 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_5.cfg
@@ -7,7 +7,7 @@
 
     @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
     @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
-    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_615
     @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
     
     moduleShape rectangular

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_5.cfg
@@ -1,0 +1,71 @@
+  Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2.75
+    bigDelta 6.25 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+    Disk 1 { placeZ 253.00 }
+    Disk 2 { placeZ 322.95 }
+    Disk 3 { placeZ 412.23 }
+    Disk 4 { placeZ 526.20 }
+    Disk 5 { placeZ 671.68 }
+    Disk 6 { placeZ 842.38 }     // -15 mm, optimal was: Z = 857.38 mm
+    Disk 7 { placeZ 1109.42 }    // +15 mm, optimal was: Z = 1094.42 mm
+    Disk 8 { placeZ 1397.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_6.cfg
@@ -7,7 +7,7 @@
 
     @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
     @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
-    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_616
     @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
     
     moduleShape rectangular

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_1_6.cfg
@@ -1,0 +1,71 @@
+  Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_614
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2.75
+    bigDelta 6.25 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+    Disk 1 { placeZ 278.00 }
+    Disk 2 { placeZ 347.95 }
+    Disk 3 { placeZ 437.23 }
+    Disk 4 { placeZ 551.20 }
+    Disk 5 { placeZ 696.68 }
+    Disk 6 { placeZ 867.38 }
+    Disk 7 { placeZ 1134.42 }
+    Disk 8 { placeZ 1422.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_5.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_5.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_1_4.cfg
+  @include ../Pixel_V6/FPIX1_6_1_5.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_6.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_1_4.cfg
+  @include ../Pixel_V6/FPIX1_6_1_6.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_6.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_1_6.cfg
@@ -16,7 +16,7 @@ Tracker Pixels {
   barrelDetIdScheme Phase2Subdetector1
   endcapDetIdScheme Phase2Subdetector4
   
-  @include BPIX_6_1_4.cfg
+  @include BPIX_6_1_6.cfg
   @include ../Pixel_V6/FPIX1_6_1_6.cfg
   @include ../Pixel_V6/FPIX2_6_1_3.cfg
 

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -473,10 +473,14 @@ OT616_IT614.cfg                      OT Version 6.1.6
                                      
 OT616_IT615.cfg                      OT Version 6.1.6
                                      Based from Inner Tracker version 6.1.4.
-                                     Stretched double-disk system, data from Yadira. 
+                                     TFPX: Stretched double-disk system, data from Yadira. 
                                      smallDelta: 2 -> 2.75 mm. bigDelta: 4 -> 6.25 mm.
                                      Sensors on both faces of same dee: inter sensor centers distance (in Z) is now 5.5 mm.
                                      Back sensors of one dee VS front sensors of next dee: inter sensor centers distance (in Z) is now 7 mm.
+                                     
+OT616_IT616.cfg                      OT Version 6.1.6
+                                     Based from Inner Tracker version 6.1.5.
+                                     TFPX: Tested shift in Z of +25 mm on all double-disks.                                     
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>  
 
 

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -466,10 +466,17 @@ OT614_200_IT613.cfg                  OT Version 6.1.4
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>   
 
 
-=================   MATERIAL BUDGET STUDIES   =================     
+=================   INSTALLATION STUDIES   =================     
 OT616_IT614.cfg                      OT Version 6.1.6
-                                     Based from Inner Tracker version 6.1.4.
+                                     Based from Inner Tracker version 6.1.3.
                                      TFPX, Disk 6 : -15 mm. Disk 7: + 15mm. All TBPX conversion stations placed between Disk 6 and Disk 7.
+                                     
+OT616_IT615.cfg                      OT Version 6.1.6
+                                     Based from Inner Tracker version 6.1.4.
+                                     Stretched double-disk system, data from Yadira. 
+                                     smallDelta: 2 -> 2.75 mm. bigDelta: 4 -> 6.25 mm.
+                                     Sensors on both faces of same dee: inter sensor centers distance (in Z) is now 5.5 mm.
+                                     Back sensors of one dee VS front sensors of next dee: inter sensor centers distance (in Z) is now 7 mm.
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>  
 
 


### PR DESCRIPTION
**IT 615:** 
http://ghugo.web.cern.ch/ghugo/layouts/T17/OT616_IT615/materialpixel.html 
TFPX: Stretched double-disk system, data from Yadira. 
- smallDelta: 2 -> 2.75 mm. 
Sensors on both faces of same dee: inter sensor centers distance (in Z) is now 5.5 mm.
- bigDelta: 4 -> 6.25 mm.
Back sensors of one dee VS front sensors of next dee: inter sensor centers distance (in Z) is now 7 mm.

**IT 616:** 
http://ghugo.web.cern.ch/ghugo/layouts/T18/OT616_IT616/materialpixel.html
TFPX: Tested shift in Z of +25 mm on all double-disks.  

See: https://indico.cern.ch/event/866839/contributions/3657003/attachments/1954592/3246242/Latest_Tracker_geometries_to_CMSSW.pdf 