### PR TITLE
Latest IT cabling map flavor (notably, GBTs reshuffling in TBPX Layers 2 & 3)

### DIFF
--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -24,7 +24,7 @@ class GBT : public PropertyObject, public Buildable, public Identifiable<int> {
   typedef std::vector<Module*> Container; 
 
 public:
-  GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule);
+  GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndexColor, const int numELinksPerModule);
 
   // MODULES CONNECTED TO THE GBT
   const Container& modules() const { return modules_; }
@@ -71,6 +71,7 @@ public:
   const int plotPowerChainColor() const { return plotPowerChainColor_; }
 
 private:
+  const int computePlotGBTIndexInPowerChain(const int myGBTIndexInPowerChain, PowerChain* myPowerChain) const;
   const int computePlotColor(const PowerChain* myPowerChain) const;
 
   Container modules_;

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -50,8 +50,8 @@ public:
   const std::string GBTId() const { return myGBTId_; }
   void setCMSSWId(const int cmsswId) { myGBTCMSSWId_ = cmsswId; }
   const int getCMSSWId() const { return myGBTCMSSWId_; }
-  const int GBTPhiIndex() const { return myGBTIndex_; }
-  const int indexColor() const { return myGBTIndexColor_; }
+  const int GBTIndexInPowerChain() const { return myGBTIndexInPowerChain_; }
+  const int plotGBTIndexInPowerChain() const { return plotGBTIndexInPowerChain_; }
   const int numELinksPerModule() const { return numELinksPerModule_; }
   
   const bool isPositiveZEnd() const { return myPowerChain_->isPositiveZEnd(); }
@@ -68,7 +68,7 @@ public:
   const int powerChainPhiRef() const { return myPowerChain_->phiRef(); }
   
 
-  const int plotColor() const { return plotColor_; }
+  const int plotPowerChainColor() const { return plotPowerChainColor_; }
 
 private:
   const int computePlotColor(const PowerChain* myPowerChain) const;
@@ -80,11 +80,11 @@ private:
 
   std::string myGBTId_;
   int myGBTCMSSWId_;
-  int myGBTIndex_;
-  int myGBTIndexColor_;
+  int myGBTIndexInPowerChain_;
+  int plotGBTIndexInPowerChain_;
   int numELinksPerModule_;
 
-  int plotColor_;
+  int plotPowerChainColor_;
 };
 
 

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -50,8 +50,8 @@ public:
   const std::string GBTId() const { return myGBTId_; }
   void setCMSSWId(const int cmsswId) { myGBTCMSSWId_ = cmsswId; }
   const int getCMSSWId() const { return myGBTCMSSWId_; }
-  const int GBTIndexInPowerChain() const { return myGBTIndexInPowerChain_; }
-  const int plotGBTIndexInPowerChain() const { return plotGBTIndexInPowerChain_; }
+  const int GBTIndexInPowerChain() const { return myGBTIndexInPowerChain_; } // GBT location index in power chain
+  const int plotStyleGBTIndexInPowerChain() const { return plotStyleGBTIndexInPowerChain_; } // GBT plotting style
   const int numELinksPerModule() const { return numELinksPerModule_; }
   
   const bool isPositiveZEnd() const { return myPowerChain_->isPositiveZEnd(); }
@@ -71,7 +71,7 @@ public:
   const int plotPowerChainColor() const { return plotPowerChainColor_; }
 
 private:
-  const int computePlotGBTIndexInPowerChain(const int myGBTIndexInPowerChain, PowerChain* myPowerChain) const;
+  const int computePlotStyleGBTIndexInPowerChain(const int myGBTIndexInPowerChain, PowerChain* myPowerChain) const;
   const int computePlotColor(const PowerChain* myPowerChain) const;
 
   Container modules_;
@@ -82,7 +82,7 @@ private:
   std::string myGBTId_;
   int myGBTCMSSWId_;
   int myGBTIndexInPowerChain_;
-  int plotGBTIndexInPowerChain_;
+  int plotStyleGBTIndexInPowerChain_;
   int numELinksPerModule_;
 
   int plotPowerChainColor_;

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -35,9 +35,9 @@ private:
 
   // CONNECT MODULES TO GBTS
   const std::pair<int, double> computeNumGBTsInPowerChain(const int numELinksPerModule, const int numModulesInPowerChain, const bool isBarrel);
