### PR TITLE
CMS Phase 2 branches: Add CMake setup for Centos7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prerequisites
+# Environment
 
 tkLayout requires:
 
@@ -8,7 +8,8 @@ tkLayout requires:
 
 If you are on lxplus, you can just run a bash shell and then:
 
-     source setup_centos7.sh
+     source setup_centos7.sh         # If you plan to use make directly
+     source setupCMake_centos7.sh    # If you plan to use make CMake
      
      
 # Getting the code
@@ -16,17 +17,19 @@ If you are on lxplus, you can just run a bash shell and then:
      git clone https://github.com/tkLayout/tkLayout.git
      cd tkLayout
 
-The latest official version is at tkLayout/master branch, the latest devolpment version at tkLayout/dev branch.
+The latest official version is at tkLayout/master branch, the latest development version at tkLayout/dev branch.
+
 
 # Compilation
 
-Compilation using make:
+- Compilation using make:
 
     make -j8
+    make install
 
-This will build the needed programs and put them in the ./bin directory.
+This will build the needed programs, and put them in the tkLayout/bin directory.
 
-Compilation using cmake:
+- Compilation using cmake:
 
     mkdir build     (all object files, help files, libs, ... will be kept here)
     cd build
@@ -38,13 +41,8 @@ Compilation using cmake:
     make uninstall  (if cleaning needed)
     rm *            (clean all content in build directory & restart if needed)
 
-This will build the needed programs, copy the executables into tkLayout/bin directory and create symlink in ${HOME}/bin directory.
+This will build the needed programs, and put them in the tkLayout/build/bin directory.
 
-
-# Install
-  If the make command runs properly, you can install the program with:
-
-     make install
 
 ### First-time install
 If this is the first time that you install tkLayout, a few questions will be asked. You will need to provide:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Getting the code
+
+     git clone https://github.com/tkLayout/tkLayout.git
+     cd tkLayout
+
+The latest official version is at tkLayout/master branch, the latest development version at tkLayout/dev branch.
+
+
 # Environment
 
 tkLayout requires:
@@ -11,25 +19,17 @@ If you are on lxplus, you can just run a bash shell and then:
      source setup_centos7.sh         # If you plan to use make directly
      source setupCMake_centos7.sh    # If you plan to use make CMake
      
-     
-# Getting the code
-
-     git clone https://github.com/tkLayout/tkLayout.git
-     cd tkLayout
-
-The latest official version is at tkLayout/master branch, the latest development version at tkLayout/dev branch.
-
 
 # Compilation
 
-- Compilation using make:
+Compilation using make:
 
     make -j8
     make install
 
 This will build the needed programs, and put them in the tkLayout/bin directory.
 
-- Compilation using cmake:
+Compilation using cmake:
 
     mkdir build     (all object files, help files, libs, ... will be kept here)
     cd build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Getting the code
+# Getting the repository
 
      git clone https://github.com/tkLayout/tkLayout.git
      cd tkLayout

--- a/README.md
+++ b/README.md
@@ -22,18 +22,19 @@ The latest official version is at tkLayout/master branch, the latest devolpment 
 
 Compilation using make:
 
-    make
+    make -j8
 
 This will build the needed programs and put them in the ./bin directory.
 
-Compilation using cmake (NEW):
+Compilation using cmake:
 
     mkdir build     (all object files, help files, libs, ... will be kept here)
     cd build
     cmake ..        (generate makefile)
-    make install    (or write make all + make install)
+    make -j8
+    
     make doc        (generate Doxygen-based documentation in doc directory)
-
+    
     make uninstall  (if cleaning needed)
     rm *            (clean all content in build directory & restart if needed)
 
@@ -41,7 +42,7 @@ This will build the needed programs, copy the executables into tkLayout/bin dire
 
 
 # Install
-  If the make command runs properly you can install the program with the script
+  If the make command runs properly, you can install the program with:
 
      make install
 

