### PR TITLE
Add OT 617 (and OT 618): Increase TEDD outermost radius to improve transition with TB2S (and TBPS)

### DIFF
--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_1Strip_referenceSensors
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_1Strip_referenceSensors
@@ -1,0 +1,11 @@
+// 2S, 1 Strip, reference sensors
+
+// Default sensor:
+ReferenceSensor 1 {
+  numStripsAcross 1016
+  numSegments 1
+}
+ReferenceSensor 2 {
+  numStripsAcross 1016
+  numSegments 1
+} 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_1Strip_320_18_components
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_1Strip_320_18_components
@@ -1,0 +1,11 @@
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_1Strip_referenceSensors
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2xSensor_Active_2S_290um
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Inactive_Silicon_320um
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/Module_Fibers
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/Module_Power
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Module_Supports
+
+

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_1Strip_320_18
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_1Strip_320_18
@@ -1,0 +1,8 @@
+// pt-2S module 10x10 for the outer region
+// GBT on the module
+
+Materials module-pt2S_1Strip_320_18 {
+  type module
+  @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_1Strip_320_18_components
+} 
+   

--- a/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/pt2S_1Strip_320
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/pt2S_1Strip_320
@@ -1,0 +1,96 @@
+// Generic 2S module properties
+
+moduleType pt2S
+// Active silicon size
+width 91.44  // NB: Latest info is 91.488 mm (91.44 mm used in MB).
+length 100.5 // NB: Latest info is 100.58 mm + 0.13 mm = 100.71 mm (100.71 mm already used in MB).
+
+sensorLayout pt
+zCorrelation samesegment
+
+numSensors 2
+
+powerPerModule 4700  // mW
+
+sensorThickness 0.29     // 290 um active + 30 um inactive
+
+Sensor 1 {
+  sensorType strip
+  numStripsAcross 1016
+  numSegments 1
+  numROCX 8
+  numROCY 2
+}
+
+Sensor 2 {
+  sensorType strip
+  numStripsAcross 1016
+  numSegments 1
+  numROCX 8
+  numROCY 2
+}
+
+
+// These quantities' materials appear in tkLayout, but the geo volumes are only modeled in CMSSW
+serviceHybridWidth 16.78   // 15.4085 hybrid + 1.3715 inactive silicon // OK
+frontEndHybridWidth 21.725 // 20.625 hybrid  + 1.1    inactive silicon // OK
+hybridThickness 1.0
+supportPlateThickness 0.0
+
+
+plotColor 2 
+
+ContourPoint 0 {
+  pointY 71.951
+  pointX 62.5
+}
+
+ContourPoint 1 {
+  pointY 71.951
+  pointX 0
+}
+
+ContourPoint 2 {
+  pointY 71.951
+  pointX -62.5
+}
+
+ContourPoint 3 {
+  pointY 42.5
+  pointX -62.5
+}
+
+ContourPoint 4 {
+  pointY 42.5
+  pointX -47.791
+}
+
+ContourPoint 5 {
+  pointY -42.5
+  pointX -47.791
+}
+
+ContourPoint 6 {
+  pointY -42.5
+  pointX -62.5
+}
+
+ContourPoint 7 {
+  pointY -71.951
+  pointX -62.5
+}
+
+ContourPoint 8 {
+  pointY -71.951
+  pointX 0 
+}
+
+ContourPoint 9 {
+  pointY -71.951
+  pointX 62.5
+}
+
+
+
+
+

--- a/geometries/CMS_Phase2/OT617_IT613.cfg
+++ b/geometries/CMS_Phase2/OT617_IT613.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V617.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_3.cfg

--- a/geometries/CMS_Phase2/OT617_IT615.cfg
+++ b/geometries/CMS_Phase2/OT617_IT615.cfg
@@ -1,3 +1,3 @@
 @include-std CMS_Phase2/SimParms
 @include OuterTracker/Tilted/OT_V617.cfg
-@include Pixel/Pixel_V6/Pixel_V6_1_3.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_5.cfg