-  const std::pair<int, int> computeGBTPhiIndex(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
+  const int computeGBTIndexInPowerChain(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
   const std::string computeGBTId(const int powerChainId, const int myGBTIndex) const;
-  void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
+  void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
   void connectOneModuleToOneGBT(Module* m, GBT* GBT) const;
   void checkModulesToGBTsCabling(const std::map<std::string, std::unique_ptr<GBT> >& GBTs) const;
 

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -35,7 +35,7 @@ private:
 
   // CONNECT MODULES TO GBTS
   const std::pair<int, double> computeNumGBTsInPowerChain(const int numELinksPerModule, const int numModulesInPowerChain, const bool isBarrel);
-  const std::pair<int, int> computeGBTPhiIndex(const bool isBarrel, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
+  const std::pair<int, int> computeGBTPhiIndex(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
   const std::string computeGBTId(const int powerChainId, const int myGBTIndex) const;
   void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
   void connectOneModuleToOneGBT(Module* m, GBT* GBT) const;

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -30,6 +30,11 @@ public:
   const int numModules() const { return modules_.size(); }
   void addModule(Module* m);
 
+  // GBTs CONNECTED TO THE MODULES WHICH ARE IN THE SAME POWER CHAIN
+  // NB: This is set a posteriori, once the connections from the modules to the GBTs are made.
+  void setNumGBTsInPowerChain(const int numGBTsInPowerChain) { numGBTsInPowerChain_ = numGBTsInPowerChain; }
+  const int numGBTsInPowerChain() const { return numGBTsInPowerChain_; }
+
   // HIGH VOLTAGE LINE, TO WHICH THE MODULES OF THE POWER CHAIN ARE ALL CONNECTED
   const HvLine* getHvLine() const {
     if (!hvLine_) throw PathfulException("hvLine_ is nullptr");
@@ -66,6 +71,8 @@ private:
   const std::string computeHvLineName(const int powerChainId) const;
 
   Container modules_;
+
+  int numGBTsInPowerChain_ = 0;
 
   std::unique_ptr<HvLine> hvLine_; // PowerChain owns HvLine
 

--- a/include/InnerCabling/inner_cabling_constants.hh
+++ b/include/InnerCabling/inner_cabling_constants.hh
@@ -13,7 +13,7 @@ static const int inner_cabling_maxNumModulesPerPowerChain = 12;
 // Maximum number of ELinks per GBT
 static const int inner_cabling_maxNumELinksPerGBT = 7;
 // Maximum number of modules per GBT
-static const int inner_cabling_maxNumModulesPerGBT = 5;
+static const int inner_cabling_maxNumModulesPerGBT = 6;
 // Maximum number of GBTs per bundle
 static const int inner_cabling_maxNumGBTsPerBundle = 12;
 // Maximum number of bundles per cable

--- a/include/InnerCabling/inner_cabling_constants.hh
+++ b/include/InnerCabling/inner_cabling_constants.hh
@@ -12,6 +12,8 @@
 static const int inner_cabling_maxNumModulesPerPowerChain = 12;
 // Maximum number of ELinks per GBT
 static const int inner_cabling_maxNumELinksPerGBT = 7;
+// Maximum number of modules per GBT
+static const int inner_cabling_maxNumModulesPerGBT = 5;
 // Maximum number of GBTs per bundle
 static const int inner_cabling_maxNumGBTsPerBundle = 12;
 // Maximum number of bundles per cable

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -229,6 +229,23 @@ struct FillStyle {
   template <class StatType> void operator()(TPolyLine& line, StatType& bin, const DrawerPalette& palette) const {
     line.SetFillColor(palette.getColor(bin.get()));
     line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY(),"f");
+
+    /*line.SetLineColor(0);
+    line.SetLineWidth(2);
+    line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY());*/
+  }
+};
+
+struct DashedContourStyle {
+  template <class StatType> void operator()(TPolyLine& line, StatType& bin, const DrawerPalette& palette) const {
+    line.SetFillColor(palette.getColor(bin.get()));
+    line.SetFillStyle(3004);
+    line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY(),"f");
+
+    line.SetLineColor(palette.getColor(bin.get()));
+    line.SetLineWidth(2);
+    //line.SetLineStyle(7);
+    line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY());
   }
 };
 

--- a/include/PlotDrawer.hh
+++ b/include/PlotDrawer.hh
@@ -224,33 +224,26 @@ public:
 
 
 
-
 struct FillStyle {
   template <class StatType> void operator()(TPolyLine& line, StatType& bin, const DrawerPalette& palette) const {
     line.SetFillColor(palette.getColor(bin.get()));
     line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY(),"f");
-
-    /*line.SetLineColor(0);
-    line.SetLineWidth(2);
-    line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY());*/
   }
 };
 
-struct DashedContourStyle {
+struct DashedStyle {
   template <class StatType> void operator()(TPolyLine& line, StatType& bin, const DrawerPalette& palette) const {
+    // dashed fill style
     line.SetFillColor(palette.getColor(bin.get()));
-    line.SetFillStyle(3004);
+    line.SetFillStyle(3004); // dashed fill style
     line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY(),"f");
 
+    // draw contour as well for clarity
     line.SetLineColor(palette.getColor(bin.get()));
     line.SetLineWidth(2);
-    //line.SetLineStyle(7);
     line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY());
   }
 };
-
-extern int
-g;
 
 class ContourStyle {
   const int lineWidth_;
@@ -262,6 +255,9 @@ public:
     line.DrawPolyLine(line.GetN(),line.GetX(),line.GetY());
   }
 };
+
+extern int
+g;
 
 
 // ===============================================================================================