--- a/setupCMake_centos7.sh
+++ b/setupCMake_centos7.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+ARCH=x86_64-centos7-gcc8
+RELEASE=/cvmfs/sft.cern.ch/lcg/releases
+RELEASE_LCG=$RELEASE/LCG_95
+VIEW_LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_95
+
+
+# CMAKE
+export PATH=$CONTRIB/CMake/3.13.4/Linux-x86_64/bin/:$PATH
+
+# COMPILER
+source $RELEASE/gcc/8.2.0/x86_64-centos7/setup.sh
+export CC=`which gcc`
+export CXX=`which g++`
+
+# ROOT
+source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
+export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
+
+# BOOST
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/lib
+
+# DOXYGEN
+export DOXYGEN_PATH=$RELEASE_LCG/doxygen/1.8.11/$ARCH-opt/bin/
+export PATH=${DOXYGEN_PATH}:${PATH}
+
+# GRAPHVIZ
+source $RELEASE_LCG/graphviz/2.28.0/$ARCH-opt/graphviz-env.sh
+
+# UPDATE PATH
+export PATH=`pwd`/build/bin:$PATH

--- a/setupCMake_centos7.sh
+++ b/setupCMake_centos7.sh
@@ -1,32 +1,14 @@
 #!/bin/bash
 
-ARCH=x86_64-centos7-gcc8
-RELEASE=/cvmfs/sft.cern.ch/lcg/releases
-RELEASE_LCG=$RELEASE/LCG_95
-VIEW_LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_95
+# EXPLICIT, MINIMAL DPEENDENCIES FOR CENTOS7
+source setup_centos7.sh
 
 
 # CMAKE
 export PATH=$CONTRIB/CMake/3.13.4/Linux-x86_64/bin/:$PATH
 
-# COMPILER
-source $RELEASE/gcc/8.2.0/x86_64-centos7/setup.sh
-export CC=`which gcc`
-export CXX=`which g++`
-
-# ROOT
-source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
-export LD_LIBRARY_PATH=$VIEW_LCG/$ARCH-opt/lib64/:$VIEW_LCG/$ARCH-opt/lib/:$LD_LIBRARY_PATH
-
 # BOOST
 export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/lib
-
-# DOXYGEN
-export DOXYGEN_PATH=$RELEASE_LCG/doxygen/1.8.11/$ARCH-opt/bin/
-export PATH=${DOXYGEN_PATH}:${PATH}
-
-# GRAPHVIZ
-source $RELEASE_LCG/graphviz/2.28.0/$ARCH-opt/graphviz-env.sh
 
 # UPDATE PATH
 export PATH=`pwd`/build/bin:$PATH

--- a/setupCMake_slc6.sh
+++ b/setupCMake_slc6.sh
@@ -1,26 +1,14 @@
 #!/bin/bash
 
-ARCH=x86_64-slc6-gcc8
-CONTRIB=/cvmfs/sft.cern.ch/lcg/contrib
-RELEASE_LCG=/cvmfs/sft.cern.ch/lcg/releases/LCG_95
-TK_DIRECTORY=$(dirname $BASH_SOURCE)
+# EXPLICIT, MINIMAL DPEENDENCIES FOR SLC6
+source setup_slc6.sh
 
 
 # CMAKE
 export PATH=$CONTRIB/CMake/3.13.4/Linux-x86_64/bin/:$PATH
 
-# COMPILER
-source $CONTRIB/gcc/8.2.0/$ARCH-opt/setup.sh
-export CC=`which gcc`
-export CXX=`which g++`
-
-# ROOT
-source $RELEASE_LCG/ROOT/6.16.00/$ARCH-dbg/bin/thisroot.sh
-source $TK_DIRECTORY/ROOT-env.sh
-
 # BOOST
-export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/include:$RELEASE_LCG/Boost/1.69.0/$ARCH-opt/lib
 
-# DOXYGEN
-export DOXYGEN_PATH=$RELEASE_LCG/doxygen/1.8.11/$ARCH-opt/bin/
-export PATH=${DOXYGEN_PATH}:${PATH}
+# UPDATE PATH
+export PATH=`pwd`/build/bin:$PATH


### PR DESCRIPTION
Usually just directly using make, but added setupCMake_centos7.sh for CMake users.