### PR TITLE
Minor-PR: Inner cabling map: consistent scheme for full Tracker

### DIFF
--- a/include/InnerCabling/inner_cabling_constants.hh
+++ b/include/InnerCabling/inner_cabling_constants.hh
@@ -60,4 +60,11 @@ static const std::string inner_cabling_tfpx = "FPIX_1";
 static const std::string inner_cabling_tepx = "FPIX_2";
 
 
+// CMSSW IDS
+// Total number of DTCs in OT
+static const int outer_cabling_totalNumDTCs = 216; // This could be obtained by:
+// outer_cabling_numNonants * outer_cabling_maxNumDTCsPerNonantPerZEnd,
+// but ugly to introduce dependency of IT cabling map on OT, because the maps are actually fully independent.
+
+
 #endif  // INNER_CABLING_CONSTANTS_HH

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -421,7 +421,7 @@ void InnerCablingMap::connectOneBundleToOneDTC(InnerBundle* myBundle, InnerDTC* 
  */
 void InnerCablingMap::computeCMSSWIds(std::map<int, std::unique_ptr<InnerDTC> >& DTCs) {
   int lastDTCId = 0;
-  int dtcCMSSWId = 0;
+  int dtcCMSSWId = outer_cabling_totalNumDTCs; // Start from last CMSSW OT Id, to be as compact as possible.
 
   // DTCs loop
   for (auto& it : DTCs) {
@@ -435,7 +435,7 @@ void InnerCablingMap::computeCMSSWIds(std::map<int, std::unique_ptr<InnerDTC> >&
     myDTC->setCMSSWId(dtcCMSSWId);
 
     std::string lastGBTId = "";
-    int gbtCMSSWId = 0; // CMSSW GBTs Ids are local: ie they are GBTs Ids PER DTC!!
+    int gbtCMSSWId = 0; // CMSSW GBTs Ids are local: ie they are Ids PER DTC!!
 
     const std::vector<InnerBundle*>& myBundles = myDTC->bundles();
     // Bundles loop


### PR DESCRIPTION
Add a shift of 216 (number of OT DTCs) to the IT DTC CMSSW Ids. 
This allows to have all Tracker DTCs Ids consecutive integers, from 1 to 216 + 28 = 244.