### PR TITLE
Inner cabling map: Add GBT Id scheme for CMSSW integration

### DIFF
--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -49,6 +49,7 @@ public:
   // GENERAL INFO ON THE GBT
   const std::string GBTId() const { return myGBTId_; }
   const int GBTPhiIndex() const { return myGBTIndex_; }
+  const int getCMSSWId() const { return myGBTCMSSWId_; } 
   const int indexColor() const { return myGBTIndexColor_; }
   const int numELinksPerModule() const { return numELinksPerModule_; }
   
@@ -77,6 +78,7 @@ private:
   InnerBundle* myBundle_ = nullptr;
 
   std::string myGBTId_;
+  int myGBTCMSSWId_;
   int myGBTIndex_;
   int myGBTIndexColor_;
   int numELinksPerModule_;

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -691,17 +691,25 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
     //*                                   //
     //************************************//
 void CMSSWInnerTrackerCablingMapVisitor::preVisit() {
-  output_ << "Module DetId/U, DTC Id/U" << std::endl;
+  output_ << "Module DetId/U, GBT Id/U, DTC Id/U" << std::endl;
 }
 
 void CMSSWInnerTrackerCablingMapVisitor::visit(const Module& m) {
   std::stringstream moduleInfo;
   moduleInfo << m.myDetId() << ", ";
-  const InnerDTC* myDTC = m.getInnerDTC();
-  if (myDTC) {
-    std::stringstream DTCInfo;
-    DTCInfo << myDTC->myid();	 
-    output_ << moduleInfo.str() << DTCInfo.str() << std::endl;
+
+  const GBT* myGBT = m.getGBT();
+  if (myGBT) {
+    std::stringstream GBTInfo;
+    GBTInfo << myGBT->getCMSSWId() << ",";
+
+    const InnerDTC* myDTC = m.getInnerDTC();
+    if (myDTC) {
+      std::stringstream DTCInfo;
+      DTCInfo << myDTC->myid();	 
+      output_ << moduleInfo.str() << GBTInfo.str() << DTCInfo.str() << std::endl;
+    }
+    else output_ << moduleInfo.str() << GBTInfo.str() << std::endl;
   }
   else output_ << moduleInfo.str() << std::endl;
 }

--- a/src/InnerCabling/GBT.cc
+++ b/src/InnerCabling/GBT.cc
@@ -4,6 +4,7 @@
 
 GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule) :
   myGBTId_(GBTId),
+  myGBTCMSSWId_(myPowerChain->myid() * 10 + myGBTIndex),
   myGBTIndex_(myGBTIndex),
   myGBTIndexColor_(myGBTIndexColor),
   numELinksPerModule_(numELinksPerModule)


### PR DESCRIPTION
Simply used:
GBT Id = power chain id x 10 + GBTIndexInPowerChain. 
This is not as compact as it could be (not all consecutive integers values are used).
But much safer and easier to debug, and values are quite small anyway.

**After PR:** 
http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT616_IT613_IT_cabling_map_for_CMSSW/cablingInner.html 