@@ -560,11 +556,11 @@ struct HistogramFrameStyle {
 ///   - canvas is the TCanvas to draw on. cd() is called automatically by the PlotDrawer
 ///   - frameStyle is the instance of a FrameStyleType class, which can be used in case of custom frame styles. Default is FrameStyleType<CoordType>()
 /// 4) Draw the modules: void drawModules<DrawStyleType>(canvas, drawStyle)
-///   - DrawStyleType is the style of module drawing. The predefined classes are ContourStyle (which only draws the contours of modules) and FillStyle (which draws solid modules).
+///   - DrawStyleType is the style of module drawing. The predefined classes are ContourStyle (which only draws the contours of modules), FillStyle (which draws filled modules), and DashedStyle (which draws dashed modules).
 ///   - canvas is the TCanvas to draw on. cd() is called automatically by the PlotDrawer
 ///   - drawStyle is the instance of a DrawStyleType class, which can be used in case of custom draw styles. Default is DrawStyleType<CoordType>()
 /// 5) Draw the modules with outer contour: void drawModuleContours<DrawStyleType>(canvas, drawStyle)
-///   - DrawStyleType is the style of module drawing. The predefined classes are ContourStyle (which only draws the contours of modules) and FillStyle (which draws solid modules).
+///   - DrawStyleType is the style of module drawing. The predefined classes are ContourStyle (which only draws the contours of modules), FillStyle (which draws filled modules), and DashedStyle (which draws dashed modules).
 ///   - canvas is the TCanvas to draw on. cd() is called automatically by the PlotDrawer
 ///   - drawStyle is the instance of a DrawStyleType class, which can be used in case of custom draw styles. Default is DrawStyleType<CoordType>()
 

--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -185,7 +185,7 @@ namespace insur {
   // TODO: make sure the following constants are only used in
   // mainConfigHandler
   static const std::string default_cabledOTName                  = "OT616";
-  static const std::string default_cabledITName                  = "IT613";
+  static const std::string default_cabledITName                  = "IT701";
   static const std::string default_mattabdir                     = "config";
   static const std::string default_mattabfile                    = "mattab.list";
   static const std::string default_chemicalElementsFile          = "chemical_elements.list";

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -825,7 +825,7 @@ const int DetectorModule::gbtPlotColor() const {
   int gbtPlotColor = 0;
   const GBT* myGBT = getGBT();
   if (myGBT) {
-    gbtPlotColor = myGBT->plotColor();
+    gbtPlotColor = myGBT->plotPowerChainColor();
   }
   return gbtPlotColor;
 }

--- a/src/InnerCabling/GBT.cc
+++ b/src/InnerCabling/GBT.cc
@@ -6,7 +6,7 @@ GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex
   myGBTId_(GBTId),
   myGBTCMSSWId_(0), // Need to have consecutive integers, hence is done after full cabling map is created.
   myGBTIndexInPowerChain_(myGBTIndexInPowerChain),
-  plotGBTIndexInPowerChain_(computePlotGBTIndexInPowerChain(myGBTIndexInPowerChain)),
+  plotGBTIndexInPowerChain_(computePlotGBTIndexInPowerChain(myGBTIndexInPowerChain, myPowerChain)),
   numELinksPerModule_(numELinksPerModule)
 {
   myPowerChain_ = myPowerChain;
@@ -26,26 +26,21 @@ void GBT::addModule(Module* m) {
  * Compute GBT plot style on website.
  * To distinguish different GBTs within the same power chain, alternation of fill, contour and dashed styles is used
  */
-const int GBT::computePlotGBTIndexInPowerChain(const int myGBTIndexInPowerChain) const {
-
-  if (isBarrel) {
-    std::cout << "ringRef = " << ringRef << std::endl;
-    std::cout << "moduleRef = " << moduleRef << std::endl;
-    std::cout << "myGBTIndexInPowerChainExact = " << myGBTIndexInPowerChainExact << std::endl;
-    std::cout << "myGBTIndexInPowerChain = " << myGBTIndexInPowerChain << std::endl;
-  }
+const int GBT::computePlotGBTIndexInPowerChain(const int myGBTIndexInPowerChain, PowerChain* myPowerChain) const {
+  const bool isBarrel = myPowerChain->isBarrel();
+  const int numGBTsInPowerChain = myPowerChain->numGBTsInPowerChain();
 
   //int myGBTIndexInPowerChainPlotStyle = myGBTIndexInPowerChain;
   //if (isBarrel && phiRefInPowerChain == 1 && femod(numGBTsInPowerChain, 2) == 0) myGBTIndexInPowerChainPlotStyle += 1;
 
   //myGBTIndexInPowerChainPlotStyle = femod(myGBTIndexInPowerChainPlotStyle, 2);
   std::cout << "numGBTsInPowerChain = " << numGBTsInPowerChain << std::endl;
-  int myGBTIndexInPowerChainPlotStyle = ( (!isBarrel || femod(numGBTsInPowerChain, 2) == 0 ) ? femod(myGBTIndexInPowerChain, 2) : femod(myGBTIndexInPowerChain, 3));
+  const int myGBTIndexInPowerChainPlotStyle = ( (!isBarrel || femod(numGBTsInPowerChain, 2) == 0 ) ? femod(myGBTIndexInPowerChain, 2) : femod(myGBTIndexInPowerChain, 3));
   //myGBTIndexInPowerChainPlotStyle = femod(myGBTIndexInPowerChainPlotStyle, 3);
   std::cout << "myGBTIndexInPowerChainPlotStyle = " << myGBTIndexInPowerChainPlotStyle << std::endl;
 
   //myGBTIndexInPowerChainPlotStyle = myGBTIndexInPowerChainPlotStyle;
-
+  return myGBTIndexInPowerChainPlotStyle;
 }
 
 

--- a/src/InnerCabling/GBT.cc
+++ b/src/InnerCabling/GBT.cc
@@ -2,15 +2,15 @@
 #include "InnerCabling/InnerBundle.hh"
 
 
-GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex, const int myGBTIndexColor, const int numELinksPerModule) :
+GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndexInPowerChain, const int numELinksPerModule) :
   myGBTId_(GBTId),
   myGBTCMSSWId_(0), // Need to have consecutive integers, hence is done after full cabling map is created.
-  myGBTIndex_(myGBTIndex),
-  myGBTIndexColor_(myGBTIndexColor),
+  myGBTIndexInPowerChain_(myGBTIndexInPowerChain),
+  plotGBTIndexInPowerChain_(computePlotGBTIndexInPowerChain(myGBTIndexInPowerChain)),
   numELinksPerModule_(numELinksPerModule)
 {
   myPowerChain_ = myPowerChain;
-  plotColor_ = computePlotColor(myPowerChain);
+  plotPowerChainColor_ = computePlotColor(myPowerChain);
 };
 
 
@@ -23,11 +23,37 @@ void GBT::addModule(Module* m) {
 
 
 /*
+ * Compute GBT plot style on website.
+ * To distinguish different GBTs within the same power chain, alternation of fill, contour and dashed styles is used
+ */
+const int GBT::computePlotGBTIndexInPowerChain(const int myGBTIndexInPowerChain) const {
+
+  if (isBarrel) {
+    std::cout << "ringRef = " << ringRef << std::endl;
+    std::cout << "moduleRef = " << moduleRef << std::endl;
+    std::cout << "myGBTIndexInPowerChainExact = " << myGBTIndexInPowerChainExact << std::endl;
+    std::cout << "myGBTIndexInPowerChain = " << myGBTIndexInPowerChain << std::endl;
+  }
+
+  //int myGBTIndexInPowerChainPlotStyle = myGBTIndexInPowerChain;
+  //if (isBarrel && phiRefInPowerChain == 1 && femod(numGBTsInPowerChain, 2) == 0) myGBTIndexInPowerChainPlotStyle += 1;
+
+  //myGBTIndexInPowerChainPlotStyle = femod(myGBTIndexInPowerChainPlotStyle, 2);
+  std::cout << "numGBTsInPowerChain = " << numGBTsInPowerChain << std::endl;
+  int myGBTIndexInPowerChainPlotStyle = ( (!isBarrel || femod(numGBTsInPowerChain, 2) == 0 ) ? femod(myGBTIndexInPowerChain, 2) : femod(myGBTIndexInPowerChain, 3));
+  //myGBTIndexInPowerChainPlotStyle = femod(myGBTIndexInPowerChainPlotStyle, 3);
+  std::cout << "myGBTIndexInPowerChainPlotStyle = " << myGBTIndexInPowerChainPlotStyle << std::endl;
+
+  //myGBTIndexInPowerChainPlotStyle = myGBTIndexInPowerChainPlotStyle;
+
+}
+
+
+/*
  * Compute GBT color on website.
  * GBT color is the same as the power chain its modules belong to.
- * To distinguish different GBTs on the same power chain, alternation of fill and contour style is used.
  */
 const int GBT::computePlotColor(const PowerChain* myPowerChain) const {
-  const int plotColor = myPowerChain->plotColor();
-  return plotColor;
+  const int plotPowerChainColor = myPowerChain->plotColor();
+  return plotPowerChainColor;
 }

--- a/src/InnerCabling/GBT.cc
+++ b/src/InnerCabling/GBT.cc
@@ -6,7 +6,7 @@ GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex
   myGBTId_(GBTId),
   myGBTCMSSWId_(0), // Need to have consecutive integers, hence is done after full cabling map is created.
   myGBTIndexInPowerChain_(myGBTIndexInPowerChain),
-  plotGBTIndexInPowerChain_(computePlotGBTIndexInPowerChain(myGBTIndexInPowerChain, myPowerChain)),
+  plotStyleGBTIndexInPowerChain_(computePlotStyleGBTIndexInPowerChain(myGBTIndexInPowerChain, myPowerChain)),
   numELinksPerModule_(numELinksPerModule)
 {
   myPowerChain_ = myPowerChain;
@@ -24,22 +24,22 @@ void GBT::addModule(Module* m) {
 
 /*
  * Compute GBT plot style on website.
- * To distinguish different GBTs within the same power chain, alternation of fill, contour and dashed styles is used
+ * To distinguish different GBTs within the same power chain, alternation of fill, contour and dashed styles is used.
  */
-const int GBT::computePlotGBTIndexInPowerChain(const int myGBTIndexInPowerChain, PowerChain* myPowerChain) const {
+const int GBT::computePlotStyleGBTIndexInPowerChain(const int myGBTIndexInPowerChain, PowerChain* myPowerChain) const {
   const bool isBarrel = myPowerChain->isBarrel();
   const int numGBTsInPowerChain = myPowerChain->numGBTsInPowerChain();
 
-  //int myGBTIndexInPowerChainPlotStyle = myGBTIndexInPowerChain;
-  //if (isBarrel && phiRefInPowerChain == 1 && femod(numGBTsInPowerChain, 2) == 0) myGBTIndexInPowerChainPlotStyle += 1;
-
-  //myGBTIndexInPowerChainPlotStyle = femod(myGBTIndexInPowerChainPlotStyle, 2);
-  std::cout << "numGBTsInPowerChain = " << numGBTsInPowerChain << std::endl;
-  const int myGBTIndexInPowerChainPlotStyle = ( (!isBarrel || femod(numGBTsInPowerChain, 2) == 0 ) ? femod(myGBTIndexInPowerChain, 2) : femod(myGBTIndexInPowerChain, 3));
-  //myGBTIndexInPowerChainPlotStyle = femod(myGBTIndexInPowerChainPlotStyle, 3);
-  std::cout << "myGBTIndexInPowerChainPlotStyle = " << myGBTIndexInPowerChainPlotStyle << std::endl;
-
-  //myGBTIndexInPowerChainPlotStyle = myGBTIndexInPowerChainPlotStyle;
+  // Usually, only 2 plot styles are needed (for example, alternation of fill and empty plot styles) 
+  // to distinguish the GBTs among a power chain.
+  // Exception: case of an odd number of GBTs within the same power chain in the barrel:
+  // a third plot style (for example, dashed) becomes necessary.
+  const int myGBTIndexInPowerChainPlotStyle = ( (!isBarrel || femod(numGBTsInPowerChain, 2) == 0 ) 
+                                                // 2 styles are enough (for example, full and contour)
+                                                ? femod(myGBTIndexInPowerChain, 2)
+                                                // 3 styles are necessary (for example, full, contour, and dashed)
+                                                : femod(myGBTIndexInPowerChain, 3));
+ 
   return myGBTIndexInPowerChainPlotStyle;
 }
 

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -110,7 +110,7 @@ const std::pair<int, double> InnerCablingMap::computeNumGBTsInPowerChain(const i
                            // This is becasue it makes the powering of the GBTs much easier.
 			   }*/
 
-  const double maxNumModulesPerGBTExact = static_cast<double>(inner_cabling_maxNumELinksPerGBT) / numELinksPerModule;
+  const double maxNumModulesPerGBTExact = std::min(static_cast<double>(inner_cabling_maxNumELinksPerGBT) / numELinksPerModule, static_cast<double>(inner_cabling_maxNumModulesPerGBT));
   const int maxNumModulesPerGBT = (fabs(maxNumModulesPerGBTExact - round(maxNumModulesPerGBTExact)) < inner_cabling_roundingTolerance ? 
 					       round(maxNumModulesPerGBTExact) 
 					       : std::floor(maxNumModulesPerGBTExact)

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -67,6 +67,7 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
     const std::pair<int, double> gbtsInPowerChain = computeNumGBTsInPowerChain(numELinksPerModule, numModulesInPowerChain, isBarrel);
     const int numGBTsInPowerChain = gbtsInPowerChain.first;
     const double numModulesPerGBTExact = gbtsInPowerChain.second;
+    myPowerChain->setNumGBTsInPowerChain(numGBTsInPowerChain);
 
     const int powerChainId = myPowerChain->myid();
     const bool isLongBarrel = myPowerChain->isLongBarrel();

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8235,11 +8235,11 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
+		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 1) // fill style
 		  ); 
 	} );
-      zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get()); // call once and first
-      // WARNING: this will draw the plot frame according to the positions of the filled modules only.
+      zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get()); // Call once and first.
+      // WARNING: this will draw the plot frame, according to the positions of the filled modules only.
       zphiBarrelFillDrawerPos.drawModules<FillStyle>(*ZPhiCanvasPos.get());
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerPos;
@@ -8247,7 +8247,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
+		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 0) // contour style
 		  ); 
 	} );
       zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
