### PR TITLE
Fixing the tracker volume cut-out at the minus end for FBCM

### DIFF
--- a/xml/trackerVolumeTemplate.xml
+++ b/xml/trackerVolumeTemplate.xml
@@ -5,7 +5,9 @@
 -->
 <Polycone name="<!--mid point marker-->" startPhi="0*deg" deltaPhi="360*deg">
   <!-- TEMPORARY!! Should be defined automatically -->
-  <ZSection z="-291.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="-291.0*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="-276.9*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="-276.9*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-150.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-150.0*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>    <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" -->


### PR DESCRIPTION
In previous try to cut-out the FBCM volume (belongs to BRIL) from the tracker volume, the minus side was missed to be shortened on the PR [tkLayout:PR543](https://github.com/tkLayout/tkLayout/pull/543) at the commit [Cut out Tracker...](https://github.com/tkLayout/tkLayout/pull/543/commits/dba9dc2d6fbaa11d175ab76dca1a1b4b9e44911d). 
At this stage, the minus part of the tracker volume is also cut-out to make space for FBCM at the minus end. 
