### PR TITLE
Fix run time issues

### DIFF
--- a/src/Track.cc
+++ b/src/Track.cc
@@ -1106,6 +1106,13 @@ std::vector<std::pair<const DetectorModule*, HitType>> Track::getHitModules() co
 //
 bool Track::computeCovarianceMatrixRPhi(double refPointRPos, bool propagOutIn) {
 
+  // Get the track's deltaTheta
+  const double deltaTheta = getDeltaTheta(refPointRPos, propagOutIn); // VERY IMPORTANT NB:
+  // Track::getDeltaCtgTheta introduces a call to Track::computeErrorsRZ.
+  // IE, THE TRACK THETA ERROR ON (RZ) PLANE IS COMPUTED FIRST, THEN IS USED TO GET THE RPHI ERROR!
+  // getDeltaTheta should be called first, in computeCovarianceMatrixRPhi, as it sorts the hits in a certain way.
+  // Hence, it needs to be done before the custom sorting done below.
+
   // Matrix size
   int nHits = m_hits.size();
   m_varMatrixRPhi.ResizeTo(nHits,nHits);
@@ -1228,17 +1235,9 @@ bool Track::computeCovarianceMatrixRPhi(double refPointRPos, bool propagOutIn) {
 
           }
 
-          if (r == c) {
+          if (r == c) {	    
 	    // Get hit
 	    const Hit* const myHit = m_hits.at(r).get();
-
-	    // Get the track's deltaTheta
-	    const double deltaTheta = getDeltaTheta(refPointRPos, propagOutIn); // VERY IMPORTANT NB:
-	    // Track::getDeltaCtgTheta introduces a call to Track::computeErrorsRZ.
-	    // IE, THE TRACK THETA ERROR ON (RZ) PLANE IS COMPUTED FIRST, THEN IS USED TO GET THE RPHI ERROR!
-
-	    // Sort back hits as needed by Track::computeCovarianceMatrixRPhi.
-	    if (m_pt>=0 && !propagOutIn) sortHits(!bySmallerR);
 
 	    // Get the hit's Rphi resolution
 	    const double trackRadius = getRadius(myHit->getZPos());

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -3717,9 +3717,9 @@ namespace insur {
     const double outerTrackerModuleOperatingTemp = outerVisitor.getOuterTrackerModuleOperatingTemp();
     const double outerTrackerModuleBiasVoltage = outerVisitor.getOuterTrackerModuleBiasVoltage();
     ModuleOperatingParmsVisitor innerVisitor;
-    if (!innerTracker) { innerTracker->accept(innerVisitor); }
-    const double innerTrackerModuleOperatingTemp = (!innerTracker ? innerVisitor.getInnerTrackerModuleOperatingTemp() : 0.);
-    const double innerTrackerModuleBiasVoltage = (!innerTracker ? innerVisitor.getInnerTrackerModuleBiasVoltage() : 0.);
+    if (innerTracker) { innerTracker->accept(innerVisitor); }
+    const double innerTrackerModuleOperatingTemp = (innerTracker ? innerVisitor.getInnerTrackerModuleOperatingTemp() : 0.);
+    const double innerTrackerModuleBiasVoltage = (innerTracker ? innerVisitor.getInnerTrackerModuleBiasVoltage() : 0.);
 
 
     // Add sim parms and module operating parameters to info page


### PR DESCRIPTION
- Pettern reco run time: is divided by 2 by avoiding re-sorting hits several times, and wisely doing the sorting at the points where actually needed.
- Info page: IT parameters not properly displayed.