@@ -8257,7 +8257,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 2)
+		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 2) // dashed style
 		  ); 
 	} );
       zphiBarrelDashedDrawerPos.drawModules<DashedStyle>(*ZPhiCanvasPos.get());
@@ -8273,11 +8273,11 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
+		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 1) // fill style
 		  ); 
 	} );
-      zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get()); // call once and first
-      // WARNING: this will draw the plot frame according to the positions of the filled modules only.
+      zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get()); // Call once and first.
+      // WARNING: this will draw the plot frame, according to the positions of the filled modules only.
       zphiBarrelFillDrawerNeg.drawModules<FillStyle>(*ZPhiCanvasNeg.get());
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerNeg;
@@ -8285,7 +8285,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
+		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 0) // contour style
 		  ); 
 	} );
       zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
@@ -8295,7 +8295,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 2)
+		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 2) // dashed style
 		  ); 
 	} );
       zphiBarrelDashedDrawerNeg.drawModules<DashedStyle>(*ZPhiCanvasNeg.get());
@@ -8324,16 +8324,17 @@ namespace insur {
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskFillDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskFillDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
+			   && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 0)
 			   );
 		} );
-	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get()); // Call once and first.
+	      // WARNING: this will draw the plot frame, according to the positions of the filled modules only.
 	      xyDiskFillDrawer.drawModules<FillStyle>(*XYSurfaceDisk.get());
 	      // Contour modules
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskContourDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskContourDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
+			   && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 1)
 			   );
 		} );
 	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());
