### PR TITLE
Inner cabling map: Created CMSSW Id schemes for GBTs and DTCs (cache friendly for runs on GPUs)

### DIFF
--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -48,8 +48,9 @@ public:
 
   // GENERAL INFO ON THE GBT
   const std::string GBTId() const { return myGBTId_; }
+  void setCMSSWId(const int cmsswId) { myGBTCMSSWId_ = cmsswId; }
+  const int getCMSSWId() const { return myGBTCMSSWId_; }
   const int GBTPhiIndex() const { return myGBTIndex_; }
-  const int getCMSSWId() const { return myGBTCMSSWId_; } 
   const int indexColor() const { return myGBTIndexColor_; }
   const int numELinksPerModule() const { return numELinksPerModule_; }
   

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -52,6 +52,7 @@ private:
   const int computeDTCId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber) const;
   void createAndStoreDTCs(InnerBundle* myBundle, std::map<int, std::unique_ptr<InnerDTC> >& DTCs, const int DTCId, const bool isPositiveZEnd, const bool isPositiveXSide);
   void connectOneBundleToOneDTC(InnerBundle* myBundle, InnerDTC* myDTC) const;
+  void computeCMSSWIds(std::map<int, std::unique_ptr<InnerDTC> >& DTCs);
   void checkBundlesToDTCsCabling(const std::map<int, std::unique_ptr<InnerDTC> >& DTCs) const;
 
 

--- a/include/InnerCabling/InnerDTC.hh
+++ b/include/InnerCabling/InnerDTC.hh
@@ -26,11 +26,12 @@ public:
   const int numBundles() const { return bundles_.size(); }
   void addBundle(InnerBundle* bundle);
 
+  // GENERAL INFO
+  void setCMSSWId(const int cmsswId) { myDTCCMSSWId_ = cmsswId; }
+  const int getCMSSWId() const { return myDTCCMSSWId_; }
 
   const bool isPositiveZEnd() const { return isPositiveZEnd_; }
   const bool isPositiveXSide() const { return isPositiveXSide_; }
-
-  // GENERAL INFO
   const int plotColor() const { return plotColor_; }
 
 private:
@@ -38,9 +39,10 @@ private:
 
   Container bundles_;
 
+  int myDTCCMSSWId_;
+
   bool isPositiveZEnd_;
   bool isPositiveXSide_;
