### PR TITLE
Sensor MB files: distinguish planar and 3D types

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x1_2500
@@ -3,6 +3,7 @@ Materials BPIX_L1_1x1_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x1
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500
@@ -3,6 +3,7 @@ Materials BPIX_L1_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_3D
@@ -3,6 +3,7 @@ Materials BPIX_L1_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2_3D
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x1_2500
@@ -3,6 +3,7 @@ Materials BPIX_L2_1x1_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x1
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
@@ -3,6 +3,7 @@ Materials BPIX_L2_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500_3D
@@ -3,6 +3,7 @@ Materials BPIX_L2_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2_3D
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_1x1_2500
@@ -3,6 +3,7 @@ Materials BPIX_L3_1x1_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x1
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_1x2_2500
@@ -3,6 +3,7 @@ Materials BPIX_L3_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_10000
@@ -3,6 +3,7 @@ Materials BPIX_L3_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
@@ -3,6 +3,7 @@ Materials BPIX_L3_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_1x1_2500
@@ -3,6 +3,7 @@ Materials BPIX_L4_1x1_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic 
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x1
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_1x2_2500
@@ -3,6 +3,7 @@ Materials BPIX_L4_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_10000
@@ -3,6 +3,7 @@ Materials BPIX_L4_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
@@ -3,6 +3,7 @@ Materials BPIX_L4_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_1x1_2500
@@ -3,6 +3,8 @@ Materials FPIX2_R1_1x1_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x1
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_1x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R1_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500  
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R1_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R2_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R2_1x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R2_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R2_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_10000
@@ -3,6 +3,7 @@ Materials FPIX2_R3_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R3_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_10000
@@ -3,6 +3,7 @@ Materials FPIX2_R4_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R4_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_10000
@@ -3,6 +3,7 @@ Materials FPIX2_R5_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX2_R5_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x1_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x1_2500
@@ -3,6 +3,7 @@ Materials FPIX_R1_1x1_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x1
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
@@ -2,7 +2,8 @@
 Materials FPIX_R1_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
-  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common         
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar    
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500_3D
@@ -2,7 +2,8 @@
 Materials FPIX_R1_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
-  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common         
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D         
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2_3D
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
@@ -3,6 +3,7 @@ Materials FPIX_R2_1x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_10000
@@ -3,6 +3,7 @@ Materials FPIX_R3_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX_R3_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_10000
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_10000
@@ -3,6 +3,7 @@ Materials FPIX_R4_2x2_10000 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_10000
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
@@ -3,6 +3,7 @@ Materials FPIX_R4_2x2_2500 {
   type module
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_2x2
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
   @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
@@ -1,5 +1,5 @@
 // MATERIALS COMMON TO ALL MODULES TYPES
-// This obviously does not include bumps, ROC, cooling blocks, conectivity (dedicated ModuleMaterials files).
+// This obviously does not include bumps, ROC, cooling blocks, connectivity (dedicated ModuleMaterials files).
 
 Component {
   componentName "IT Module: HDI" 
@@ -49,20 +49,6 @@ Component {
     unit mm           // Watch out! all quantities in mm are scaled on the surface of the ACTIVE SENSOR (width x length parameters)
                       // APPROXIMATION: Takes slightly bigger thickness, because only multiplied by active sensor area.
     targetVolume 1
-  }
-}
-
-
-
-Component {
-  componentName "IT Module: Sensor (active Si)" 
-  service false
-  scaleOnSensor 0
-  Element {
-    elementName SenSi
-    quantity 0.15       
-    unit mm                  // Watch out! all quantities in mm are scaled on the surface of the ACTIVE SENSOR (width x length parameters)
-    targetVolume 2
   }
 }
 

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar
@@ -1,0 +1,15 @@
+// SENSOR ACTIVE SILICONE MATERIAL
+// This does not include inactive Si, placed in another file.
+// PLANAR SENSOR TYPE
+
+Component {
+  componentName "IT Module: Sensor (active Si)" 
+  service false
+  scaleOnSensor 0
+  Element {
+    elementName SenSi
+    quantity 0.15       
+    unit mm                  // Watch out! all quantities in mm are scaled on the surface of the ACTIVE SENSOR (width x length parameters)
+    targetVolume 2
+  }
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
@@ -1,0 +1,15 @@
+// SENSOR ACTIVE SILICONE MATERIAL
+// This does not include inactive Si, placed in another file.
+// PLANAR SENSOR TYPE
+
+Component {
+  componentName "IT Module: Sensor (active Si)" 
+  service false
+  scaleOnSensor 0
+  Element {
+    elementName SenSi
+    quantity 0.15       
+    unit mm                  // Watch out! all quantities in mm are scaled on the surface of the ACTIVE SENSOR (width x length parameters)
+    targetVolume 2
+  }
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
@@ -1,6 +1,6 @@
 // SENSOR ACTIVE SILICONE MATERIAL
 // This does not include inactive Si, placed in another file.
-// PLANAR SENSOR TYPE
+// 3D SENSOR TYPE
 
 Component {
   componentName "IT Module: Sensor (active Si)" 


### PR DESCRIPTION
This is important, since there exists already 2 different sensor types in the geometry files.

NB: 3D module: there could be other additions in the MB files which are 3D specific, not done for now.