### PR TITLE
Fix nightlies (issues in pattern reco when propagateOutIn == false)

### DIFF
--- a/src/Track.cc
+++ b/src/Track.cc
@@ -1237,7 +1237,7 @@ bool Track::computeCovarianceMatrixRPhi(double refPointRPos, bool propagOutIn) {
 	    // Track::getDeltaCtgTheta introduces a call to Track::computeErrorsRZ.
 	    // IE, THE TRACK THETA ERROR ON (RZ) PLANE IS COMPUTED FIRST, THEN IS USED TO GET THE RPHI ERROR!
 
-	    // Sort back hits based on particle direction if they were resorted
+	    // Sort back hits as needed by Track::computeCovarianceMatrixRPhi.
 	    if (m_pt>=0 && !propagOutIn) sortHits(!bySmallerR);
 
 	    // Get the hit's Rphi resolution

--- a/src/Track.cc
+++ b/src/Track.cc
@@ -1233,9 +1233,12 @@ bool Track::computeCovarianceMatrixRPhi(double refPointRPos, bool propagOutIn) {
 	    const Hit* const myHit = m_hits.at(r).get();
 
 	    // Get the track's deltaTheta
-	    const double deltaTheta = getDeltaTheta(refPointRPos); // VERY IMPORTANT NB:
+	    const double deltaTheta = getDeltaTheta(refPointRPos, propagOutIn); // VERY IMPORTANT NB:
 	    // Track::getDeltaCtgTheta introduces a call to Track::computeErrorsRZ.
 	    // IE, THE TRACK THETA ERROR ON (RZ) PLANE IS COMPUTED FIRST, THEN IS USED TO GET THE RPHI ERROR!
+
+	    // Sort back hits based on particle direction if they were resorted
+	    if (m_pt>=0 && !propagOutIn) sortHits(!bySmallerR);
 
 	    // Get the hit's Rphi resolution
 	    const double trackRadius = getRadius(myHit->getZPos());


### PR DESCRIPTION
Fix issues in pattern reco when propagateOutIn == false. 
- Need to properly propagate the propagateOutIn bool.
- When Track::getDeltaTheta is called and propagateOutIn == false, the track's hits are resorted, which needs to be corrected back to what we want in Track::computeCovarianceMatrixRPhi.

This lead to zillions of messages on the log page, blocking the nightlies.