@@ -8345,23 +8346,24 @@ namespace insur {
 	      bool isRotatedY180 = false;
 	      const std::vector<const Module*>& surfaceModules = found->second;
 	      std::unique_ptr<TCanvas> XYSurfaceDisk(new TCanvas(Form("XYPosGBTEndcap_%sAnyDiskSurface_%d", anEndcap.myid().c_str(), surfaceIndex),
-						   Form("(XY) Section : %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
-						   vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
+								 Form("(XY) Section : %s, any Disk, Surface %d. (The 4 surfaces of a disk are indexed such that |zSurface1| < |zSurface2| < |zSurface3| < |zSurface4|)", anEndcap.myid().c_str(), surfaceIndex),
+								 vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
 	      XYSurfaceDisk->cd();
 	      // Filled modules
 	      PlotDrawer<XY, TypeGBTTransparentColor> xyDiskFillDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskFillDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && (femod((m.getGBT() ? m.getGBT()->GBTPhiIndex() : 0), 2) == 0)
+			   && (femod((m.getGBT() ? m.getGBT()->GBTIndexInPowerChain() : 0), 2) == 0)
 			   );
 		} );
-	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get());
+	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get()); // Call once and first.
+	      // WARNING: this will draw the plot frame, according to the positions of the filled modules only.
 	      xyDiskFillDrawer.drawModules<FillStyle>(*XYSurfaceDisk.get());
 	      // Contour modules
 	      PlotDrawer<XY, TypeGBTTransparentColor> xyDiskContourDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskContourDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && (femod((m.getGBT() ? m.getGBT()->GBTPhiIndex() : 0), 2) == 1)
