### PR TITLE
Fix binning in info + geometry + tracking resolution plots

### DIFF
--- a/include/AnalyzerTools.hh
+++ b/include/AnalyzerTools.hh
@@ -17,7 +17,7 @@ namespace insur {
   // Example: if plotNumberOfInnerTrackerStubs == 3, and a track has 4 stubs, it will be counted in the (>=3 stubs) category.
   static const int plotMaxNumberOfOuterTrackerHitsPerLayer = 5;
   static const int plotMaxNumberOfInnerTrackerHitsPerLayer = 4;
-  static const int plotMaxNumberOfOuterTrackerStubs = 11;
+  static const int plotMaxNumberOfOuterTrackerStubs = 10;
   static const int plotMaxNumberOfInnerTrackerStubs = 3;
 
   // Simply set the plots MaxY.

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -114,7 +114,7 @@ namespace insur {
   static const int    vis_std_canvas_sizeY   = 900;
   static const int    vis_max_canvas_sizeY   =1800;
 
-  static const double vis_eta_step           = 0.1;
+  static const double vis_eta_step           = 0.01;
   static const int    vis_n_bins             = geom_max_eta_coverage/vis_eta_step;  // Default number of bins in histogram from eta=0  to max_eta_coverage
 
 

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -114,7 +114,7 @@ namespace insur {
   static const int    vis_std_canvas_sizeY   = 900;
   static const int    vis_max_canvas_sizeY   =1800;
 
-  static const double vis_eta_step           = 0.01;
+  static const double vis_eta_step           = 0.02;
   static const int    vis_n_bins             = geom_max_eta_coverage/vis_eta_step;  // Default number of bins in histogram from eta=0  to max_eta_coverage
 
 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3016,7 +3016,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   for (int numberOfStubs = 0; numberOfStubs <= plotMaxNumberOfStubs; numberOfStubs++) {
     TProfile stubProfile = TProfile( Form("layerEtaCoverageProfileNumberOfStubs%d", numberOfStubs), 
 				     "Distribution of number of stub(s) per track;#eta;Fraction of tracks", 
-				     insur::vis_n_bins, 0, maxEta); 
+				     insur::vis_n_bins / 2., 0, maxEta); 
     tracksDistributionPerNumberOfStubs_[numberOfStubs] = stubProfile;
   }
 
@@ -3027,7 +3027,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   totalEtaProfileLayers.SetLineColor(1);
   totalEtaProfileLayers.SetMarkerSize(1);
   totalEtaProfileLayers.SetTitle("Number of layers with at least a hit;#eta;Number of layers");
-  totalEtaProfileLayers.SetBins(insur::vis_n_bins, 0, maxEta);
+  totalEtaProfileLayers.SetBins(2. * insur::vis_n_bins, 0, maxEta);
   totalEtaProfileLayers.SetStats(0);
 
   // CREATE COVERAGE PER LAYER PLOTS

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -473,7 +473,7 @@ bool Analyzer::analyzePatterReco(MaterialBudget& mb, mainConfigHandler& mainConf
   const auto& directory     = mainConfig.getIrradiationDirectory();
   bool        fluenceMapOK  = false;
   IrradiationMap* fluenceMap= nullptr;
-  int         nBins         = vis_n_bins*2;
+  int         nBins         = vis_n_bins;
 
   fluenceMapOK = checkFile(default_fluence_file, directory);
   std::cout << "Reading in: " << directory + "/" + default_fluence_file << std::endl;
@@ -2947,14 +2947,14 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   for (std::map <std::string, int>::iterator it = moduleTypeCount.begin();
        it!=moduleTypeCount.end(); it++) {
     TProfile& aProfile = etaProfileByType[(*it).first];
-    aProfile.SetBins(100, 0, maxEta);  
+    aProfile.SetBins(insur::vis_n_bins, 0, maxEta);  
     aProfile.SetName((*it).first.c_str());
     aProfile.SetTitle((*it).first.c_str());
   }
 
   for (auto mel : sensorTypeCount) {
     TProfile& aProfileStubs = etaProfileByTypeSensors[mel.first];
-    aProfileStubs.SetBins(100, 0, maxEta);
+    aProfileStubs.SetBins(insur::vis_n_bins, 0, maxEta);
     aProfileStubs.SetName(mel.first.c_str());
     aProfileStubs.SetTitle(mel.first.c_str());
   }
@@ -2964,7 +2964,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     // Indeed, 1 IT 'offline' stub can be on different modules types!
     for (auto mel : moduleTypeCountStubs) {
       TProfile& aProfileStubs = etaProfileByTypeStubs[mel.first];
-      aProfileStubs.SetBins(100, 0, maxEta);
+      aProfileStubs.SetBins(insur::vis_n_bins, 0, maxEta);
       aProfileStubs.SetName(mel.first.c_str());
       aProfileStubs.SetTitle(mel.first.c_str());
     }
@@ -2982,33 +2982,33 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   TH2I mapPhiEtaCount("mapPhiEtaCount ", "phi Eta hit count", nBlocks, -1*M_PI, M_PI, nBlocks, -maxEta, maxEta);
   totalEtaProfile.Reset();
   totalEtaProfile.SetName("totalEtaProfile");
-  totalEtaProfile.SetMarkerStyle(8);
+  totalEtaProfile.SetMarkerStyle(1);
+  totalEtaProfile.SetMarkerSize(1);
   totalEtaProfile.SetMarkerColor(1);
   totalEtaProfile.SetLineColor(1);
-  totalEtaProfile.SetMarkerSize(1.5);
   totalEtaProfile.SetTitle("Number of modules with at least one hit;#eta;Number of hit modules");
-  totalEtaProfile.SetBins(100, 0, maxEta);
+  totalEtaProfile.SetBins(insur::vis_n_bins, 0, maxEta);
   totalEtaProfile.SetStats(0);
 
   totalEtaProfileSensors.Reset();
   totalEtaProfileSensors.SetName("totalEtaProfileSensors");
-  totalEtaProfileSensors.SetMarkerStyle(8);
+  totalEtaProfileSensors.SetMarkerStyle(1);
+  totalEtaProfileSensors.SetMarkerSize(1);
   totalEtaProfileSensors.SetMarkerColor(1);
   totalEtaProfileSensors.SetLineColor(1);
-  totalEtaProfileSensors.SetMarkerSize(1.5);
   totalEtaProfileSensors.SetTitle("Number of hits;#eta;Number of hits");
-  totalEtaProfileSensors.SetBins(100, 0, maxEta);
+  totalEtaProfileSensors.SetBins(insur::vis_n_bins, 0, maxEta);
   totalEtaProfileSensors.SetStats(0);
 
   totalEtaProfileStubs.Reset();
   totalEtaProfileStubs.SetName("totalEtaProfileStubs");
-  totalEtaProfileStubs.SetMarkerStyle(8);
+  totalEtaProfileStubs.SetMarkerStyle(1);
+  totalEtaProfileStubs.SetMarkerSize(1);
   totalEtaProfileStubs.SetMarkerColor(1);
   totalEtaProfileStubs.SetLineColor(1);
-  totalEtaProfileStubs.SetMarkerSize(1.5);
   if (!tracker.isPixelTracker()) { totalEtaProfileStubs.SetTitle("Number of modules with a stub;#eta;Number of stubs"); }
   else { totalEtaProfileStubs.SetTitle("Number of stubs;#eta;Number of stubs"); }
-  totalEtaProfileStubs.SetBins(100, 0, maxEta);
+  totalEtaProfileStubs.SetBins(insur::vis_n_bins, 0, maxEta);
   totalEtaProfileStubs.SetStats(0);
 
   // CREATE PLOTS: distribution of tracks per number of stubs.
@@ -3016,18 +3016,18 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   for (int numberOfStubs = 0; numberOfStubs <= plotMaxNumberOfStubs; numberOfStubs++) {
     TProfile stubProfile = TProfile( Form("layerEtaCoverageProfileNumberOfStubs%d", numberOfStubs), 
 				     "Distribution of number of stub(s) per track;#eta;Fraction of tracks", 
-				     30, 0, maxEta); 
+				     insur::vis_n_bins, 0, maxEta); 
     tracksDistributionPerNumberOfStubs_[numberOfStubs] = stubProfile;
   }
 
   totalEtaProfileLayers.Reset();
   totalEtaProfileLayers.SetName("totalEtaProfileLayers");
-  totalEtaProfileLayers.SetMarkerStyle(8);
+  totalEtaProfileLayers.SetMarkerStyle(1);
   totalEtaProfileLayers.SetMarkerColor(1);
   totalEtaProfileLayers.SetLineColor(1);
-  totalEtaProfileLayers.SetMarkerSize(1.5);
+  totalEtaProfileLayers.SetMarkerSize(1);
   totalEtaProfileLayers.SetTitle("Number of layers with at least a hit;#eta;Number of layers");
-  totalEtaProfileLayers.SetBins(100, 0, maxEta);
+  totalEtaProfileLayers.SetBins(insur::vis_n_bins, 0, maxEta);
   totalEtaProfileLayers.SetStats(0);
 
   // CREATE COVERAGE PER LAYER PLOTS
@@ -3162,7 +3162,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
        it!=etaProfileByType.end(); it++) {
     TProfile* myProfile=(TProfile*)it->second.Clone();
     savingGeometryV.push_back(*myProfile); // TODO: remove savingGeometryV everywhere :-) [VERY obsolete...]
-    myProfile->SetMarkerStyle(8);
+    myProfile->SetMarkerStyle(1);
     myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetMarkerSize(1);
@@ -3178,10 +3178,10 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
   for (std::map <std::string, TProfile>::iterator it = etaProfileByTypeSensors.begin();
        it!=etaProfileByTypeSensors.end(); it++) {
     TProfile* myProfile=(TProfile*)it->second.Clone();
-    myProfile->SetMarkerStyle(8);
+    myProfile->SetMarkerStyle(1);
+    myProfile->SetMarkerSize(1);
     myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
-    myProfile->SetMarkerSize(1);
     std::string profileName = "etaProfileSensors"+(*it).first;
     myProfile->SetName(profileName.c_str());
     myProfile->SetTitle((*it).first.c_str());
@@ -3195,7 +3195,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     for (std::map <std::string, TProfile>::iterator it = etaProfileByTypeStubs.begin();
 	 it!=etaProfileByTypeStubs.end(); it++) {
       TProfile* myProfile=(TProfile*)it->second.Clone();
-      myProfile->SetMarkerStyle(8);
+      myProfile->SetMarkerStyle(1);
       myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
       myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
       myProfile->SetMarkerSize(1);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3163,6 +3163,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
     TProfile* myProfile=(TProfile*)it->second.Clone();
     savingGeometryV.push_back(*myProfile); // TODO: remove savingGeometryV everywhere :-) [VERY obsolete...]
     myProfile->SetMarkerStyle(1);
+    myProfile->SetMarkerSize(1);
     myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
     myProfile->SetMarkerSize(1);
@@ -3196,6 +3197,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 	 it!=etaProfileByTypeStubs.end(); it++) {
       TProfile* myProfile=(TProfile*)it->second.Clone();
       myProfile->SetMarkerStyle(1);
+      myProfile->SetMarkerSize(1);
       myProfile->SetMarkerColor(Palette::color(modulePlotColors[it->first]));
       myProfile->SetLineColor(Palette::color(modulePlotColors[it->first]));
       myProfile->SetMarkerSize(1);

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -3055,8 +3055,8 @@ namespace insur {
       detailProfile.SetMarkerColor(Palette::color(colorIndex));
       detailProfile.SetLineColor(Palette::color(colorIndex));
       detailProfile.SetFillColor(Palette::color(colorIndex));
-      detailProfile.SetMarkerStyle(8);
-      detailProfile.SetMarkerSize(1.5);
+      detailProfile.SetMarkerStyle(1);
+      detailProfile.SetMarkerSize(1);
       detailProfile.GetYaxis()->SetTitleOffset(1.3);
       detailProfile.SetStats(0);
       detailProfile.Draw("same");
@@ -3282,8 +3282,8 @@ namespace insur {
 	detailProfile.SetMaximum(1.05);
 	detailProfile.SetMarkerColor(Palette::color(colorIndex));
 	detailProfile.SetLineColor(Palette::color(colorIndex));
-	detailProfile.SetMarkerStyle(8);
-	detailProfile.SetMarkerSize(0.3);  
+	detailProfile.SetMarkerStyle(1);
+	detailProfile.SetMarkerSize(1);  
 	detailProfile.Draw("same");
 
 	std::ostringstream titleStream;
@@ -3618,7 +3618,7 @@ namespace insur {
     if (totalEtaProfileSensorsPixel_) totalEtaStack->Add(totalEtaProfileSensorsPixel_->ProjectionX());
     std::unique_ptr<TCanvas> totalEtaProfileFull(new TCanvas("TotalEtaProfileFull", "Full eta profile (Hits)", vis_std_canvas_sizeX, vis_std_canvas_sizeY));
     totalEtaProfileFull->cd();
-    ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerStyle(8);
+    ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerStyle(1);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerSize(1);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMinimum(0.);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetStats(0.);
@@ -3639,7 +3639,7 @@ namespace insur {
     if (totalLayersCountOuter) {
       totalLayersCountOuter->SetBit(1);
       totalLayersEtaStack->Add(totalLayersCountOuter);
-      totalLayersCountOuter->SetMarkerStyle(8);
+      totalLayersCountOuter->SetMarkerStyle(1);
       totalLayersCountOuter->SetMarkerSize(1);
       totalLayersCountOuter->SetMarkerColor(Palette::color(1));
       totalLayersCountOuter->SetStats(0);
@@ -3648,12 +3648,12 @@ namespace insur {
     if (totalLayersCountInner) {   
       totalLayersCountInner->SetBit(1);
       totalLayersEtaStack->Add(totalLayersCountInner);
-      totalLayersCountInner->SetMarkerStyle(8);
+      totalLayersCountInner->SetMarkerStyle(1);
       totalLayersCountInner->SetMarkerSize(1);
       totalLayersCountInner->SetMarkerColor(Palette::color(2));
       totalLayersCountInner->SetStats(0);
     }
-    ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerStyle(8);
+    ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerStyle(1);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerSize(1);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerColor(kBlack);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMinimum(0.);
@@ -4099,8 +4099,8 @@ namespace insur {
         std::unique_ptr<TCanvas> pCanvas(new TCanvas());
 
         int myColor=0;
-        int nRebin = 2;
-        int markerStyle = 21;
+        int nRebin = 1;
+        int markerStyle = 1;
         double markerSize = 1.;
         double lineWidth = 2.;
 
@@ -4216,11 +4216,13 @@ namespace insur {
           ctgThetaProfile.SetMaximum(vis_max_dCtgTheta);
           ctgThetaCanvas->SetLogy();
           ctgThetaProfile.SetLineColor(momentumColor(myColor));
+	  ctgThetaProfile.SetLineWidth(lineWidth);
           ctgThetaProfile.SetMarkerColor(momentumColor(myColor));
           etaProfile.SetMinimum(vis_min_dCtgTheta);
           etaProfile.SetMaximum(vis_max_dCtgTheta);
           etaCanvas->SetLogy();
           etaProfile.SetLineColor(momentumColor(myColor));
+	  etaProfile.SetLineWidth(lineWidth);
           etaProfile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           ctgThetaProfile.SetMarkerStyle(markerStyle);
@@ -4248,6 +4250,7 @@ namespace insur {
           z0Profile.SetMaximum(vis_max_dZ0);//1*verticalScale);
           z0Canvas->SetLogy();
           z0Profile.SetLineColor(momentumColor(myColor));
+	  z0Profile.SetLineWidth(lineWidth);
           z0Profile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           z0Profile.SetMarkerStyle(markerStyle);
@@ -4256,7 +4259,7 @@ namespace insur {
           if (z0Graph.GetN() > 0) {
             z0Canvas->cd();
             z0Profile.Draw(plotOption.c_str());
-            plotOption = "p same";
+            plotOption = "same";
           }
         }
         plotOption = "";
@@ -4275,6 +4278,7 @@ namespace insur {
           }
           pCanvas->SetLogy();
           pProfile.SetLineColor(momentumColor(myColor));
+	  pProfile.SetLineWidth(momentumColor(myColor));
           pProfile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           pProfile.SetMarkerStyle(markerStyle);
@@ -4283,7 +4287,7 @@ namespace insur {
           if (pGraph.GetN() > 0) {
             pCanvas->cd();
             pProfile.Draw(plotOption.c_str());
-            plotOption = "p same";
+            plotOption = "same";
           }
         }
         RootWImage& linearMomentumImage = myContent->addImage(std::move(linearMomentumCanvas), vis_std_canvas_sizeX, vis_min_canvas_sizeY);
@@ -4513,7 +4517,7 @@ namespace insur {
           // Default attributes
           int myColor            = 0;
           int nBins              = insur::vis_n_bins;
-          int markerStyle        = 21;
+          int markerStyle        = 1;
           double markerSize      = 1.;
           double lineWidth       = 2.;
           std::string plotOption = "";
@@ -4596,7 +4600,7 @@ namespace insur {
             if (pGraph.GetN() > 0) {
               pCanvas_Pt->cd();
               pProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
           // Draw d0
@@ -4724,7 +4728,7 @@ namespace insur {
             if (z0Graph.GetN() > 0) {
               z0Canvas_Pt->cd();
               z0Profile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -4752,7 +4756,7 @@ namespace insur {
             if (LGraph.GetN() > 0) {
               lCanvas_Pt->cd();
               lProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -4780,7 +4784,7 @@ namespace insur {
             if (BetaGraph.GetN() > 0) {
               betaCanvas_Pt->cd();
               betaProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -4808,7 +4812,7 @@ namespace insur {
             if (OmegaGraph.GetN() > 0) {
               omegaCanvas_Pt->cd();
               omegaProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -4894,7 +4898,7 @@ namespace insur {
           // Default attributes
           int myColor            = 0;
           int nBins              = insur::vis_n_bins;
-          int markerStyle        = 21;
+          int markerStyle        = 1;
           double markerSize      = 1.;
           double lineWidth       = 2.;
           std::string plotOption = "";
@@ -4977,7 +4981,7 @@ namespace insur {
             if (pGraph.GetN() > 0) {
               pCanvas_P->cd();
               pProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
           // Draw d0
@@ -5105,7 +5109,7 @@ namespace insur {
             if (z0Graph.GetN() > 0) {
               z0Canvas_P->cd();
               z0Profile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
           plotOption = "";
@@ -5135,7 +5139,7 @@ namespace insur {
             if (LGraph.GetN() > 0) {
               lCanvas_P->cd();
               lProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -5163,7 +5167,7 @@ namespace insur {
             if (BetaGraph.GetN() > 0) {
               betaCanvas_P->cd();
               betaProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -5191,7 +5195,7 @@ namespace insur {
             if (OmegaGraph.GetN() > 0) {
               omegaCanvas_P->cd();
               omegaProfile.Draw(plotOption.c_str());
-              plotOption = "p same";
+              plotOption = "same";
             }
           }
 
@@ -5518,7 +5522,7 @@ namespace insur {
 
       a.hisPatternRecoInOutPt[iMomentum]->SetNameTitle(std::string("hisPatternRecoInOutPt"+any2str(pIter/Units::GeV)+"GeV").c_str(),"In-Out: Bkg contamination prob. in 95% area of 2D error ellipse accumulated accross N layers;#eta;1 - #Pi_{i=1}^{N} (1-p^{i}_{bkg_95%})");
       a.hisPatternRecoInOutPt[iMomentum]->SetLineWidth(2.);
-      a.hisPatternRecoInOutPt[iMomentum]->SetMarkerStyle(21);
+      a.hisPatternRecoInOutPt[iMomentum]->SetMarkerStyle(1);
       a.hisPatternRecoInOutPt[iMomentum]->SetMarkerSize(1.);
       a.hisPatternRecoInOutPt[iMomentum]->SetLineColor(momentumColor(iMomentum));
       a.hisPatternRecoInOutPt[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5553,7 +5557,7 @@ namespace insur {
 
       a.hisPatternRecoOutInPt[iMomentum]->SetNameTitle(std::string("hisPatternRecoOutInPt"+any2str(pIter/Units::GeV)+"GeV").c_str(),"Out-In: Bkg contamination prob. in 95% area of 2D error ellipse accumulated accross N layers;#eta;1 - #Pi_{i=1}^{N} (1-p^{i}_{bkg_95%})");
       a.hisPatternRecoOutInPt[iMomentum]->SetLineWidth(2.);
-      a.hisPatternRecoOutInPt[iMomentum]->SetMarkerStyle(21);
+      a.hisPatternRecoOutInPt[iMomentum]->SetMarkerStyle(1);
       a.hisPatternRecoOutInPt[iMomentum]->SetMarkerSize(1.);
       a.hisPatternRecoOutInPt[iMomentum]->SetLineColor(momentumColor(iMomentum));
       a.hisPatternRecoOutInPt[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5596,7 +5600,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPtD0InOut"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{R-#Phi} from previous layers/discs;#eta; #sigma_{R-#Phi} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5639,7 +5643,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPtZ0InOut"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{Z} from previous layers/discs;#eta; #sigma_{Z} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5679,7 +5683,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPtProbContamInOut"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: bkg contamination prob. as error ellipse extrap. from previous layers/discs;#eta; probability").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5724,7 +5728,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPtD0OutIn"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{R-#Phi} from previous layers/discs;#eta; #sigma_{R-#Phi} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5767,7 +5771,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPtZ0OutIn"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{Z} from previous layers/discs;#eta; #sigma_{Z} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5807,7 +5811,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPtProbContamOutIn"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: bkg contamination prob. as error ellipse extrap. from previous layers/discs;#eta; probability").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5852,7 +5856,7 @@ namespace insur {
 
       a.hisPatternRecoInOutP[iMomentum]->SetNameTitle(std::string("hisPBkgContInOut"+any2str(pIter/Units::GeV)+"GeV").c_str(),"In-Out: Bkg contamination prob. in 95% area of 2D error ellipse accumulated accross N layers;#eta;1 - #Pi_{i=1}^{N} (1-p^{i}_{bkg_95%})");
       a.hisPatternRecoInOutP[iMomentum]->SetLineWidth(2.);
-      a.hisPatternRecoInOutP[iMomentum]->SetMarkerStyle(21);
+      a.hisPatternRecoInOutP[iMomentum]->SetMarkerStyle(1);
       a.hisPatternRecoInOutP[iMomentum]->SetMarkerSize(1.);
       a.hisPatternRecoInOutP[iMomentum]->SetLineColor(momentumColor(iMomentum));
       a.hisPatternRecoInOutP[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5887,7 +5891,7 @@ namespace insur {
 
       a.hisPatternRecoOutInP[iMomentum]->SetNameTitle(std::string("hisPBkgContOutIn"+any2str(pIter/Units::GeV)+"GeV").c_str(),"Out-In: Bkg contamination prob. in 95% area of 2D error ellipse accumulated accross N layers;#eta;1 - #Pi_{i=1}^{N} (1-p^{i}_{bkg_95%})");
       a.hisPatternRecoOutInP[iMomentum]->SetLineWidth(2.);
-      a.hisPatternRecoOutInP[iMomentum]->SetMarkerStyle(21);
+      a.hisPatternRecoOutInP[iMomentum]->SetMarkerStyle(1);
       a.hisPatternRecoOutInP[iMomentum]->SetMarkerSize(1.);
       a.hisPatternRecoOutInP[iMomentum]->SetLineColor(momentumColor(iMomentum));
       a.hisPatternRecoOutInP[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5930,7 +5934,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPD0InOut"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{R-#Phi} from previous layers/discs;#eta; #sigma_{R-#Phi} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -5973,7 +5977,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPZ0InOut"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{Z} from previous layers/discs;#eta; #sigma_{Z} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -6015,7 +6019,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPProbContamInOut"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: bkg contamination prob. as error ellipse extrap. from previous layers/discs;#eta; probability").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -6059,7 +6063,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPD0OutIn"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{R-#Phi} from previous layers/discs;#eta; #sigma_{R-#Phi} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -6102,7 +6106,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPZ0OutIn"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: an extrapolated #sigma_{Z} from previous layers/discs;#eta; #sigma_{Z} [#mum]").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -6144,7 +6148,7 @@ namespace insur {
         auto & profHis = iterMap.second;
         profHis[iMomentum]->SetNameTitle(std::string("canvasPProbContamOutIn"+name+any2str(pIter/Units::GeV)+"GeV").c_str(),std::string(name+" In-Out approach: bkg contamination prob. as error ellipse extrap. from previous layers/discs;#eta; probability").c_str());
         profHis[iMomentum]->SetLineWidth(2.);
-        profHis[iMomentum]->SetMarkerStyle(21);
+        profHis[iMomentum]->SetMarkerStyle(1);
         profHis[iMomentum]->SetMarkerSize(1.);
         profHis[iMomentum]->SetLineColor(momentumColor(iMomentum));
         profHis[iMomentum]->SetMarkerColor(momentumColor(iMomentum));
@@ -6248,7 +6252,7 @@ namespace insur {
         npointsProfile.SetMarkerColor(Palette::color(myColor));
         npointsProfile.SetFillColor(Palette::color(myColor));
         myColor++;
-        npointsProfile.SetMarkerStyle(8);
+        npointsProfile.SetMarkerStyle(1);
         pointsCanvas->SetFillColor(color_plot_background);
 
         pointsCanvas->cd();
@@ -6310,7 +6314,7 @@ namespace insur {
         fractionProfile.SetMarkerColor(Palette::color(myColor));
         fractionProfile.SetFillColor(Palette::color(myColor));
         myColor++;
-        fractionProfile.SetMarkerStyle(8);
+        fractionProfile.SetMarkerStyle(1);
         fractionCanvas->SetFillColor(color_plot_background);
 
         fractionCanvas->cd();
@@ -6376,7 +6380,7 @@ namespace insur {
         purityProfile.SetMarkerColor(Palette::color(myColor));
         purityProfile.SetFillColor(Palette::color(myColor));
         myColor++;
-        purityProfile.SetMarkerStyle(8);
+        purityProfile.SetMarkerStyle(1);
         purityCanvas->SetFillColor(color_plot_background);
 
         purityCanvas->cd();

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -3620,6 +3620,8 @@ namespace insur {
     totalEtaProfileFull->cd();
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerStyle(1);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerSize(1);
+    ((TH1D*)totalEtaStack->GetStack()->Last())->SetMarkerColor(kBlack);
+    ((TH1D*)totalEtaStack->GetStack()->Last())->SetLineColor(kBlack);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetMinimum(0.);
     ((TH1D*)totalEtaStack->GetStack()->Last())->SetStats(0.);
     totalEtaStack->GetStack()->Last()->Draw();
@@ -3642,6 +3644,7 @@ namespace insur {
       totalLayersCountOuter->SetMarkerStyle(1);
       totalLayersCountOuter->SetMarkerSize(1);
       totalLayersCountOuter->SetMarkerColor(Palette::color(1));
+      totalLayersCountOuter->SetLineColor(Palette::color(1));
       totalLayersCountOuter->SetStats(0);
     }
     TH1D* totalLayersCountInner = (totalEtaProfileLayersPixel_ ? (TH1D*)totalEtaProfileLayersPixel_->ProjectionX()->Clone() : nullptr);
@@ -3651,11 +3654,13 @@ namespace insur {
       totalLayersCountInner->SetMarkerStyle(1);
       totalLayersCountInner->SetMarkerSize(1);
       totalLayersCountInner->SetMarkerColor(Palette::color(2));
+      totalLayersCountInner->SetLineColor(Palette::color(2));
       totalLayersCountInner->SetStats(0);
     }
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerStyle(1);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerSize(1);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMarkerColor(kBlack);
+    ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetLineColor(kBlack);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetMinimum(0.);
     ((TH1D*)totalLayersEtaStack->GetStack()->Last())->SetStats(0);
     totalLayersEtaStack->GetStack()->Last()->Draw();
@@ -4278,7 +4283,7 @@ namespace insur {
           }
           pCanvas->SetLogy();
           pProfile.SetLineColor(momentumColor(myColor));
-	  pProfile.SetLineWidth(momentumColor(myColor));
+	  pProfile.SetLineWidth(lineWidth);
           pProfile.SetMarkerColor(momentumColor(myColor));
           myColor++;
           pProfile.SetMarkerStyle(markerStyle);


### PR DESCRIPTION
- deltaEta : 0.1 -> 0.02 on all plots.
- removed spot markers, which are hiding the interesting information.

This allows to see (hence understand...) way better the geometric coverage, as well as the details of the tracking resolution.

NB: deltaEta has 2 exceptions:
- deltaEta = 0.04 in 'Distribution of number of stubs per track' plots.
- deltaEta = 0.01 in 'Number of layers with at least a hit' plots. Might be nice to have it as well for the 'Number of hits' plots.