-
   int plotColor_;
 };
 

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -620,7 +620,7 @@ void CMSSWOuterTrackerCablingMapVisitor::visit(const Module& m) {
     //************************************//
 
 void InnerTrackerModulesToDTCsVisitor::preVisit() {
-  output_ << "Module_DetId/i, Module_Section/C, Module_Layer/I, Module_Ring/I, Module_phi_deg/D, N_Chips_Per_Module/I, N_Channels_Per_Module/I, Is_LongBarrel/O, Power_Chain/I, Power_Chain_Type/C, N_ELinks_Per_Module/I, LpGBT/C, MFB/I, DTC/I, IsPlusZEnd/O, IsPlusXSide/O" << std::endl;
+  output_ << "Module_DetId/i, Module_Section/C, Module_Layer/I, Module_Ring/I, Module_phi_deg/D, N_Chips_Per_Module/I, N_Channels_Per_Module/I, Is_LongBarrel/O, Power_Chain/I, Power_Chain_Type/C, N_ELinks_Per_Module/I, LpGBT_Id/C, LpGBT_CMSSW_IdPerDTC/U, MFB/I, DTC_Id/I, DTC_CMSSW_Id/U, IsPlusZEnd/O, IsPlusXSide/O" << std::endl;
 }
 
 void InnerTrackerModulesToDTCsVisitor::visit(const Barrel& b) {
@@ -661,7 +661,8 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
     if (myGBT != nullptr) {
       std::stringstream GBTInfo;
       GBTInfo << myGBT->numELinksPerModule() << ","
-	      << any2str(myGBT->GBTId()) << ",";
+	      << any2str(myGBT->GBTId()) << ","
+	      << myGBT->getCMSSWId() << ",";
 
       const InnerBundle* myBundle = myGBT->getBundle();
       if (myBundle != nullptr) {
@@ -672,6 +673,7 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
 	if (myDTC != nullptr) {
 	  std::stringstream DTCInfo;
 	  DTCInfo << myDTC->myid() << ","
+		  << myDTC->getCMSSWId() << ","
 		  << myDTC->isPositiveZEnd() << ","
 		  << myDTC->isPositiveXSide();
 	  output_ << moduleInfo.str() << powerChainInfo.str() << GBTInfo.str() << bundleInfo.str() << DTCInfo.str() << std::endl;
@@ -691,7 +693,7 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
     //*                                   //
     //************************************//
 void CMSSWInnerTrackerCablingMapVisitor::preVisit() {
-  output_ << "Module DetId/U, GBT Id/U, DTC Id/U" << std::endl;
+  output_ << "Module_DetId/U, GBT_CMSSW_IdPerDTC/U, DTC_CMSSW_Id/U" << std::endl;
 }
 
 void CMSSWInnerTrackerCablingMapVisitor::visit(const Module& m) {
@@ -706,7 +708,7 @@ void CMSSWInnerTrackerCablingMapVisitor::visit(const Module& m) {
     const InnerDTC* myDTC = m.getInnerDTC();
     if (myDTC) {
       std::stringstream DTCInfo;
-      DTCInfo << myDTC->myid();	 
+      DTCInfo << myDTC->getCMSSWId();	 
       output_ << moduleInfo.str() << GBTInfo.str() << DTCInfo.str() << std::endl;
     }
     else output_ << moduleInfo.str() << GBTInfo.str() << std::endl;

--- a/src/InnerCabling/GBT.cc
+++ b/src/InnerCabling/GBT.cc
@@ -4,7 +4,7 @@
 
 GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule) :
   myGBTId_(GBTId),
-  myGBTCMSSWId_(myPowerChain->myid() * 10 + myGBTIndex),
+  myGBTCMSSWId_(0), // Need to have consecutive integers, hence is done after full cabling map is created.
   myGBTIndex_(myGBTIndex),
   myGBTIndexColor_(myGBTIndexColor),
   numELinksPerModule_(numELinksPerModule)

--- a/src/InnerCabling/InnerDTC.cc
+++ b/src/InnerCabling/InnerDTC.cc
@@ -2,6 +2,7 @@
 
 
 InnerDTC::InnerDTC(const int DTCId, const bool isPositiveZEnd, const bool isPositiveXSide) :
+  myDTCCMSSWId_(0), // Need to have consecutive integers, hence is done after full cabling map is created.
   isPositiveZEnd_(isPositiveZEnd),
   isPositiveXSide_(isPositiveXSide)
 {
@@ -17,7 +18,6 @@ InnerDTC::InnerDTC(const int DTCId, const bool isPositiveZEnd, const bool isPosi
 void InnerDTC::addBundle(InnerBundle* bundle) { 
   bundles_.push_back(bundle);
 }
-
 
 
 /*

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8253,7 +8253,7 @@ namespace insur {
       ZPhiLayerPlots.push_back(std::move(ZPhiCanvasPos));
       // NEGATIVE X SIDE
       std::unique_ptr<TCanvas> ZPhiCanvasNeg(new TCanvas(Form("ZPhiGBTBarrelLayer%d_negativeXSide", layerNumber),
-					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
+					   Form("(ZPhi), Barrel Layer %d. (-X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasNeg->cd();
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerNeg;
@@ -9097,7 +9097,7 @@ namespace insur {
   std::string Vizard::createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* myInnerCablingMap) {
 
     std::stringstream dtcsToModulesCsv;
-    dtcsToModulesCsv << "IsPlusZEnd/O, IsPlusXSide/O, DTC/I, MFB/I, LpGBT/C, N_ELinks_Per_Module/I, Power_Chain/I, Power_Chain_Type/C, Is_LongBarrel/O, Module_DetId/i, Module_Section/C, Module_Layer/I, Module_Ring/I, Module_phi_deg/D, N_Chips_Per_Module/I, N_Channels_Per_Module/I" << std::endl;
+    dtcsToModulesCsv << "IsPlusZEnd/O, IsPlusXSide/O, DTC_Id/I, DTC_CMSSW_Id/U, MFB/I, LpGBT_Id/C, LpGBT_CMSSW_IdPerDTC/U, N_ELinks_Per_Module/I, Power_Chain/I, Power_Chain_Type/C, Is_LongBarrel/O, Module_DetId/i, Module_Section/C, Module_Layer/I, Module_Ring/I, Module_phi_deg/D, N_Chips_Per_Module/I, N_Channels_Per_Module/I" << std::endl;
 
     const std::map<int, std::unique_ptr<InnerDTC> >& myDTCs = myInnerCablingMap->getDTCs();
     for (const auto& itDTC : myDTCs) {
@@ -9106,7 +9106,8 @@ namespace insur {
 	std::stringstream DTCInfo;
 	DTCInfo << myDTC->isPositiveZEnd() << ","
 		<< myDTC->isPositiveXSide() << ","
-		<< myDTC->myid() << ",";
+		<< myDTC->myid() << ","
+		<< myDTC->getCMSSWId() << ",";
 
 	const std::vector<InnerBundle*>& myBundles = myDTC->bundles();
 	for (const auto& myBundle : myBundles) {
@@ -9117,6 +9118,7 @@ namespace insur {
 	  for (const auto& myGBT : myGBTs) {
 	    std::stringstream GBTInfo;
 	    GBTInfo << any2str(myGBT->GBTId()) << ","
+		    << myGBT->getCMSSWId() << ","
 		    << myGBT->numELinksPerModule() << ",";
 
 	    const PowerChain* myPowerChain = myGBT->getPowerChain();


### PR DESCRIPTION
Created CMSSW GBT and DTC Id schemes, not convenient for debugging, but better for the cabling map (in CMSSW) to be run on GPUs.

- GBTs CMSSW Ids are consecutive integers, and they are Ids PER DTC (from 1 to 60 max).
- DTCs are consecutive integers (from 1 to 28).

After PR: http://ghugo.web.cern.ch/ghugo/layouts/cabling/OT616_IT613_CMSSW_Ids/cablingInner.html