+			   && (femod((m.getGBT() ? m.getGBT()->GBTIndexInPowerChain() : 0), 2) == 1)
 			   );
 		} );
 	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8229,17 +8229,6 @@ namespace insur {
       std::unique_ptr<TCanvas> ZPhiCanvasPos(new TCanvas(Form("ZPhiGBTBarrelLayer%d_positiveXSide", layerNumber),
 					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasPos->cd();
-      // Contour modules
-      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerPos;
-      zphiBarrelContourDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
-	  return (m.subdet() == BARREL 
-		  && m.uniRef().layer == layerNumber
-		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
-		  ); 
-	} );
-      zphiBarrelContourDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
-      zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
       // Filled modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelFillDrawerPos;
       zphiBarrelFillDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
@@ -8249,23 +8238,35 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 		  ); 
 	} );
+      zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
       zphiBarrelFillDrawerPos.drawModules<FillStyle>(*ZPhiCanvasPos.get());
+      // Contour modules
+      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerPos;
+      zphiBarrelContourDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
+	  return (m.subdet() == BARREL 
+		  && m.uniRef().layer == layerNumber
+		  && m.isPositiveXSide()
+		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
+		  ); 
+	} );
+      //zphiBarrelContourDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
+      zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
+      // Dashed contour modules
+      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelDashedContourDrawerPos;
+      zphiBarrelDashedContourDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
+	  return (m.subdet() == BARREL 
+		  && m.uniRef().layer == layerNumber
+		  && m.isPositiveXSide()
+		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 2)
+		  ); 
+	} );
+      zphiBarrelDashedContourDrawerPos.drawModules<DashedContourStyle>(*ZPhiCanvasPos.get());
+
       ZPhiLayerPlots.push_back(std::move(ZPhiCanvasPos));
       // NEGATIVE X SIDE
       std::unique_ptr<TCanvas> ZPhiCanvasNeg(new TCanvas(Form("ZPhiGBTBarrelLayer%d_negativeXSide", layerNumber),
 					   Form("(ZPhi), Barrel Layer %d. (-X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasNeg->cd();
-      // Contour modules
-      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerNeg;
-      zphiBarrelContourDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
-	  return (m.subdet() == BARREL 
-		  && m.uniRef().layer == layerNumber
-		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
-		  ); 
-	} );
-      zphiBarrelContourDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
-      zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
       // Filled modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelFillDrawerNeg;
       zphiBarrelFillDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
@@ -8275,7 +8276,29 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 		  ); 
 	} );
+      zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
       zphiBarrelFillDrawerNeg.drawModules<FillStyle>(*ZPhiCanvasNeg.get());
