### PR TITLE
IMPORTANT: Fixed major issue in pT resolution

### DIFF
--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -3,8 +3,8 @@ SimParms {
     bunchSpacingNs 25
     
     // Luminous region used in analysis (IP always on (Z) axis, with Z centered around 0)
-    lumiRegZError                   0     // mm
-    lumiRegShape                    spot   // Choose among { spot, flat, gaussian }
+    lumiRegZError                   70     // mm
+    lumiRegShape                    flat   // Choose among { spot, flat, gaussian }
     lumiRegShapeInMatBudgetAnalysis spot
 
     // Adds IP to the track with corresponding resolution

--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -3,8 +3,8 @@ SimParms {
     bunchSpacingNs 25
     
     // Luminous region used in analysis (IP always on (Z) axis, with Z centered around 0)
-    lumiRegZError                   70     // mm
-    lumiRegShape                    flat   // Choose among { spot, flat, gaussian }
+    lumiRegZError                   0     // mm
+    lumiRegShape                    spot   // Choose among { spot, flat, gaussian }
     lumiRegShapeInMatBudgetAnalysis spot
 
     // Adds IP to the track with corresponding resolution

--- a/include/Hit.hh
+++ b/include/Hit.hh
@@ -95,8 +95,8 @@ public:
   bool     isActivityUndefined() const { if (m_activity==HitActivity::Undefined) return true; else return false;};
   HitType  getActiveHitType() const    { return m_activeHitType; } // NONE, INNER, OUTER, BOTH or STUB -- only meaningful for hits on active elements
   RILength getCorrectedMaterial();
-  double   getResolutionRphi(double trackRadius);
-  double   getResolutionZ(double trackRadius);
+  double   getResolutionRphi(const double trackRadius, const double deltaTheta) const;
+  double   getResolutionZ(const double trackRadius) const;
   double   getD();
 
   std::string getDetName()       const { return m_detName; };

--- a/include/Track.hh
+++ b/include/Track.hh
@@ -103,17 +103,14 @@ public:
   //! Helper method printing track covariance matrices in R-Phi
   void printErrors();
 
-  //! Helper method printing symmetric matrix
-  void printSymMatrix(const TMatrixTSym<double>&) const;
-
-  //! Helper method printing general matrix
+  //! Helper method printing matrix
   void printMatrix(const TMatrixT<double>&) const;
 
   //! Helper method printing track hits
-  void printHits() const;
+  void printHits();
 
   //! Helper method printing active track hits
-  void printActiveHits() const;
+  void printActiveHits();
 
   //! Does track contain no hits?
   bool hasNoHits() const {return m_hits.empty(); }
@@ -154,7 +151,13 @@ public:
 
   //! Get DeltaCtgTheta at refPoint [rPos, zPos]
   //! Propagator direction defines, which part of tracker (at higher radii or lower radii from the ref. point) is going to be used.
-  double getDeltaCtgTheta(double refPointRPos, bool propagOutIn=true);
+  double getDeltaCtgTheta(double refPointRPos, bool propagOutIn = true);
+
+  //! Get DeltaTheta at refPoint [rPos, zPos]
+  //! Propagator direction defines, which part of tracker (at higher radii or lower radii from the ref. point) is going to be used.
+  double getDeltaTheta(double refPointRPos, bool propagOutIn = true) {
+    return getDeltaCtgTheta(refPointRPos, propagOutIn) * pow(sin(getTheta()), 2.);
+  }
 
   //! Get DeltaZ (Z0) at refPoint [rPos, zPos] ([0,0])
   //! Propagator direction defines, which part of tracker (at higher radii or lower radii from the ref. point) is going to be used.

--- a/src/Hit.cc
+++ b/src/Hit.cc
@@ -256,49 +256,69 @@ RILength Hit::getCorrectedMaterial() {
     return m_correctedMaterial;
 }
 
+
 /**
- * Getter for the rPhi resolution (local x coordinate for a module)
- * If the hit is not active it returns -1
- * If the hit is connected to a module, then the module's resolution
- * is retured (if the hit is trigger-type, then then module's trigger resultion is requested)
- * if there is not any hit module, then the hit's resolution property is read and returned
- * @return the hit's local resolution
+ * Returns the hit's Rphi resolution.
+ * If the hit is not active, it returns -1.
+ * IMPORTANT NB: THE deltaTheta PARAMETER INTRODUCES A DEPENDENCY ON THE TRACK'S deltaTheta RESOLUTION IN (RZ) PLANE.
+ * HENCE, Track::computeErrorsRZ IS CALLED AND COMPUTED FIRST!!
  */
-double Hit::getResolutionRphi(double trackRadius) {
+double Hit::getResolutionRphi(const double trackRadius, const double deltaTheta) const {
 
+  // INACTIVE HIT
   if (!(this->isActive())) {
-
     logERROR("Hit::getResolutionRphi called on a non-active hit");
     return -1;
   }
+
+  // ACTIVE HIT
   else {
 
-    // Module hit
+    // ON A MODULE
     if (m_hitModule) {
 
-      // R-Phi-resolution calculated as for a barrel-type module -> transform local R-Phi res. to a true module orientation (rotation by theta angle, skew, tilt)
-      // In detail, take into account a propagation of MS error on virtual barrel plane, on which all measurements are evaluated for consistency (global chi2 fit applied) ->
-      // in limit R->inf. propagation along line used, otherwise a very small correction factor coming from the circular shape of particle track is required (similar
-      // approach as for local resolutions)
-      // TODO: Currently, correction mathematicaly derived only for use case of const magnetic field -> more complex mathematical expression expected in non-const B field
-      // (hence correction not applied in such case)
-      double A = 0;
-      if (SimParms::getInstance().isMagFieldConst()) A = getRPos()/(2*trackRadius); // r_i / 2R
-      double B         = A/sqrt(1-A*A);
-      double tiltAngle = m_hitModule->tiltAngle();
-      double skewAngle = m_hitModule->skewAngle();
-      const double resLocalX = m_hitModule->resolutionLocalX(getTrackDirection());
-      const double resLocalY = m_hitModule->resolutionLocalY(getTrackDirection());
+      // Sensor local resolution
+      const double resoSensorLocalX = getHitModule()->resolutionLocalX(getTrackDirection());
+      const double resoSensorLocalY = getHitModule()->resolutionLocalY(getTrackDirection());
 
-      // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
-      double resolutionRPhi = sqrt(pow((B*sin(skewAngle)*cos(tiltAngle) + cos(skewAngle)) * resLocalX,2) + pow(B*sin(tiltAngle) * resLocalY,2));
+      // Also get hit position resolution in (RZ) plane
+      // Simply project R * deltaTheta into the sensor plane.
+      // Formula is: R * deltaTheta / sin(theta + tilt)
+      // * Barrel module: this is equivalent to: R * deltaTheta / sin(theta)
+      // * Endcap module: this is equivalent to: R * deltaTheta / cos(theta)
+      const double hitR = std::hypot(getZPos(), getRPos());
+      const double incidentAngleInRZPlane = fabs(getHitModule()->beta(getTrackDirection()));	    
+      const double resoPositionLocalY = hitR * deltaTheta / sin(incidentAngleInRZPlane);
+
+      // Resolution localY: 
+      // take into account both the sensor local Y resolution and the hit position resolution in (RZ) plane.
+      const double resoLocalY = pow( 1/pow(resoSensorLocalY, 2) + 1/pow(resoPositionLocalY , 2) , -0.5);
+
+      // Dependency on pT: compute B coefficient
+      // Very small correction factor, associated with the circular shape of particle track.
+      const double A = (SimParms::getInstance().isMagFieldConst() ? getRPos() / ( 2 * trackRadius) : 0.); // r_i / 2R
+      const double B         = A / sqrt(1. - pow(A, 2.));
+
+      // Sensor's orientation
+      const double tiltAngle = fabs(getHitModule()->tiltAngle());
+      const double skewAngle = fabs(getHitModule()->skewAngle());
+
+
+      // Can finally compute resolutionRPhi !!
+      const double resolutionRPhi = sqrt(
+					 pow( (B * sin(skewAngle) * cos(tiltAngle) + cos(skewAngle)) * resoSensorLocalX, 2.) 
+					 + pow(B * sin(tiltAngle) * resoLocalY, 2.)	
+					 );
 
       return resolutionRPhi;
     }
-    // IP or beam-constraint etc. hit
+
+    // IP OR BEAM-CONSTRAINT HIT
     else return m_resolutionRPhi;
   }
+
 }
+
 
 /**
  * Getter for the y resolution (local y coordinate for a module)
@@ -309,7 +329,7 @@ double Hit::getResolutionRphi(double trackRadius) {
  * if there is not any hit module, then the hit's resolution property is read and returned
  * @return the hit's local resolution
  */
-double Hit::getResolutionZ(double trackRadius) {
+double Hit::getResolutionZ(const double trackRadius) const {
 
   if (!(this->isActive())) {
 
@@ -344,6 +364,8 @@ double Hit::getResolutionZ(double trackRadius) {
 
         // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
         double resolutionZ = sqrt(pow(((D*cos(tiltAngle) + sin(tiltAngle))*sin(skewAngle)) * resLocalX,2) + pow((D*sin(tiltAngle) + cos(tiltAngle)) * resLocalY,2));
+	// NB: IN A SYMMETRIC WAY, HERE WE MIGHT HAVE WANTED A DEPENDENCY ON THE TRACK'S RPHI RESOLUTION,
+	// TO TAKE INTO ACCOUNT BOTH THE HIT'S POSITION RPHI RESOLUTION AND the sensor's resLocalX?????
 
         return resolutionZ;
       }
@@ -352,6 +374,7 @@ double Hit::getResolutionZ(double trackRadius) {
     else return m_resolutionZ;
   }
 }
+
 
 /*
  * Checks wether a module belongs to the outer endcap (no pixel allowed)

--- a/src/Track.cc
+++ b/src/Track.cc
@@ -1252,22 +1252,27 @@ bool Track::computeCovarianceMatrixRPhi(double refPointRPos, bool propagOutIn) {
 	    // r_i / 2R
 	    const double A = (SimParms::getInstance().isMagFieldConst() ? myHit->getRPos() / ( 2 * trackRadius) : 0.);
 	    const double B         = A/sqrt(1-A*A);
-	    const double tiltAngle = myHit->getHitModule()->tiltAngle();
-	    const double skewAngle = myHit->getHitModule()->skewAngle();
+	    const double tiltAngle = fabs(myHit->getHitModule()->tiltAngle());
+	    const double skewAngle = fabs(myHit->getHitModule()->skewAngle());
 	    const double resoSensorLocalX = myHit->getHitModule()->resolutionLocalX(getDirection());
 	    const double resoSensorLocalY = myHit->getHitModule()->resolutionLocalY(getDirection());
 
 
 	    const double hitR = std::hypot(myHit->getZPos(), myHit->getRPos());
 	    const double deltaTheta = getDeltaCtgTheta(refPointRPos) * pow(sin(getTheta()), 2.);
-	    const double resoPositionLocalY = hitR * deltaTheta * sin(myHit->getHitModule()->beta(getDirection()));
+	    const double incidentAngleInRZPlane = myHit->getHitModule()->beta(getDirection());
+	    
+	    const double resoPositionLocalY = hitR * deltaTheta / fabs(sin(incidentAngleInRZPlane));
+	   
+
+	    /*if (tiltAngle > 89 * M_PI / 180.) {
+	      resoPositionLocalY = myHit->getZPos() * getDeltaCtgTheta(refPointRPos) * pow(tan(getTheta()), 2.);
+	      
+	      }*/
+
+	    
 
 	    const double resoLocalY = pow( 1/pow(resoSensorLocalY, 2) + 1/pow(resoPositionLocalY , 2) , -0.5);
-
-	    //std::cout << "newwwwww resPosY = " << resPosY << std::endl;
-	    //std::cout << "newwwwww resY = " << resY << std::endl;
-
-
 
 
 

--- a/src/Track.cc
+++ b/src/Track.cc
@@ -722,7 +722,7 @@ void Track::printErrors() {
 //
 // Helper method printing matrix
 //
-void Track::printMatrix(const TMatrixTSym<double>& matrix) const {
+void Track::printMatrix(const TMatrixT<double>& matrix) const {
 
   std::cout << std::endl;
 


### PR DESCRIPTION
**R-Phi resolution:**
Only the **strip length** was considered to compute the radial uncertainty.
The track's deltaTheta should be considered as well. 

This lead to TEDD R-Phi resolution being far too bad : only the 2S sensors 's very long strips were used to compute the radial uncertainty. 
Hence, TEDD impact on pT resolution was under-estimated.

In TFPX, TEPX, tilted TBPS and TEDD PS, this was also true. 
But in these subdetectors, the strip length is much shorter, making this effect completely negligible.


NB: deltaTheta needs to be computed once all hits along a track have been looked at.
This implies that the track's RZ uncertainty is computed first.
Then, the resulting track's deltaTheta is used to compute the R-Phi uncertainty.