--- a/geometries/CMS_Phase2/OT618_IT615.cfg
+++ b/geometries/CMS_Phase2/OT618_IT615.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V618.cfg
+@include Pixel/Pixel_V6/Pixel_V6_1_5.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V617.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V617.cfg
@@ -1,0 +1,29 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDDTop_V351.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD2_V366.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+  
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V616.cfg
+  @include TB2S_V616.cfg
+  @include TEDD1_V617.cfg
+  @include TEDD2_V617.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V618.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V618.cfg
@@ -1,0 +1,29 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDDTop_V351.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD2_V366.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+  
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V616.cfg
+  @include TB2S_V616.cfg
+  @include TEDD1_V617.cfg
+  @include TEDD2_V618.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V617.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V617.cfg
@@ -1,0 +1,121 @@
+Endcap TEDD_1 {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD1_V351.cfg
+  
+  etaCut 10
+  trackingTags trigger,tracker 
+
+  // Layout construction parameters
+  numDisks 2
+  bigParity 1
+  smallParity 1
+  bigDelta 15.755  // NICK 2018-12-10 adds 0.68, not rounded value of 0.80 mm, since what is needed is (+1.36mm)
+  smallDelta 7.55  // NICK 2017-11-07
+  minZ 1311.80 // Stefano&Duccio 2017-03-17 reducing clearance from 20 mm to 5 mm
+  maxZ 1550.00
+  
+  phiSegments 4
+  phiOverlap -2 // which saves 4 modules in ring 6 
+  
+  numRings 15  
+  outerRadius 1073.41                       // NICK 2019-01-11
+  
+  //////////////////////////////////
+  /// RINGS RADII AUTO PLACEMENT ///
+  //////////////////////////////////
+  // Used this as the first jet, then fined tune by hand (avoid clashes, reduce # modules when possible...).
+  // NB: zError and rSafetyMargin can be specified per disk or per ring!
+  // zError: luminous region coverage, transition ring (i) with ring (i+1).
+  // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
+  //zError 150                              // great coverage!
+  //rSafetyMargin 15.0 
+  //Ring 9 { rSafetyMargin 38.0 }           // will force the radial distance between rings 9 and 11 to avoid clash.   
+ 
+  Ring 1 { ringOuterRadius 283.252 }        // NICK 2019-01-11
+  Ring 2 { ringOuterRadius 331 }
+  Ring 3 { ringOuterRadius 364.307 }
+  Ring 4 { ringOuterRadius 414 } 
+  Ring 5 { ringOuterRadius 443.645 } 
+  Ring 6 { ringOuterRadius 494.2 }  
+  Ring 7 { ringOuterRadius 522.225 }   
+  Ring 8 { ringOuterRadius 573.7 }  
+  Ring 9 { ringOuterRadius 600.141 }
+  Ring 10 { ringOuterRadius 655.1 } 
+  Ring 11 { ringOuterRadius 739.641 } 
+  Ring 12 { ringOuterRadius 838 } 
+  Ring 13 { ringOuterRadius 904.8 } 
+  Ring 14 { ringOuterRadius 1013.4 } 
+  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11  
+  
+  
+
+  alignEdges true
+  moduleShape rectangular
+  Ring 1-10 {
+    smallDelta 7.55
+    dsDistance 4.0
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
+    @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40
+  }
+  Ring 11-14 {
+    smallDelta 7.495       
+    dsDistance 1.8
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+  }
+  Ring 15 {
+    smallDelta 8.495       
+    dsDistance 1.8
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_1Strip_320
+    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+  }
+
+  @include-std CMS_Phase2/OuterTracker/Materials/disk
+  @include-std CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+  
+  Disk 1 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 3 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 6 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 8 }
+    Ring 10 { triggerWindow 10 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 9 }
+    Ring 14 { triggerWindow 11 }
+    Ring 15 { triggerWindow 12 }
+  }
+  
+  Disk 2 {
+    Ring 1 { triggerWindow 2 }
+    Ring 2 { triggerWindow 2 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 4 }
+    Ring 5 { triggerWindow 5 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 7 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 9 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 7 }
+    Ring 13 { triggerWindow 8 }
+    Ring 14 { triggerWindow 10 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)      
+  Disk 1-2 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V617.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V617.cfg
@@ -66,7 +66,7 @@ Endcap TEDD_1 {
     smallDelta 8.495       
     dsDistance 1.8
     @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_1Strip_320
-    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_1Strip_320_18
   }
 
   @include-std CMS_Phase2/OuterTracker/Materials/disk

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V617.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V617.cfg
@@ -9,15 +9,15 @@ Endcap TEDD_1 {
   bigParity 1
   smallParity 1
   bigDelta 15.755  // NICK 2018-12-10 adds 0.68, not rounded value of 0.80 mm, since what is needed is (+1.36mm)
-  smallDelta 7.55  // NICK 2017-11-07
-  minZ 1311.80 // Stefano&Duccio 2017-03-17 reducing clearance from 20 mm to 5 mm
+  smallDelta 7.55  // MUSSGILLER 2020-01-08
+  minZ 1311.80
   maxZ 1550.00
   
   phiSegments 4
   phiOverlap -2 // which saves 4 modules in ring 6 
   
   numRings 15  
-  outerRadius 1073.41                       // NICK 2019-01-11
+  outerRadius 1093.88                       // MUSSGILLER 2020-01-08
   
   //////////////////////////////////
   /// RINGS RADII AUTO PLACEMENT ///
@@ -41,10 +41,10 @@ Endcap TEDD_1 {
   Ring 9 { ringOuterRadius 600.141 }
   Ring 10 { ringOuterRadius 655.1 } 
   Ring 11 { ringOuterRadius 739.641 } 
-  Ring 12 { ringOuterRadius 838 } 
-  Ring 13 { ringOuterRadius 904.8 } 
-  Ring 14 { ringOuterRadius 1013.4 } 
-  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11  
+  Ring 12 { ringOuterRadius 847.6 } 
+  Ring 13 { ringOuterRadius 919.4 } 
+  Ring 14 { ringOuterRadius 1029.2 } 
+  Ring 15 { ringOuterRadius 1093.88 }      // MUSSGILLER 2020-01-08
   
   
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V617.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V617.cfg
@@ -7,7 +7,7 @@ Endcap TEDD_2 {
   bigParity 1
   smallParity 1  
   bigDelta 15.755  // NICK 2018-12-10 adds 0.68, not rounded value of 0.80 mm, since what is needed is (+1.36mm)
-  smallDelta 7.55  // NICK 2017-11-07
+  smallDelta 7.55  // MUSSGILLER 2020-01-08
   minZ 1853.400
   Disk 2 { placeZ 2216.190 }
   maxZ 2650.000
@@ -44,7 +44,7 @@ Endcap TEDD_2 {
   Ring 12 { ringOuterRadius 818 } 
   Ring 13 { ringOuterRadius 894.812 } 
   Ring 14 { ringOuterRadius 1000.17 }  
-  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11  
+  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11
     
   
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V617.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V617.cfg
@@ -1,0 +1,154 @@
+Endcap TEDD_2 {
+  etaCut 10
+  trackingTags trigger,tracker
+  
+  // Layout construction parameters
+  numDisks 3
+  bigParity 1
+  smallParity 1  
+  bigDelta 15.755  // NICK 2018-12-10 adds 0.68, not rounded value of 0.80 mm, since what is needed is (+1.36mm)
+  smallDelta 7.55  // NICK 2017-11-07
+  minZ 1853.400
+  Disk 2 { placeZ 2216.190 }
+  maxZ 2650.000
+    
+  phiSegments 4
+  phiOverlap -2
+  
+  numRings 15
+  outerRadius 1073.41                       // NICK 2019-01-11              
+  
+  
+  //////////////////////////////////
+  /// RINGS RADII AUTO PLACEMENT ///
+  //////////////////////////////////
+  // Used this as the first jet, then fined tune by hand (avoid clashes, reduce # modules when possible...).
+  // NB: zError and rSafetyMargin can be specified per disk or per ring!
+  // zError: luminous region coverage, transition ring (i) with ring (i+1).
+  // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
+  //zError 150                              // great coverage!
+  //rSafetyMargin 15.0
+  //Ring 9 { rSafetyMargin 38.0 }           // will force the radial distance between rings 9 and 11 to avoid clash. 
+    
+  Ring 1 { removeModule true } 
+  Ring 2 { removeModule true }  
+  Ring 3 { removeModule true }
+  Ring 4 { ringOuterRadius 378.252 }        // NICK 2019-01-11
+  Ring 5 { ringOuterRadius 412.101 }
+  Ring 6 { ringOuterRadius 460.726 }
+  Ring 7 { ringOuterRadius 494.631 }
+  Ring 8 { ringOuterRadius 543.593 }
+  Ring 9 { ringOuterRadius 575.153 }
+  Ring 10 { ringOuterRadius 625.9 }
+  Ring 11 { ringOuterRadius 715.153 } 
+  Ring 12 { ringOuterRadius 818 } 
+  Ring 13 { ringOuterRadius 894.812 } 
+  Ring 14 { ringOuterRadius 1000.17 }  
+  Ring 15 { ringOuterRadius 1073.41 }       // NICK 2019-01-11  
+    
+  
+
+  alignEdges true
+  moduleShape rectangular
+  Ring 1-10 {
+    smallDelta 7.55
+    dsDistance 4.0
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
+    @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40
+  }
+  Ring 11 {
+    smallDelta 8.595
+    dsDistance 4.0
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_40
+  }
+  
+  Disk 1-2 {
+    Ring 12-15 {
+      smallDelta 7.495
+      dsDistance 1.8
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+    }
+  }
+  Disk 3 {
+    Ring 12 {
+      smallDelta 8.595
+      dsDistance 4.0
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_40
+    }
+    Ring 13-15 {
+      smallDelta 7.495
+      dsDistance 1.8
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+    }
+  }
+
+  @include-std CMS_Phase2/OuterTracker/Materials/disk
+  @include-std CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+
+  Disk 1 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 8 }
+    Ring 11 { triggerWindow 10 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 9 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  Disk 2 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 7 }
+    Ring 11 { triggerWindow 9 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 8 }
+    Ring 15 { triggerWindow 9 }
+  }
+
+  Disk 3 {
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 3 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 5 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 6 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 8 }
+    Ring 13 { triggerWindow 6 }
+    Ring 14 { triggerWindow 7 }
+    Ring 15 { triggerWindow 8 }
+  }
+ 
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)
+  Disk 1-3 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V618.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V618.cfg
@@ -1,0 +1,164 @@
+Endcap TEDD_2 {
+  etaCut 10
+  trackingTags trigger,tracker
+  
+  // Layout construction parameters
+  numDisks 3
+  bigParity 1
+  smallParity 1  
+  bigDelta 15.755  // NICK 2018-12-10 adds 0.68, not rounded value of 0.80 mm, since what is needed is (+1.36mm)
+  smallDelta 7.55  // MUSSGILLER 2020-01-08
+  minZ 1853.400
+  Disk 2 { placeZ 2216.190 }
+  maxZ 2650.000
+    
+  phiSegments 4
+  phiOverlap -2
+  
+  numRings 15
+  outerRadius 1073.41                       // NICK 2019-01-11              
+  
+  
+  //////////////////////////////////
+  /// RINGS RADII AUTO PLACEMENT ///
+  //////////////////////////////////
+  // Used this as the first jet, then fined tune by hand (avoid clashes, reduce # modules when possible...).
+  // NB: zError and rSafetyMargin can be specified per disk or per ring!
+  // zError: luminous region coverage, transition ring (i) with ring (i+1).
+  // rSafetyMargin: radial distance [ring (i+2) rMin] - [ring (i) rHigh].
+  //zError 150                              // great coverage!
+  //rSafetyMargin 15.0
+  //Ring 9 { rSafetyMargin 38.0 }           // will force the radial distance between rings 9 and 11 to avoid clash. 
+    
+  Ring 1 { removeModule true } 
+  Ring 2 { removeModule true }  
+  Ring 3 { removeModule true }
+  Ring 4 { ringOuterRadius 378.252 }        // NICK 2019-01-11
+  Ring 5 { ringOuterRadius 412.101 }
+  Ring 6 { ringOuterRadius 460.726 }
+  Ring 7 { ringOuterRadius 494.631 }
+  Ring 8 { ringOuterRadius 543.593 }
+  Ring 9 { ringOuterRadius 575.153 }
+  Ring 10 { ringOuterRadius 625.9 }
+  Ring 11 { ringOuterRadius 715.153 } 
+  Ring 12 { ringOuterRadius 820 }
+  Ring 13 { ringOuterRadius 905 } 
+  Ring 14 { ringOuterRadius 1012.5 }  
+  Ring 15 { ringOuterRadius 1093.88 }      // MUSSGILLER 2020-01-08
+    
+  
+
+  alignEdges true
+  moduleShape rectangular
+  
+  Ring 1-10 {
+    smallDelta 7.55
+    dsDistance 4.0
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
+    @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40
+  }
+  
+  Ring 11 {
+    smallDelta 8.595
+    dsDistance 4.0
+    @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_40
+  }
+  
+  Disk 1-2 {
+    Ring 12 {
+      smallDelta 7.495
+      dsDistance 1.8
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+    }
+  }
+  Disk 3 {
+    Ring 12 {
+      smallDelta 8.595
+      dsDistance 4.0
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_40
+    }
+  }
+  
+  Ring 13-14 {
+      smallDelta 7.495
+      dsDistance 1.8
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+  }
+  
+  Ring 15 {
+      smallDelta 7.495
+      dsDistance 1.8
+      @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_1Strip_320
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_1Strip_320_18
+  }
+
+  @include-std CMS_Phase2/OuterTracker/Materials/disk
+  @include-std CMS_Phase2/OuterTracker/Conversions/flangeTEDD
+
+  Disk 1 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 5 }
+    Ring 7 { triggerWindow 6 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 7 }
+    Ring 10 { triggerWindow 8 }
+    Ring 11 { triggerWindow 10 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 9 }
+    Ring 15 { triggerWindow 10 }
+  }
+
+  Disk 2 {
+    Ring 1 { triggerWindow 1 }
+    Ring 2 { triggerWindow 1 }
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 4 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 6 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 7 }
+    Ring 11 { triggerWindow 9 }
+    Ring 12 { triggerWindow 6 }
+    Ring 13 { triggerWindow 7 }
+    Ring 14 { triggerWindow 8 }
+    Ring 15 { triggerWindow 9 }
+  }
+
+  Disk 3 {
+    Ring 3 { triggerWindow 2 }
+    Ring 4 { triggerWindow 3 }
+    Ring 5 { triggerWindow 3 }
+    Ring 6 { triggerWindow 4 }
+    Ring 7 { triggerWindow 5 }
+    Ring 8 { triggerWindow 5 }
+    Ring 9 { triggerWindow 6 }
+    Ring 10 { triggerWindow 6 }
+    Ring 11 { triggerWindow 6 }
+    Ring 12 { triggerWindow 8 }
+    Ring 13 { triggerWindow 6 }
+    Ring 14 { triggerWindow 7 }
+    Ring 15 { triggerWindow 8 }
+  }
+ 
+  // Special solution to avoid clashes between the last PS ring
+  // (ring 8) and the first 2S ring (ring 10)
+  Disk 1-3 {
+    Ring 8 {
+      frontEndHybridWidth 6.5 // 5.05 hybrid + 1.45 inactive silicon // OK
+    }
+    Ring 10 {
+      frontEndHybridWidth 16.725 // 15.625 hybrid + 1.1 inactive silicon // OK
+    }
+  }
+}

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V618.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V618.cfg
@@ -16,7 +16,7 @@ Endcap TEDD_2 {
   phiOverlap -2
   
   numRings 15
-  outerRadius 1073.41                       // NICK 2019-01-11              
+  outerRadius 1093.88                       // MUSSGILLER 2020-01-08          
   
   
   //////////////////////////////////

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -233,6 +233,16 @@ OT616_200_IT404.cfg	   Diff with OT615:
 OT616_IT613.cfg	       Diff with OT616_200:
                        Sensor thickness: 200 um -> 290 um + Add 30 um deep-diffused Si + Review Si in inactive edges and MPA.
                        Add 164 um to s-sensor in PS module.
+                       
+OT617_IT615.cfg	       Diff with OT616:
+                       All TEDD: update smallDeltas to latest info.
+                          * PS 4 mm: 7.375 mm -> 7.550 mm.
+                          * 2S 4 mm:  8.550 mm -> 8.595 mm.
+                          * 2S 1.8 mm: 7.450 mm -> 7.495 mm.
+                       Improve transition region between TB2S and TEDD by removing readout hybrid in TEDD1, R15.
+                          * Special modules in TEDD1, R15, with halved number of strips / module. WARNING: MB NOT UPDATED!! SHOULD UPDATE REF SENSOR MB AND READOUT MB.
+                          * Outer radius increased by 20.47 mm : R15 sensors centers: 1023.16 mm -> 1043.63 mm.
+                          * Radii in TEDD1, R12, R13, R14 adjusted accordingly.                              
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                          
         
 ===========   POST-TDR INNER TRACKER STUDIES   ===========                           

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -240,9 +240,15 @@ OT617_IT615.cfg	       Diff with OT616:
                           * 2S 4 mm:  8.550 mm -> 8.595 mm.
                           * 2S 1.8 mm: 7.450 mm -> 7.495 mm.
                        Improve transition region between TB2S and TEDD by removing readout hybrid in TEDD1, R15.
-                          * Special modules in TEDD1, R15, with halved number of strips / module. WARNING: MB NOT UPDATED!! SHOULD UPDATE REF SENSOR MB AND READOUT MB.
+                          * Special modules in TEDD1, R15, with halved number of strips / module. WARNING: MB NOT UPDATED!! SHOULD UPDATE MODULE MB.
                           * Outer radius increased by 20.47 mm : R15 sensors centers: 1023.16 mm -> 1043.63 mm.
-                          * Radii in TEDD1, R12, R13, R14 adjusted accordingly.                              
+                          * Radii in TEDD1, R12, R13, R14 adjusted accordingly.
+                       
+OT618_IT615.cfg	       Diff with OT617:
+                       Also improve transition between TB2S/TBPS and TEDD by removing readout hybrid in TEDD2, R15.
+                          * Special modules in TEDD2, R15, with halved number of strips / module. WARNING: MB NOT UPDATED!! SHOULD UPDATE MODULE MB.
+                          * Outer radius increased by 20.47 mm : R15 sensors centers: 1023.16 mm -> 1043.63 mm.
+                          * Radii in TEDD2, R12, R13, R14 adjusted accordingly.                          
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                          
         
 ===========   POST-TDR INNER TRACKER STUDIES   ===========                           


### PR DESCRIPTION
- All TEDD: update smallDeltas to latest info.
PS 4 mm: 7.375 mm -> 7.550 mm.
2S 4 mm:  8.550 mm -> 8.595 mm.
2S 1.8 mm: 7.450 mm -> 7.495 mm.

- Improve transition region between TB2S and TEDD by removing readout hybrid in TEDD1, R15.
Special modules in TEDD1, R15, with halved number of strips / module. WARNING: MODULE MB NOT UPDATED!!
Outer radius increased by 20.47 mm : R15 sensors centers: 1023.16 mm -> 1043.63 mm.
Radii in TEDD1, R12, R13, R14 adjusted accordingly.

- OT618: do the same thing on TEDD 2 R15 as well.

- The idea behind this is to reduce the gap at eta ~ 1.05.
OT 617 layout might never be built, if the performance is not shown to improve significantly.
OT 618 layout is not likely to be built, since TEDD 2 design (Lyon) is already frozen.