+      // Contour modules
+      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerNeg;
+      zphiBarrelContourDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
+	  return (m.subdet() == BARREL 
+		  && m.uniRef().layer == layerNumber
+		  && !m.isPositiveXSide()
+		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
+		  ); 
+	} );
+      //zphiBarrelContourDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
+      zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
+      // Dashed contour modules
+      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelDashedContourDrawerNeg;
+      zphiBarrelDashedContourDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
+	  return (m.subdet() == BARREL 
+		  && m.uniRef().layer == layerNumber
+		  && !m.isPositiveXSide()
+		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 2)
+		  ); 
+	} );
+      zphiBarrelDashedContourDrawerNeg.drawModules<DashedContourStyle>(*ZPhiCanvasNeg.get());
       ZPhiLayerPlots.push_back(std::move(ZPhiCanvasNeg));
     }
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8227,7 +8227,7 @@ namespace insur {
     for (int layerNumber = 1; layerNumber <= numLayers; layerNumber++) {
       // POSITIVE X SIDE
       std::unique_ptr<TCanvas> ZPhiCanvasPos(new TCanvas(Form("ZPhiGBTBarrelLayer%d_positiveXSide", layerNumber),
-					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
+					   Form("(ZPhi), Barrel Layer %d. (+X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/empty/(dashed) module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasPos->cd();
       // Filled modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelFillDrawerPos;
@@ -8238,7 +8238,8 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 		  ); 
 	} );
-      zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
+      zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get()); // call once and first
+      // WARNING: this will draw the plot frame according to the positions of the filled modules only.
       zphiBarrelFillDrawerPos.drawModules<FillStyle>(*ZPhiCanvasPos.get());
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerPos;
@@ -8249,23 +8250,22 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
 		  ); 
 	} );
-      //zphiBarrelContourDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get());
       zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
-      // Dashed contour modules
-      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelDashedContourDrawerPos;
-      zphiBarrelDashedContourDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
+      // Dashed modules
+      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelDashedDrawerPos;
+      zphiBarrelDashedDrawerPos.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 2)
 		  ); 
 	} );
-      zphiBarrelDashedContourDrawerPos.drawModules<DashedContourStyle>(*ZPhiCanvasPos.get());
+      zphiBarrelDashedDrawerPos.drawModules<DashedStyle>(*ZPhiCanvasPos.get());
 
       ZPhiLayerPlots.push_back(std::move(ZPhiCanvasPos));
       // NEGATIVE X SIDE
       std::unique_ptr<TCanvas> ZPhiCanvasNeg(new TCanvas(Form("ZPhiGBTBarrelLayer%d_negativeXSide", layerNumber),
-					   Form("(ZPhi), Barrel Layer %d. (-X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/contoured module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
+					   Form("(ZPhi), Barrel Layer %d. (-X) side. (≠ colors) => (≠ power chains). Alternance of groups of filled/empty/(dashed) module(s) is used to show the alternance of GBTs.", layerNumber), vis_min_canvas_sizeX, vis_min_canvas_sizeY) );
       ZPhiCanvasNeg->cd();
       // Filled modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelFillDrawerNeg;
@@ -8276,7 +8276,8 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 1)
 		  ); 
 	} );
-      zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
+      zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get()); // call once and first
+      // WARNING: this will draw the plot frame according to the positions of the filled modules only.
       zphiBarrelFillDrawerNeg.drawModules<FillStyle>(*ZPhiCanvasNeg.get());
       // Contour modules
       PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelContourDrawerNeg;
@@ -8287,18 +8288,17 @@ namespace insur {
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 0)
 		  ); 
 	} );
-      //zphiBarrelContourDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get());
       zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
-      // Dashed contour modules
-      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelDashedContourDrawerNeg;
-      zphiBarrelDashedContourDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
+      // Dashed modules
+      PlotDrawer<ZPhi, TypeGBTTransparentColor> zphiBarrelDashedDrawerNeg;
+      zphiBarrelDashedDrawerNeg.addModules(tracker.modules().begin(), tracker.modules().end(), [layerNumber] (const Module& m ) { 
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
 		  && ((m.getGBT() ? m.getGBT()->indexColor() : 0) == 2)
 		  ); 
 	} );
-      zphiBarrelDashedContourDrawerNeg.drawModules<DashedContourStyle>(*ZPhiCanvasNeg.get());
+      zphiBarrelDashedDrawerNeg.drawModules<DashedStyle>(*ZPhiCanvasNeg.get());
       ZPhiLayerPlots.push_back(std::move(ZPhiCanvasNeg));
     }
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8235,7 +8235,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 1) // fill style
+		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 1) // fill style
 		  ); 
 	} );
       zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get()); // Call once and first.
@@ -8247,7 +8247,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 0) // contour style
+		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 0) // contour style
 		  ); 
 	} );
       zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
@@ -8257,7 +8257,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 2) // dashed style
+		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 2) // dashed style
 		  ); 
 	} );
       zphiBarrelDashedDrawerPos.drawModules<DashedStyle>(*ZPhiCanvasPos.get());
@@ -8273,7 +8273,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 1) // fill style
+		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 1) // fill style
 		  ); 
 	} );
       zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get()); // Call once and first.
@@ -8285,7 +8285,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 0) // contour style
+		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 0) // contour style
 		  ); 
 	} );
       zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
@@ -8295,7 +8295,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 2) // dashed style
+		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 2) // dashed style
 		  ); 
 	} );
       zphiBarrelDashedDrawerNeg.drawModules<DashedStyle>(*ZPhiCanvasNeg.get());
@@ -8324,7 +8324,7 @@ namespace insur {
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskFillDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskFillDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 0)
+			   && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 0)
 			   );
 		} );
 	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get()); // Call once and first.
