### PR TITLE
 Update from Mechanics: now using different services channels for the cooling pipes.

### DIFF
--- a/src/OuterCabling/ServicesChannel.cc
+++ b/src/OuterCabling/ServicesChannel.cc
@@ -146,8 +146,8 @@ PowerSection::PowerSection(const int semiPhiRegionRef, const bool isPositiveCabl
 /* Compute the number of the Channel, through which the power cables are routed when they exit the Tracker.
  * Also compute the channel slot on which the power cables are routed.
  * This is done in a way that leaves space free for the cooling pipes routing.
- * Positive cabling side: 1A, 3A, 5A, 7A, 9A, 11A used for cooling pipes.
- * Negative cabling side: -2C, -4C, -6C, -8C, -10C, -12C used for cooling pipes.
+ * Positive cabling side: 1C, 3C, 5C, 7C, 9C, 11C used for cooling pipes.
+ * Negative cabling side: -2A, -4A, -6A, -8A, -10A, -12A used for cooling pipes.
  */
 std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int semiPhiRegionRef, const bool isPositiveCablingSide) const {
 
@@ -155,22 +155,22 @@ std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int 
   ChannelSlot channelSlot = ChannelSlot::UNKNOWN;
 
   if (isPositiveCablingSide) {
-    if (semiPhiRegionRef == 0) { channelNumber = 1; channelSlot = ChannelSlot::C; }
+    if (semiPhiRegionRef == 0) { channelNumber = 1; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 1) { channelNumber = 2; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 2) { channelNumber = 2; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 3) { channelNumber = 3; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 3) { channelNumber = 3; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 4) { channelNumber = 4; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 5) { channelNumber = 4; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 6) { channelNumber = 5; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 6) { channelNumber = 5; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 7) { channelNumber = 6; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 8) { channelNumber = 6; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 9) { channelNumber = 7; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 9) { channelNumber = 7; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 10) { channelNumber = 8; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 11) { channelNumber = 8; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 12) { channelNumber = 9; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 12) { channelNumber = 9; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 13) { channelNumber = 10; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 14) { channelNumber = 10; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 15) { channelNumber = 11; channelSlot = ChannelSlot::C; }
+    else if (semiPhiRegionRef == 15) { channelNumber = 11; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 16) { channelNumber = 12; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 17) { channelNumber = 12; channelSlot = ChannelSlot::C; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
@@ -179,22 +179,22 @@ std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int 
   else {
     if (semiPhiRegionRef == 0) { channelNumber = -1; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 1) { channelNumber = -1; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 2) { channelNumber = -2; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 2) { channelNumber = -2; channelSlot = ChannelSlot::C; }
     else if (semiPhiRegionRef == 3) { channelNumber = -3; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 4) { channelNumber = -3; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 5) { channelNumber = -4; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 5) { channelNumber = -4; channelSlot = ChannelSlot::C; }
     else if (semiPhiRegionRef == 6) { channelNumber = -5; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 7) { channelNumber = -5; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 8) { channelNumber = -6; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 8) { channelNumber = -6; channelSlot = ChannelSlot::C; }
     else if (semiPhiRegionRef == 9) { channelNumber = -7; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 10) { channelNumber = -7; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 11) { channelNumber = -8; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 11) { channelNumber = -8; channelSlot = ChannelSlot::C; }
     else if (semiPhiRegionRef == 12) { channelNumber = -9; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 13) { channelNumber = -9; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 14) { channelNumber = -10; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 14) { channelNumber = -10; channelSlot = ChannelSlot::C; }
     else if (semiPhiRegionRef == 15) { channelNumber = -11; channelSlot = ChannelSlot::A; }
     else if (semiPhiRegionRef == 16) { channelNumber = -11; channelSlot = ChannelSlot::C; }
-    else if (semiPhiRegionRef == 17) { channelNumber = -12; channelSlot = ChannelSlot::A; }
+    else if (semiPhiRegionRef == 17) { channelNumber = -12; channelSlot = ChannelSlot::C; }
     else { std::cout << "ERROR: semiPhiRegionRef = " << semiPhiRegionRef << std::endl; }
   }
 

--- a/src/OuterCabling/ServicesChannel.cc
+++ b/src/OuterCabling/ServicesChannel.cc
@@ -206,8 +206,8 @@ std::pair<int, ChannelSlot> PowerSection::computeChannelNumberAndSlot(const int 
  */
 const int PowerSection::computeChannelPlotColor(const int channelNumber, const ChannelSlot& channelSlot, const bool isPositiveCablingSide) const {
   int plotColor = fabs(channelNumber);
-  if ( (isPositiveCablingSide && channelSlot == ChannelSlot::A)
-       || (!isPositiveCablingSide && channelSlot == ChannelSlot::C)
+  if ( (isPositiveCablingSide && channelSlot == ChannelSlot::C)
+       || (!isPositiveCablingSide && channelSlot == ChannelSlot::A)
        ) {
     //if (channelSlot == ChannelSlot::A) {
     plotColor += 12;  // This is used to activate transparency.


### PR DESCRIPTION
This results in a shift of the channels used for powering.
NB: No change in the channels assignments mapping itself though! Just a shift of the sections available for powering.

**Power cables channels:**
**(+Z) end:** 
1C->1A, 3C->3A, etc. 
**(-Z) end:** 
-2A -> -2C, -4A -> -4C, etc. 

**Before PR:**
http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT616_200_IT404/cablingOuter.html 

Barrel, (+Z) end:
![barrelB](https://user-images.githubusercontent.com/11192654/79225200-ad6e4f00-7e5c-11ea-8cb9-9bb212606622.png)

TEDD Disk 1, (+Z) end:
![endcapB](https://user-images.githubusercontent.com/11192654/79225209-b101d600-7e5c-11ea-8058-615fe5b2e6c7.png)


**After PR:**
http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT616_IT615_cooling_update/cablingOuter.html

Barrel, (+Z) end:
![barrelA](https://user-images.githubusercontent.com/11192654/79225232-b7904d80-7e5c-11ea-8ea1-2700c70eefcb.png)

TEDD Disk 1, (+Z) end:
![endcapA](https://user-images.githubusercontent.com/11192654/79225237-b9f2a780-7e5c-11ea-857c-5ae7d9ee4b5e.png)
