### PR TITLE
Add OT 801 (new TB2S with increased inter-ladder spacing) and IT 701 ('a la TEPX' dee model)

### DIFF
--- a/geometries/CMS_Phase2/OT800_IT701.cfg
+++ b/geometries/CMS_Phase2/OT800_IT701.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V800.cfg
+@include Pixel/Pixel_V7/Pixel_V7_0_1.cfg

--- a/geometries/CMS_Phase2/OT801_IT701.cfg
+++ b/geometries/CMS_Phase2/OT801_IT701.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V801.cfg
+@include Pixel/Pixel_V7/Pixel_V7_0_1.cfg

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V801.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/OT_V801.cfg
@@ -1,0 +1,29 @@
+Tracker Outer {
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsTracker.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDDTop_V616.cfg
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD2_V366.cfg
+
+  // Layout construction parameters
+  zError 70
+  zOverlap 0
+  etaCut 10
+  
+  @include-std CMS_Phase2/OuterTracker/moduleOperatingParms
+
+  trackingTags trigger,tracker
+  
+  barrelDetIdScheme Phase2Subdetector5
+  endcapDetIdScheme Phase2Subdetector4
+
+  @include TBPS_V800.cfg
+  @include TB2S_V801.cfg
+  @include TEDD1_V800.cfg
+  @include TEDD2_V800.cfg
+}
+
+Support {
+  midZ 290
+}
+
+
+

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V801.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TB2S_V801.cfg
@@ -1,0 +1,39 @@
+Barrel TB2S {
+  phiOverlap 0.9
+  phiSegments 2
+  
+  bigParity 1
+  smallParity 1
+  rotateBarrelByHalfPi true
+
+  @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+  @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+  @include-std CMS_Phase2/OuterTracker/Materials/rodPt2S
+  @include-std CMS_Phase2/OuterTracker/Conversions/flangeTB2S
+
+  dsDistance 1.8
+  Layer 1 { triggerWindow 9 }
+  Layer 2 { triggerWindow 12 }
+  Layer 3 { triggerWindow 15 }
+
+  @include-std CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsBarrelTB2S.cfg
+  bigDelta 15.8   // Antti 2015-02-18
+  smallDelta 2.75 // 2020-10-13
+  numLayers 3
+  numModules 12
+  startZMode moduleedge
+  innerRadiusFixed true
+  outerRadiusFixed true
+  innerRadius 687  // ideal = 687.134 for overlap = 1.0 (690.9 for overlap=0.5)
+  Layer 2 {
+    radiusMode fixed
+    placeRadiusHint 860 // ideal = 860.0 for overlap = 1.0 (864.7 for overlap=0.5)
+  }
+  outerRadius 1083 // used to be 1108, remove extra 25mm. ideal = 1119 for for overlap = 1.0 (1125.4 for overlap=0.5) 
+  sameRods true
+  compressed false
+
+  // Due to module mount on TB2S rod
+  forbiddenRange 91-95
+
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/FPIX1_7_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/FPIX1_7_0_1.cfg
@@ -1,0 +1,71 @@
+  Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_615
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 6.25
+    bigDelta 2.75 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_3D
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500_3D
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+    Disk 1 { placeZ 253.00 }
+    Disk 2 { placeZ 322.95 }
+    Disk 3 { placeZ 412.23 }
+    Disk 4 { placeZ 526.20 }
+    Disk 5 { placeZ 671.68 }
+    Disk 6 { placeZ 842.38 }     // -15 mm, optimal was: Z = 857.38 mm
+    Disk 7 { placeZ 1109.42 }    // +15 mm, optimal was: Z = 1094.42 mm
+    Disk 8 { placeZ 1397.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/Pixel_V7_0_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/Pixel_V7_0_1.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_7_0_0.cfg
+  @include FPIX1_7_0_1.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -548,3 +548,12 @@ OT616_IT700.cfg                      OT Version 6.1.6
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 
+================   INSTALLATION STUDIES   ================
+OT800_IT701.cfg                      OT Version 8.0.0
+                                     Based from Inner Tracker version 7.0.0.
+                                     TFPX: Change of ring paradigm: modules of the same ring are now on 2 different dees, instead of being on both sides of the same dee.
+                                     This model is already used in TEPX. 
+                                     This makes the dee model mecanically feasible (cut at X~0), and better equilibrates services distribution among disks.
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                                     
+
+

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -268,6 +268,9 @@ OT800_IT615.cfg	       Based from Outer Tracker version 616.
 		       TBPS:
 		          Adjustments in Layer 1 to enable a safe IT installation, while respecting needed spacing with TBPS Layer 2 (supports and services).
 		       	  Layer 1, Ring 12-16: radius +0.5 mm, tiltAngle 74 -> 72 deg.
+		       	  
+OT801_IT701.cfg	       Based from Outer Tracker version 800.
+                       TB2S: inter-ladder radial spacing increased by 1 mm (smallDelta: 2.25 mm -> 2.75 mm). Z positions recomputed accordingly.		       	  
 		                                          
 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>                          
 

--- a/src/RodPair.cc
+++ b/src/RodPair.cc
@@ -214,35 +214,14 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
       double forbiddenRange_begin,forbiddenRange_end; 
       forbiddenRange_begin=(forbiddenRange[0]+forbiddenRange[1])/2;
       forbiddenRange_end=forbiddenRange[1];
-
-      std::cout << subdetectorName_ << std::endl;
-      std::cout << "minr = " << minr << ", maxr = " << maxr  << std::endl;
-      std::cout << "Layer " << myid() << std::endl;
-      std::cout << "newZ = " << newZ << std::endl;
-      std::cout << "newZ from overlaps was " << newZA << std::endl;
-      std::cout << "newZ from zError() was " << newZB << std::endl;
-      std::cout << "sensor length = " << newDsLength << std::endl;
-      std::cout << "newZ-lastZ = " << (newZ-lastZ) << std::endl;
-      std::cout << "parity = " << parity << std::endl;
-
       if (newZ-lastZ >= (forbiddenRange_begin - newDsLength) && newZ - lastZ <= (forbiddenRange_end - newDsLength)) {
         newZ = lastZ + forbiddenRange_begin - newDsLength;
-	std::cout << "forbiddenRange_begin = forbiddenRange[0]" << std::endl;
-	std::cout << "forbiddenRange_end = (forbiddenRange[0]+forbiddenRange[1])/2" << std::endl;
-	std::cout << "(forbiddenRange_begin - newDsLength) <= (newZ - lastZ) <= (forbiddenRange_end - newDsLength) " << std::endl;
-	std::cout << (forbiddenRange_begin - newDsLength) << " <= (newZ - lastZ) <= " << (forbiddenRange_end - newDsLength) << std::endl;
-	std::cout << "newZ = " << newZ << std::endl;
       } else {
-	forbiddenRange_begin=forbiddenRange[0];
-	forbiddenRange_end=(forbiddenRange[0]+forbiddenRange[1])/2;
-	if (newZ-lastZ >= (forbiddenRange_begin - newDsLength) && newZ - lastZ <= (forbiddenRange_end - newDsLength)) {
-	  newZ = lastZ + forbiddenRange_begin - newDsLength;
-	  std::cout << "forbiddenRange_begin = (forbiddenRange[0]+forbiddenRange[1])/2" << std::endl;
-	  std::cout << "forbiddenRange_end = forbiddenRange[1]" << std::endl;
-	  std::cout << "(forbiddenRange_begin - newDsLength) <= (newZ - lastZ) <= (forbiddenRange_end - newDsLength) " << std::endl;
-	  std::cout << (forbiddenRange_begin - newDsLength) << " <= (newZ - lastZ) <= " << (forbiddenRange_end - newDsLength) << std::endl;
-	  std::cout << "newZ = " << newZ << std::endl;
-	}
+         forbiddenRange_begin=forbiddenRange[0];
+         forbiddenRange_end=(forbiddenRange[0]+forbiddenRange[1])/2;
+	 if (newZ-lastZ >= (forbiddenRange_begin - newDsLength) && newZ - lastZ <= (forbiddenRange_end - newDsLength)) {
+            newZ = lastZ + forbiddenRange_begin - newDsLength;
+	 }
       }
     }
   } 