@@ -8334,7 +8334,7 @@ namespace insur {
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskContourDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskContourDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && ((m.getGBT() ? m.getGBT()->indexPlotStyle() : 0) == 1)
+			   && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 1)
 			   );
 		} );
 	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -8235,7 +8235,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 1) // fill style
+		  && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 1) // fill style
 		  ); 
 	} );
       zphiBarrelFillDrawerPos.drawFrame<SummaryFrameStyle>(*ZPhiCanvasPos.get()); // Call once and first.
@@ -8247,7 +8247,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 0) // contour style
+		  && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 0) // contour style
 		  ); 
 	} );
       zphiBarrelContourDrawerPos.drawModules<ContourStyle>(*ZPhiCanvasPos.get());
@@ -8257,7 +8257,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 2) // dashed style
+		  && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 2) // dashed style
 		  ); 
 	} );
       zphiBarrelDashedDrawerPos.drawModules<DashedStyle>(*ZPhiCanvasPos.get());
@@ -8273,7 +8273,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 1) // fill style
+		  && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 1) // fill style
 		  ); 
 	} );
       zphiBarrelFillDrawerNeg.drawFrame<SummaryFrameStyle>(*ZPhiCanvasNeg.get()); // Call once and first.
@@ -8285,7 +8285,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 0) // contour style
+		  && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 0) // contour style
 		  ); 
 	} );
       zphiBarrelContourDrawerNeg.drawModules<ContourStyle>(*ZPhiCanvasNeg.get());
@@ -8295,7 +8295,7 @@ namespace insur {
 	  return (m.subdet() == BARREL 
 		  && m.uniRef().layer == layerNumber
 		  && !m.isPositiveXSide()
-		  && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 2) // dashed style
+		  && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 2) // dashed style
 		  ); 
 	} );
       zphiBarrelDashedDrawerNeg.drawModules<DashedStyle>(*ZPhiCanvasNeg.get());
@@ -8324,7 +8324,7 @@ namespace insur {
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskFillDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskFillDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 0)
+			   && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 0)
 			   );
 		} );
 	      xyDiskFillDrawer.drawFrame<SummaryFrameStyle>(*XYSurfaceDisk.get()); // Call once and first.
@@ -8334,7 +8334,7 @@ namespace insur {
 	      PlotDrawer<XYRotateY180, TypeGBTTransparentColor> xyDiskContourDrawer(forwardViewPort, forwardViewPort);
 	      xyDiskContourDrawer.addModules(surfaceModules.begin(), surfaceModules.end(), [] (const Module& m ) { 
 		  return ( (m.subdet() == ENDCAP)
-			   && ((m.getGBT() ? m.getGBT()->plotGBTIndexInPowerChain() : 0) == 1)
+			   && ((m.getGBT() ? m.getGBT()->plotStyleGBTIndexInPowerChain() : 0) == 1)
 			   );
 		} );
 	      xyDiskContourDrawer.drawModules<ContourStyle>(*XYSurfaceDisk.get());


### PR DESCRIPTION
This PR gathers several recent changes & brainstormings which were hanging around.

- **Base the IT cabling map on the IT 701 layout as a default (instead of IT 613).** 
The relevant change here, from the cabling map point of view, is in TFPX, where the double-disk model becomes 'a la TEPX' (ie, the 2 disks in each double-disk become complementary in phi, instead of being complementary in R).
Check robustness of the code against all regressions.

-  **GBTs reshuffling in TBPX Layers 2 & 3 (to reduce number of portcards & GBTs)**
A possible (selected) portcard design, is to have a maximum of 3 LpGBTs (instead of 2 LpGBTs) per portcard.
In TBPX L2 and L3, the number of GBTs was not as small as it could be. There were 4 GBTs among modules connected to the same power chain, while only 3 GBTs would be sufficient (in terms of e-links <-> GBTs connections). 
This deliberate choice of 4 GBTs was stemming from the previous portcard design: even with 3 GBTs among modules connected to the same power chain, 2 portcards would have been necessary anyway.
The new portcard design allows to have only 1 portcard (with 3 LpGBTs) for all modules connected to the same power chain, in TBPX L2 and L3.
There is no possible optimization in TBPX L1 and L4, because there, the number of GBTs is already as low as it can be.

- **Add a parameter to control the maximum number of modules connected to each GBT.**
An attempt was to set the maximum number of modules per GBT to 5. 
However, this would add 2 GBTs per TEPX dee side (= per TEPX MFB), in TEPX Ring 4 and 5.
Since each TEPX MFB was already connected to 12 GBTs, there would be 14 GBTs per TEPX MFB instead (not an option ;p).
Hence, the only solution was to keep the number of GBTs as it is in TEPX, and hence set the maximum number of modules connected to each GBT to 6. An extra control line is added in the LpGBT design to support 6 modules.

Before PR:
https://cms-tklayout.web.cern.ch/cms-tklayout/layouts-work/repository-git-dev/OT614_200_IT613/cablingInner.html

After PR:
https://ghugo.web.cern.ch/ghugo/layouts/it_cabling/OT800_IT701_cabling/cablingInner.html
NB: Will automatically appear after the nightly builds on cms-tklayout.web.cern.ch, at repository-git-dev/OT800_IT701 tab.

@sorfanel @alkemyst @adewit 