### PR TITLE
FBCM in CMSSW: Cut out Tracker volume to leave space for FBCM

### DIFF
--- a/xml/pixfwd.xml
+++ b/xml/pixfwd.xml
@@ -52,7 +52,7 @@
    <ZSection z="120.9*cm"   rMin="6.23*cm" rMax="[TBPXAndTFPXOuterRadius]"/>
    <ZSection z="129.9*cm"   rMin="6.23*cm" rMax="[TBPXAndTFPXOuterRadius]"/>
    <ZSection z="129.9*cm"   rMin="6.23*cm" rMax="[TEPXOuterRadius]"/>
-   <ZSection z="247.8*cm"   rMin="6.23*cm" rMax="[RootRadius2]"/>
+   <ZSection z="247.8*cm"   rMin="6.23*cm" rMax="[TEPXOuterRadius]"/>
  </Polycone>
  <SubtractionSolid name="Phase2OTForward">
    <rSolid name="Forward"/>

--- a/xml/pixfwd.xml
+++ b/xml/pixfwd.xml
@@ -42,7 +42,9 @@
    <ZSection z="95.90*cm" rMin="2.8*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
    <ZSection z="120.9*cm" rMin="2.8*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
    <ZSection z="120.9*cm" rMin="6.23*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
-   <ZSection z="261.9*cm" rMin="6.23*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
+   <ZSection z="247.8*cm" rMin="6.23*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
+   <ZSection z="247.8*cm" rMin="110.0*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
+   <ZSection z="261.9*cm" rMin="110.0*cm" rMax="[pixbar:Tracker2SOuterRadius]"/>
  </Polycone>
  <Polycone name="Phase2PixelEndcap" startPhi="0*deg" deltaPhi="360*deg" >
    <ZSection z="[RootStartZ]"  rMin="2.8*cm" rMax="[TBPXAndTFPXOuterRadius]"/>
@@ -50,7 +52,7 @@
    <ZSection z="120.9*cm"   rMin="6.23*cm" rMax="[TBPXAndTFPXOuterRadius]"/>
    <ZSection z="129.9*cm"   rMin="6.23*cm" rMax="[TBPXAndTFPXOuterRadius]"/>
    <ZSection z="129.9*cm"   rMin="6.23*cm" rMax="[TEPXOuterRadius]"/>
-   <ZSection z="261.9*cm"   rMin="6.23*cm" rMax="[TEPXOuterRadius]"/>
+   <ZSection z="247.8*cm"   rMin="6.23*cm" rMax="[RootRadius2]"/>
  </Polycone>
  <SubtractionSolid name="Phase2OTForward">
    <rSolid name="Forward"/>

--- a/xml/trackerVolumeTemplate.xml
+++ b/xml/trackerVolumeTemplate.xml
@@ -14,5 +14,7 @@
   <ZSection z="22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>     <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm" -->
   <ZSection z="150.0*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="150.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-  <ZSection z="291.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="276.9*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="276.9*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="291.0*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
 </Polycone>


### PR DESCRIPTION
NB: In CMSSW, I placed **FBCM volume outside of Tracker volume, directly inside OCMS** (instead of being inside Tracker volume).
I find it safer and nicer to keep a consistent Tracker volume (with no FBCM inside). This will avoid regressions further downstream in CMSSW.

CMSSW PR to FBCM private repo at: https://github.com/m-sedghi/cmssw/pull/1 