@@ -370,7 +349,6 @@ void StraightRodPair::buildModules(Container& modules, const RodTemplate& rodTem
     if (smallDelta() != 0) { mod->flipped(parity != 1); } // When smallDelta() != 0, the flip is alternated.
     else { mod->flipped(!isPlusBigDeltaRod); } // When smallDelta() == 0, the flip only depends whether the rod is located at + BigDelta or at - BigDelta.
     mod->translateZ(posList[i] + (direction == BuildDir::RIGHT ? mod->length()/2 : -mod->length()/2));
-    std::cout << "mod->translateZ" << posList[i] + (direction == BuildDir::RIGHT ? mod->length()/2 : -mod->length()/2) << std::endl;
     // mod->translate(XYZVector(parity > 0 ? smallDelta() : -smallDelta(), 0, posList[i])); // CUIDADO: we are now translating the center instead of an edge as before
     modules.push_back(mod);
   }

--- a/src/RodPair.cc
+++ b/src/RodPair.cc
@@ -214,14 +214,35 @@ double StraightRodPair::computeNextZ(double newDsLength, double newDsDistance, d
       double forbiddenRange_begin,forbiddenRange_end; 
       forbiddenRange_begin=(forbiddenRange[0]+forbiddenRange[1])/2;
       forbiddenRange_end=forbiddenRange[1];
+
+      std::cout << subdetectorName_ << std::endl;
+      std::cout << "minr = " << minr << ", maxr = " << maxr  << std::endl;
+      std::cout << "Layer " << myid() << std::endl;
+      std::cout << "newZ = " << newZ << std::endl;
+      std::cout << "newZ from overlaps was " << newZA << std::endl;
+      std::cout << "newZ from zError() was " << newZB << std::endl;
+      std::cout << "sensor length = " << newDsLength << std::endl;
+      std::cout << "newZ-lastZ = " << (newZ-lastZ) << std::endl;
+      std::cout << "parity = " << parity << std::endl;
+
       if (newZ-lastZ >= (forbiddenRange_begin - newDsLength) && newZ - lastZ <= (forbiddenRange_end - newDsLength)) {
         newZ = lastZ + forbiddenRange_begin - newDsLength;
+	std::cout << "forbiddenRange_begin = forbiddenRange[0]" << std::endl;
+	std::cout << "forbiddenRange_end = (forbiddenRange[0]+forbiddenRange[1])/2" << std::endl;
+	std::cout << "(forbiddenRange_begin - newDsLength) <= (newZ - lastZ) <= (forbiddenRange_end - newDsLength) " << std::endl;
+	std::cout << (forbiddenRange_begin - newDsLength) << " <= (newZ - lastZ) <= " << (forbiddenRange_end - newDsLength) << std::endl;
+	std::cout << "newZ = " << newZ << std::endl;
       } else {
-         forbiddenRange_begin=forbiddenRange[0];
-         forbiddenRange_end=(forbiddenRange[0]+forbiddenRange[1])/2;
-	 if (newZ-lastZ >= (forbiddenRange_begin - newDsLength) && newZ - lastZ <= (forbiddenRange_end - newDsLength)) {
-            newZ = lastZ + forbiddenRange_begin - newDsLength;
-	 }
+	forbiddenRange_begin=forbiddenRange[0];
+	forbiddenRange_end=(forbiddenRange[0]+forbiddenRange[1])/2;
+	if (newZ-lastZ >= (forbiddenRange_begin - newDsLength) && newZ - lastZ <= (forbiddenRange_end - newDsLength)) {
+	  newZ = lastZ + forbiddenRange_begin - newDsLength;
+	  std::cout << "forbiddenRange_begin = (forbiddenRange[0]+forbiddenRange[1])/2" << std::endl;
+	  std::cout << "forbiddenRange_end = forbiddenRange[1]" << std::endl;
+	  std::cout << "(forbiddenRange_begin - newDsLength) <= (newZ - lastZ) <= (forbiddenRange_end - newDsLength) " << std::endl;
+	  std::cout << (forbiddenRange_begin - newDsLength) << " <= (newZ - lastZ) <= " << (forbiddenRange_end - newDsLength) << std::endl;
+	  std::cout << "newZ = " << newZ << std::endl;
+	}
       }
     }
   } 
