### PR TITLE
Bricked export

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_bricked
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_bricked
@@ -1,0 +1,33 @@
+// 1x2 chips pixel module (25um x 100um)
+// Chip size 16.8 x 21.6
+moduleType pixel_1x2_25x100_wide_bricked  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.25mm)
+width 16.8
+length 43.45
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+deadAreaExtraLength 0.5
+deadAreaExtraWidth 0.5
+chipNegativeXExtraWidth 0.0   
+chipPositiveXExtraWidth 1.0
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.025
+  stripLengthEstimate 0.100
+  isBricked true
+  numROCX 1 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 11  // 

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
@@ -1,0 +1,33 @@
+// 2x2 chips pixel module (25um x 100um)
+// Chip size 16.8 x 21.6
+moduleType pixel_2x2_25x100_wide  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.25mm)
+width 33.85
+length 43.45
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+deadAreaExtraLength 0.5
+deadAreaExtraWidth 0.5
+chipNegativeXExtraWidth 1.0
+chipPositiveXExtraWidth 1.0
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.025
+  stripLengthEstimate 0.100
+  isBricked true
+  numROCX 2 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 12  // 

--- a/include/Sensor.hh
+++ b/include/Sensor.hh
@@ -53,7 +53,7 @@ public:
     stripLengthEstimate("stripLengthEstimate", parsedOnly()),
     numROCX("numROCX", parsedOnly()),
     numROCY("numROCY", parsedOnly()),
-    isBricked("isBricked", parsedOnly(),false),
+    isBricked("isBricked", parsedOnly(), false),
     sensorThickness("sensorThickness", parsedAndChecked()),
     type("sensorType", parsedOnly(), SensorType::None),
     powerPerChannel("powerPerChannel", parsedOnly()),

--- a/include/Sensor.hh
+++ b/include/Sensor.hh
@@ -31,6 +31,7 @@ public:
   ReadonlyProperty<int, NoDefault> numSegments;
   ReadonlyProperty<double, NoDefault> stripLengthEstimate;
   ReadonlyProperty<int, NoDefault> numROCX, numROCY;
+  ReadonlyProperty<bool, Default> isBricked;
   ReadonlyProperty<double, NoDefault> sensorThickness;
   ReadonlyProperty<SensorType, Default> type;
   ReadonlyProperty<double, Computable> minR, maxR;
@@ -52,6 +53,7 @@ public:
     stripLengthEstimate("stripLengthEstimate", parsedOnly()),
     numROCX("numROCX", parsedOnly()),
     numROCY("numROCY", parsedOnly()),
+    isBricked("isBricked", parsedOnly(),false),
     sensorThickness("sensorThickness", parsedAndChecked()),
     type("sensorType", parsedOnly(), SensorType::None),
     powerPerChannel("powerPerChannel", parsedOnly()),

