### PR TITLE
Export to CMSSW: Automatic export of OTST, with no clash with BTL

### DIFF
--- a/include/Extractor.hh
+++ b/include/Extractor.hh
@@ -85,7 +85,7 @@ namespace insur {
       }
     };
   public:
-    void analyse(MaterialTable& mt, MaterialBudget& mb, XmlTags& trackerXmlTags, CMSSWBundle& d, bool wt = false);
+    void analyse(MaterialTable& mt, MaterialBudget& mb, XmlTags& trackerXmlTags, CMSSWBundle& trackerData, CMSSWBundle& otstData, bool wt = false);
   protected:
     void analyseElements(std::vector<Element>& elems, std::vector<Composite>& allComposites);
     void analyseBarrelContainer(Tracker& t, XmlTags& trackerXmlTags, std::vector<std::pair<double, double> >& up,
@@ -104,8 +104,10 @@ namespace insur {
 			 std::vector<Composite>& c, std::vector<LogicalInfo>& l, std::vector<ShapeInfo>& s,
 			 std::vector<PosInfo>& p, std::vector<SpecParInfo>& t, bool wt = false);
     void analyseSupports(InactiveSurfaces& is, bool& isPixelTracker, XmlTags& trackerXmlTags,
-			 std::vector<Composite>& c, std::vector<LogicalInfo>& l, std::vector<ShapeInfo>& s,
-                         std::vector<PosInfo>& p, std::vector<SpecParInfo>& t, bool wt = false);
+			 std::vector<Composite>& c, std::vector<LogicalInfo>& l, std::vector<ShapeInfo>& s, std::vector<PosInfo>& p,
+			 std::vector<Composite>& otstComposites, std::vector<LogicalInfo>& otstLogic, std::vector<ShapeInfo>& otstShapes, std::vector<PosInfo>& otstPositions, 
+			 std::vector<SpecParInfo>& t, 
+			 bool wt = false);
   private:
     void addTiltedModuleRot( std::map<std::string,Rotation>& rotations, double tiltAngle);
     void addRotationAroundZAxis(std::map<std::string,Rotation>& storedRotations, 

--- a/include/XMLWriter.hh
+++ b/include/XMLWriter.hh
@@ -37,8 +37,8 @@ namespace insur {
   public:
     void pixbar(std::vector<ShapeInfo>& s, std::ifstream& in, std::ofstream& out);
     void pixfwd(std::vector<ShapeInfo>& s, std::ifstream& in, std::ofstream& out);
-    void otst(CMSSWBundle& otstData, std::ofstream& out, std::istream& trackerVolumeTemplate, std::ofstream& mechanicalCategoriesRL, std::ofstream& mechanicalCategoriesIL, bool isPixelTracker, XmlTags& trackerXmlTags);
     void tracker(CMSSWBundle& d, std::ofstream& out, std::istream& trackerVolumeTemplate, std::ofstream& mechanicalCategoriesRL, std::ofstream& mechanicalCategoriesIL, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
+    void otst(CMSSWBundle& otstData, std::ofstream& out, std::istream& trackerVolumeTemplate, std::ofstream& mechanicalCategoriesRL, std::ofstream& mechanicalCategoriesIL, bool isPixelTracker, XmlTags& trackerXmlTags);
     void topology(std::vector<SpecParInfo>& t, std::ifstream& in, std::ofstream& out, bool isPixelTracker, XmlTags& trackerXmlTags);
     void prodcuts(std::vector<SpecParInfo>& t, std::ifstream& in, std::ofstream& out, bool isPixelTracker, XmlTags& trackerXmlTags);
     void trackersens(std::vector<SpecParInfo>& t, std::ifstream& in, std::ofstream& out, bool isPixelTracker, XmlTags& trackerXmlTags);
@@ -48,9 +48,9 @@ namespace insur {
 
   protected:
     void trackerLogicalVolume(std::ostringstream& stream, std::istream& instream); // takes the stream containing the tracker logical volume template and outputs it to the outstream
-    void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags);
+    void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, XmlTags& trackerXmlTags, bool isPixelTracker, bool isOTST = false);
     void rotationSection(std::map<std::string,Rotation>& r, std::string label, std::ostringstream& stream);
-    void logicalPartSection(std::vector<LogicalInfo>& l, std::string label,  std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags, bool isOTST = false, bool wt = false);
+    void logicalPartSection(std::vector<LogicalInfo>& l, std::string label,  std::ostringstream& stream, XmlTags& trackerXmlTags, bool isPixelTracker, bool isOTST = false, bool wt = false);
     void solidSection(std::vector<ShapeInfo>& s, std::vector<ShapeOperationInfo>& so, std::string label, std::ostringstream& stream, std::istream& trackerVolumeTemplate, bool notobtid, bool isPixelTracker, bool isOTST = false, bool wt = false);
     void posPartSection(std::vector<PosInfo>& p, std::vector<AlgoInfo>& a, std::string label, std::ostringstream& stream);
     void specParSection(std::vector<SpecParInfo>& t, std::string label, std::ostringstream& stream);

--- a/include/XMLWriter.hh
+++ b/include/XMLWriter.hh
@@ -37,6 +37,7 @@ namespace insur {
   public:
     void pixbar(std::vector<ShapeInfo>& s, std::ifstream& in, std::ofstream& out);
     void pixfwd(std::vector<ShapeInfo>& s, std::ifstream& in, std::ofstream& out);
+    void otst(CMSSWBundle& otstData, std::ofstream& out, std::istream& trackerVolumeTemplate, std::ofstream& mechanicalCategoriesRL, std::ofstream& mechanicalCategoriesIL, bool isPixelTracker, XmlTags& trackerXmlTags);
     void tracker(CMSSWBundle& d, std::ofstream& out, std::istream& trackerVolumeTemplate, std::ofstream& mechanicalCategoriesRL, std::ofstream& mechanicalCategoriesIL, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
     void topology(std::vector<SpecParInfo>& t, std::ifstream& in, std::ofstream& out, bool isPixelTracker, XmlTags& trackerXmlTags);
     void prodcuts(std::vector<SpecParInfo>& t, std::ifstream& in, std::ofstream& out, bool isPixelTracker, XmlTags& trackerXmlTags);
@@ -49,8 +50,8 @@ namespace insur {
     void trackerLogicalVolume(std::ostringstream& stream, std::istream& instream); // takes the stream containing the tracker logical volume template and outputs it to the outstream
     void materialSection(std::string name, std::vector<Element>& e, std::vector<Composite>& c, std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags);
     void rotationSection(std::map<std::string,Rotation>& r, std::string label, std::ostringstream& stream);
-    void logicalPartSection(std::vector<LogicalInfo>& l, std::string label,  std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags, bool wt = false);
-    void solidSection(std::vector<ShapeInfo>& s, std::vector<ShapeOperationInfo>& so, std::string label, std::ostringstream& stream, std::istream& trackerVolumeTemplate, bool notobtid, bool isPixelTracker, bool wt = false);
+    void logicalPartSection(std::vector<LogicalInfo>& l, std::string label,  std::ostringstream& stream, bool isPixelTracker, XmlTags& trackerXmlTags, bool isOTST = false, bool wt = false);
+    void solidSection(std::vector<ShapeInfo>& s, std::vector<ShapeOperationInfo>& so, std::string label, std::ostringstream& stream, std::istream& trackerVolumeTemplate, bool notobtid, bool isPixelTracker, bool isOTST = false, bool wt = false);
     void posPartSection(std::vector<PosInfo>& p, std::vector<AlgoInfo>& a, std::string label, std::ostringstream& stream);
     void specParSection(std::vector<SpecParInfo>& t, std::string label, std::ostringstream& stream);
     void algorithm(std::string name, std::string parent, std::vector<std::string>& params, std::ostringstream& stream);

--- a/include/tk2CMSSW.hh
+++ b/include/tk2CMSSW.hh
@@ -55,12 +55,13 @@ namespace insur {
         struct ConfigFile { std::string name, content; };
         void addConfigFile(const ConfigFile& file) { configFiles_.push_back(file); }
     protected:
-        CMSSWBundle data;
+        CMSSWBundle trackerData;
+        CMSSWBundle otstData;
         Extractor ex;
         XMLWriter wr;
     private:
         std::vector<ConfigFile> configFiles_;
-        void print();
+        void print(CMSSWBundle& data);
         void writeSimpleHeader(std::ostream& os, std::string& metadataFileName);
 	void writeMetadata(std::ofstream& out);
         std::string currentDateTime(bool withTime) const;

--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -29,7 +29,7 @@ namespace insur {
      */
     static const std::string xml_preamble_concise = "<?xml ";
     static const std::string xml_preamble = "<?xml version=\"1.0\"?>\n";
-    static const std::string xml_definition = "<DDDefinition xmlns=\"http://www.cern.ch/cms/DDL\" xmlns:xsi=\"http://www.cern.ch/www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd\">\n";  
+    static const std::string xml_definition = "<DDDefinition xmlns=\"http://www.cern.ch/cms/DDL\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd\">\n";  
     static const std::string xml_defclose = "</DDDefinition>\n";
     static const std::string xml_general_inter = "\">\n";
     static const std::string xml_general_endline = "\"/>\n";
@@ -162,6 +162,7 @@ namespace insur {
     static const std::string xml_trackervolumefile = "trackerVolumeTemplate.xml";
     static const std::string xml_pixbarfile = "pixbar.xml";
     static const std::string xml_pixfwdfile = "pixfwd.xml";
+    static const std::string xml_OTSTfile = "otst.xml";
     static const std::string xml_topologyfile = "trackerStructureTopology.xml";
     static const std::string xml_newtopologyfile = "newTrackerStructureTopology.xml";
     static const std::string xml_PX_topologyfile = "pixelStructureTopology.xml";
@@ -194,6 +195,7 @@ namespace insur {
     static const std::string xml_base_strip = "Strip";
     static const std::string xml_base_ps = "PS";
     static const std::string xml_base_2s = "2S";
+    static const std::string xml_OTST = "OTST";
     static const std::string xml_OT = "OuterTracker";
     static const std::string xml_PX = "InnerPixel";
     static const std::string xml_3D = "3D";
@@ -221,6 +223,7 @@ namespace insur {
     static const std::string xml_sensor_LYSO = "SenLYSO";
     static const std::string xml_pixbarident = "pixbar";
     static const std::string xml_pixfwdident = "pixfwd";
+    static const std::string xml_otstident = "otst";
     static const std::string xml_fileident = "tracker";
     static const std::string xml_newfileident = "newtracker";
     static const std::string xml_PX_fileident = "pixel";

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -2911,9 +2911,11 @@ namespace insur {
 	}
       }
 
+
       if ((iter->getZOffset() + iter->getZLength()) > 0) { // && shapename.str() != "supportR1191Z1325")
         if ( iter->getLocalMasses().size() ) {
 
+	  // Create composite
           if (!isOTST) { c.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter)); }
 	  else { otstComposites.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter)); }
 

--- a/src/tk2CMSSW.cc
+++ b/src/tk2CMSSW.cc
@@ -74,27 +74,6 @@ namespace insur {
 		outstream.clear();
 		std::cout << "CMSSW modified pixel endcap has been written to " << xmlOutputPath << xml_pixfwdfile << std::endl;
 	      }
-
-	      // OTST
-	      //instream.open((xmlDirectoryPath + "/" + xml_OTSTfile).c_str());
-	      outstream.open((xmlOutputPath + xml_OTSTfile).c_str());
-	      // if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
-	      //if (instream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
-	      //writeSimpleHeader(outstream);
-	      std::ofstream mechanicalCategoriesRL;
-	      mechanicalCategoriesRL.open((xmlOutputPath + xml_mechanicalCategoriesRLfile).c_str(), std::ofstream::app);
-	      std::ofstream mechanicalCategoriesIL;
-	      mechanicalCategoriesIL.open((xmlOutputPath + xml_mechanicalCategoriesILfile).c_str(), std::ofstream::app);
-	      std::ifstream emptyStream;
-	      wr.otst(otstData, outstream, emptyStream, mechanicalCategoriesRL, mechanicalCategoriesIL, isPixelTracker, trackerXmlTags);
-	      if (outstream.fail()) throw std::runtime_error("Error writing OTST file.");
-	      mechanicalCategoriesRL.close();
-	      mechanicalCategoriesIL.close();
-	      //instream.close();
-	      //instream.clear();
-	      outstream.close();
-	      outstream.clear();
-	      std::cout << "CMSSW OTST output has been written to " << xmlOutputPath << xml_OTSTfile << std::endl;
 	    }
 
 	    if (wt) outstream.open((xmlOutputPath + xml_newtrackerfile).c_str());
@@ -109,9 +88,32 @@ namespace insur {
             if (outstream.fail()) throw std::runtime_error("Error writing to tracker file.");
             outstream.close();
             outstream.clear();
-	    mechanicalCategoriesRL.close();
-	    mechanicalCategoriesIL.close();
+	    //mechanicalCategoriesRL.close();
+	    //mechanicalCategoriesIL.close();
             std::cout << "CMSSW tracker geometry output has been written to " << xmlOutputPath << (wt ? xml_newtrackerfile : trackerXmlTags.trackerfile) << std::endl;
+
+	    // OTST
+	    if (!isPixelTracker) {
+	      outstream.open((xmlOutputPath + xml_OTSTfile).c_str());
+	      // if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
+	      //if (instream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
+	      //writeSimpleHeader(outstream);
+
+	      //std::ofstream mechanicalCategoriesRL;
+	      //mechanicalCategoriesRL.open((xmlOutputPath + xml_mechanicalCategoriesRLfile).c_str(), std::ofstream::app);
+	      //std::ofstream mechanicalCategoriesIL;
+	      //mechanicalCategoriesIL.open((xmlOutputPath + xml_mechanicalCategoriesILfile).c_str(), std::ofstream::app);
+	      std::ifstream emptyStream;
+	      wr.otst(otstData, outstream, emptyStream, mechanicalCategoriesRL, mechanicalCategoriesIL, isPixelTracker, trackerXmlTags);
+	      if (outstream.fail()) throw std::runtime_error("Error writing OTST file.");	     
+	      //instream.close();
+	      //instream.clear();
+	      outstream.close();
+	      outstream.clear();
+	      mechanicalCategoriesRL.close();
+	      mechanicalCategoriesIL.close();
+	      std::cout << "CMSSW OTST output has been written to " << xmlOutputPath << xml_OTSTfile << std::endl;
+	    }
 
 	    if (wt) instream.open((xmlDirectoryPath + "/" + xml_newtopologyfile).c_str());
 	    else instream.open((xmlDirectoryPath + "/" + xml_topologyfile).c_str());

--- a/src/tk2CMSSW.cc
+++ b/src/tk2CMSSW.cc
@@ -88,26 +88,15 @@ namespace insur {
             if (outstream.fail()) throw std::runtime_error("Error writing to tracker file.");
             outstream.close();
             outstream.clear();
-	    //mechanicalCategoriesRL.close();
-	    //mechanicalCategoriesIL.close();
             std::cout << "CMSSW tracker geometry output has been written to " << xmlOutputPath << (wt ? xml_newtrackerfile : trackerXmlTags.trackerfile) << std::endl;
 
 	    // OTST
 	    if (!isPixelTracker) {
 	      outstream.open((xmlOutputPath + xml_OTSTfile).c_str());
-	      // if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
-	      //if (instream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
-	      //writeSimpleHeader(outstream);
-
-	      //std::ofstream mechanicalCategoriesRL;
-	      //mechanicalCategoriesRL.open((xmlOutputPath + xml_mechanicalCategoriesRLfile).c_str(), std::ofstream::app);
-	      //std::ofstream mechanicalCategoriesIL;
-	      //mechanicalCategoriesIL.open((xmlOutputPath + xml_mechanicalCategoriesILfile).c_str(), std::ofstream::app);
+	      if (outstream.fail()) throw std::runtime_error("Error opening OTST file for writing.");
 	      std::ifstream emptyStream;
 	      wr.otst(otstData, outstream, emptyStream, mechanicalCategoriesRL, mechanicalCategoriesIL, isPixelTracker, trackerXmlTags);
 	      if (outstream.fail()) throw std::runtime_error("Error writing OTST file.");	     
-	      //instream.close();
-	      //instream.clear();
 	      outstream.close();
 	      outstream.clear();
 	      mechanicalCategoriesRL.close();

--- a/src/tk2CMSSW.cc
+++ b/src/tk2CMSSW.cc
@@ -27,7 +27,7 @@ namespace insur {
 
         // analyse tracker system and build up collection of elements, composites, hierarchy, shapes, positions, algorithms and topology
         // ex is an instance of Extractor class
-        ex.analyse(mt, mb, trackerXmlTags, data, wt);
+        ex.analyse(mt, mb, trackerXmlTags, trackerData, otstData, wt);
 
         std::stringstream simpleHeaderStream;
 	std::string metdataFileName = xmlOutputName + "_" + currentDateTime(false) + ".cfg";
@@ -54,7 +54,7 @@ namespace insur {
 		outstream.open((xmlOutputPath + xml_pixbarfile).c_str());
 		if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the pixbar files.");
 		//writeSimpleHeader(outstream);
-		wr.pixbar(data.shapes, instream, outstream);
+		wr.pixbar(trackerData.shapes, instream, outstream);
 		if (outstream.fail()) throw std::runtime_error("Error writing to pixbar file.");
 		instream.close();
 		instream.clear();
@@ -66,7 +66,7 @@ namespace insur {
 		outstream.open((xmlOutputPath + xml_pixfwdfile).c_str());
 		if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the pixfwdn files.");
 		//writeSimpleHeader(outstream);
-		wr.pixfwd(data.shapes, instream, outstream);
+		wr.pixfwd(trackerData.shapes, instream, outstream);
 		if (outstream.fail()) throw std::runtime_error("Error writing to pixfwd file.");
 		instream.close();
 		instream.clear();
@@ -74,6 +74,27 @@ namespace insur {
 		outstream.clear();
 		std::cout << "CMSSW modified pixel endcap has been written to " << xmlOutputPath << xml_pixfwdfile << std::endl;
 	      }
+
+	      // OTST
+	      //instream.open((xmlDirectoryPath + "/" + xml_OTSTfile).c_str());
+	      outstream.open((xmlOutputPath + xml_OTSTfile).c_str());
+	      // if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
+	      //if (instream.fail()) throw std::runtime_error("Error opening one of the OTST files.");
+	      //writeSimpleHeader(outstream);
+	      std::ofstream mechanicalCategoriesRL;
+	      mechanicalCategoriesRL.open((xmlOutputPath + xml_mechanicalCategoriesRLfile).c_str(), std::ofstream::app);
+	      std::ofstream mechanicalCategoriesIL;
+	      mechanicalCategoriesIL.open((xmlOutputPath + xml_mechanicalCategoriesILfile).c_str(), std::ofstream::app);
+	      std::ifstream emptyStream;
+	      wr.otst(otstData, outstream, emptyStream, mechanicalCategoriesRL, mechanicalCategoriesIL, isPixelTracker, trackerXmlTags);
+	      if (outstream.fail()) throw std::runtime_error("Error writing OTST file.");
+	      mechanicalCategoriesRL.close();
+	      mechanicalCategoriesIL.close();
+	      //instream.close();
+	      //instream.clear();
+	      outstream.close();
+	      outstream.clear();
+	      std::cout << "CMSSW OTST output has been written to " << xmlOutputPath << xml_OTSTfile << std::endl;
 	    }
 
 	    if (wt) outstream.open((xmlOutputPath + xml_newtrackerfile).c_str());
@@ -84,7 +105,7 @@ namespace insur {
 	    mechanicalCategoriesRL.open((xmlOutputPath + xml_mechanicalCategoriesRLfile).c_str(), std::ofstream::app);
 	    std::ofstream mechanicalCategoriesIL;
 	    mechanicalCategoriesIL.open((xmlOutputPath + xml_mechanicalCategoriesILfile).c_str(), std::ofstream::app);
-            wr.tracker(data, outstream, trackerVolumeTemplate, mechanicalCategoriesRL, mechanicalCategoriesIL, isPixelTracker, trackerXmlTags, wt);
+            wr.tracker(trackerData, outstream, trackerVolumeTemplate, mechanicalCategoriesRL, mechanicalCategoriesIL, isPixelTracker, trackerXmlTags, wt);
             if (outstream.fail()) throw std::runtime_error("Error writing to tracker file.");
             outstream.close();
             outstream.clear();
@@ -97,7 +118,7 @@ namespace insur {
 	    outstream.open((xmlOutputPath + trackerXmlTags.topologyfile).c_str());
             if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the topology files.");
             //writeSimpleHeader(outstream);
-            wr.topology(data.specs, instream, outstream, isPixelTracker, trackerXmlTags);
+            wr.topology(trackerData.specs, instream, outstream, isPixelTracker, trackerXmlTags);
             if (outstream.fail()) throw std::runtime_error("Error writing to topology file.");
             instream.close();
             instream.clear();
@@ -109,7 +130,7 @@ namespace insur {
 	    outstream.open((xmlOutputPath + trackerXmlTags.prodcutsfile).c_str());
             if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the prodcuts files.");
             //writeSimpleHeader(outstream);
-            wr.prodcuts(data.specs, instream, outstream, isPixelTracker, trackerXmlTags);
+            wr.prodcuts(trackerData.specs, instream, outstream, isPixelTracker, trackerXmlTags);
             if (outstream.fail()) throw std::runtime_error("Error writing to prodcuts file.");
             instream.close();
             instream.clear();
@@ -121,7 +142,7 @@ namespace insur {
 	    outstream.open((xmlOutputPath + trackerXmlTags.trackersensfile).c_str());
             if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the trackersens files.");
             //writeSimpleHeader(outstream);
-            wr.trackersens(data.specs, instream, outstream, isPixelTracker, trackerXmlTags);
+            wr.trackersens(trackerData.specs, instream, outstream, isPixelTracker, trackerXmlTags);
             if (outstream.fail()) throw std::runtime_error("Error writing trackersens to file.");
             instream.close();
             instream.clear();
@@ -139,7 +160,7 @@ namespace insur {
 	    }
             if (instream.fail() || outstream.fail()) throw std::runtime_error("Error opening one of the recomaterial files.");
             //writeSimpleHeader(outstream);
-            wr.recomaterial(data.specs, data.lrilength, instream, outstream, isPixelTracker, trackerXmlTags, wt);
+            wr.recomaterial(trackerData.specs, trackerData.lrilength, instream, outstream, isPixelTracker, trackerXmlTags, wt);
             if (outstream.fail()) throw std::runtime_error("Error writing recomaterial to file.");
             instream.close();
             instream.clear();
@@ -152,7 +173,7 @@ namespace insur {
     /**
      * This prints the contents of the internal CMSSWBundle collection; used for debugging.
      */
-    void tk2CMSSW::print() {
+    void tk2CMSSW::print(CMSSWBundle& data) {
         std::cout << "tm2CMSSW internal status:" << std::endl;
         std::cout << "elements: " << data.elements.size() << " entries." << std::endl;
         for (unsigned int i = 0; i < data.elements.size(); i++) {


### PR DESCRIPTION
Since introduction of MTD:
- the OTST is placed directly inside the Tracker volume.
- the OTST is described in a dedicated file (otst.xml).

Until now, OTST stayed static in CMSSW, and did not benefit from the updates from Mechanical engineers, which were studied and debugged in tkLayout.

As was in the to-do list for a long time:
**create an automatic export of the OTST.**
The difficulty lied in that the OTST needs to be seen as a different subdetector by tkLayout XML export, because it needs to be placed in its dedicated file, with its dedicated DD sections.

This allows to introduce the latest description of the OTST from Mechanics:
- CFRP skin thickness: 2 mm -> 4 mm. This explains a factor ~2 in the OTST weight!
- CFRP skin density: 1690 kg/m^3 -> 1550 kg/m^3.
- half length is updated from 2900 mm to 2650 mm.
- addition of Core materials (HexWeb HRH-10-1/4-3.1).

The effect on MB in CMSSW is expected to be significant (~ +150 kg), but obviously outside of Tracking volume.