@@ -349,6 +370,7 @@ void StraightRodPair::buildModules(Container& modules, const RodTemplate& rodTem
     if (smallDelta() != 0) { mod->flipped(parity != 1); } // When smallDelta() != 0, the flip is alternated.
     else { mod->flipped(!isPlusBigDeltaRod); } // When smallDelta() == 0, the flip only depends whether the rod is located at + BigDelta or at - BigDelta.
     mod->translateZ(posList[i] + (direction == BuildDir::RIGHT ? mod->length()/2 : -mod->length()/2));
+    std::cout << "mod->translateZ" << posList[i] + (direction == BuildDir::RIGHT ? mod->length()/2 : -mod->length()/2) << std::endl;
     // mod->translate(XYZVector(parity > 0 ? smallDelta() : -smallDelta(), 0, posList[i])); // CUIDADO: we are now translating the center instead of an edge as before
     modules.push_back(mod);
   }


### PR DESCRIPTION
**- OT 801:**
TB2S: inter-ladder radial spacing increased by 1 mm (smallDelta: 2.25 mm -> 2.75 mm). Z positions recomputed.

**- IT 701:**
TFPX: Change of ring paradigm: modules of the same ring are now on 2 different dees, instead of being on both sides of the same dee.
This model is already used in TEPX. 
This makes the dee model mecanically feasible (cut at X~0), and better equilibrates services distribution among disks.