--- a/include/tk2CMSSW_datatypes.hh
+++ b/include/tk2CMSSW_datatypes.hh
@@ -328,6 +328,7 @@ namespace insur {
       * * @struct ModuleROCInfo
       * * @brief The information in this struct is a parameter in SpecParInfo.
       * * @param name The module type
+      * * @param bricked Whether the module is bricked or not
       * * @param rocrows The number of ROCRows
       * * @param roccols The number of ROCCols
       * * @param rocx The number of ROC_X
@@ -335,6 +336,7 @@ namespace insur {
       * */
     struct ModuleROCInfo {
       std::string name;
+      bool bricked;
       std::string rocrows;
       std::string roccols;
       std::string rocx;

--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -286,6 +286,7 @@ namespace insur {
     static const std::string xml_roc_y = "PixelROC_Y";
     static const std::string xml_roc_rows_name = "PixelROCRows";
     static const std::string xml_roc_cols_name = "PixelROCCols";
+    static const std::string xml_bricked_name = "isBricked";
     static const std::string xml_par_tail = "Par";
     static const std::string xml_reco = "TrackerRecMaterial";
     static const std::string xml_OT_reco_layer_name = "Phase2OTBarrelLayer";

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -1188,6 +1188,7 @@ namespace insur {
 		// Topology
 		minfo.name		= iiter->getModule().moduleType();
 		mspec.partselectors.push_back(shape.name_tag);
+                minfo.bricked   = iiter->getModule().innerSensor().isBricked();
 		minfo.rocrows	= any2str<int>(iiter->getModule().innerSensor().numROCRows());  // in case of single sensor module innerSensor() and outerSensor() point to the same sensor
 		minfo.roccols	= any2str<int>(iiter->getModule().innerSensor().numROCCols());
 		minfo.rocx		= any2str<int>(iiter->getModule().innerSensor().numROCX());
@@ -1220,6 +1221,7 @@ namespace insur {
 
 		  // Topology
 		  mspec.partselectors.push_back(shape.name_tag);
+                  minfo.bricked = iiter->getModule().outerSensor().isBricked();
 		  minfo.rocrows	= any2str<int>(iiter->getModule().outerSensor().numROCRows());
 		  minfo.roccols	= any2str<int>(iiter->getModule().outerSensor().numROCCols());
 		  minfo.rocx	= any2str<int>(iiter->getModule().outerSensor().numROCX());
@@ -1299,6 +1301,7 @@ namespace insur {
 		  if (std::find(mspec.partselectors.begin(), mspec.partselectors.end(), crystalName) == mspec.partselectors.end()) {
 		    minfo.name		= iiter->getModule().moduleType();
 		    mspec.partselectors.push_back(crystalName);
+		    minfo.bricked	= iiter->getModule().innerSensor().isBricked();
 		    minfo.rocrows	= any2str<int>(iiter->getModule().innerSensor().numROCRows());
 		    minfo.roccols	= any2str<int>(iiter->getModule().innerSensor().numROCCols());
 		    minfo.rocx		= any2str<int>(iiter->getModule().innerSensor().numROCX());
@@ -2370,6 +2373,7 @@ namespace insur {
 	      // Topology
 	      mspec.partselectors.push_back(logic.name_tag);
 	      minfo.name		= iiter->getModule().moduleType();
+	      minfo.bricked	= iiter->getModule().innerSensor().isBricked();
 	      minfo.rocrows	= any2str<int>(iiter->getModule().innerSensor().numROCRows());
 	      minfo.roccols	= any2str<int>(iiter->getModule().innerSensor().numROCCols());
 	      minfo.rocx		= any2str<int>(iiter->getModule().innerSensor().numROCX());
@@ -2401,6 +2405,7 @@ namespace insur {
 
 		// Topology
 		mspec.partselectors.push_back(logic.name_tag);
+		minfo.bricked	= iiter->getModule().outerSensor().isBricked();
 		minfo.rocrows	= any2str<int>(iiter->getModule().outerSensor().numROCRows());
 		minfo.roccols	= any2str<int>(iiter->getModule().outerSensor().numROCCols());
 		minfo.rocx		= any2str<int>(iiter->getModule().outerSensor().numROCX());

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -967,7 +967,7 @@ namespace insur {
       if( param.second.find("TIDDet") != std::string::npos) param.second = xml_subdet_tiddet;
       stream<< xml_spec_par_parameter_first << xml_tkddd_structure << xml_spec_par_parameter_second  << param.second  << xml_general_endline;
       if( minfo.at(i).bricked ){ // Only add the line if isBricked exists
-          stream<< xml_spec_par_parameter_first << xml_bricked_name    << xml_spec_par_parameter_second << xml_true <<xml_general_endline;
+          stream<< xml_spec_par_parameter_first << xml_bricked_name << xml_spec_par_parameter_second << xml_true << xml_general_endline;
       }
       stream<< xml_spec_par_parameter_first << xml_roc_rows_name   << xml_spec_par_parameter_evaluation << xml_spec_par_parameter_second  << minfo.at(i).rocrows  << xml_general_endline;
       stream<< xml_spec_par_parameter_first << xml_roc_cols_name   << xml_spec_par_parameter_evaluation << xml_spec_par_parameter_second  << minfo.at(i).roccols  << xml_general_endline;

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -966,6 +966,9 @@ namespace insur {
       if( param.second.find("TOBDet") != std::string::npos) param.second = xml_subdet_tobdet_1;
       if( param.second.find("TIDDet") != std::string::npos) param.second = xml_subdet_tiddet;
       stream<< xml_spec_par_parameter_first << xml_tkddd_structure << xml_spec_par_parameter_second  << param.second  << xml_general_endline;
+      if( minfo.at(i).bricked ){ // Only add the line if isBricked exists
+          stream<< xml_spec_par_parameter_first << xml_bricked_name    << xml_spec_par_parameter_second << xml_true <<xml_general_endline;
+      }
       stream<< xml_spec_par_parameter_first << xml_roc_rows_name   << xml_spec_par_parameter_evaluation << xml_spec_par_parameter_second  << minfo.at(i).rocrows  << xml_general_endline;
       stream<< xml_spec_par_parameter_first << xml_roc_cols_name   << xml_spec_par_parameter_evaluation << xml_spec_par_parameter_second  << minfo.at(i).roccols  << xml_general_endline;
       stream<< xml_spec_par_parameter_first << xml_roc_x           << xml_spec_par_parameter_evaluation << xml_spec_par_parameter_second  << minfo.at(i).rocx     << xml_general_endline;


### PR DESCRIPTION
This adds a new bricked module type so the `isBricked` property can be written into the XML's. Nothing changes in the TkLayout analysis (no new resolutions etc.), at this point really just to make it easier to set the property in the XML's correctly. 

No configs included in the PR for now, but an example geometry can be found here: https://adewit.web.cern.ch/adewit/layouts/OT800_IT700_BRICKED/info.html 