### PR TITLE
Adding T27 (OT800_IT800)

### DIFF
--- a/geometries/CMS_Phase2/OT800_IT800.cfg
+++ b/geometries/CMS_Phase2/OT800_IT800.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V800.cfg
+@include Pixel/Pixel_V8/Pixel_V8_0_0.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V8/BPIX_8_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V8/BPIX_8_0_0.cfg
@@ -1,0 +1,78 @@
+  Barrel PXB {
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
+    
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity 1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      zOverlap -0.6 // 0.6 mm space between active areas: 0.15 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_3D
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_3D
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      numRods 12
+    }
+    Layer 2 {
+      bigDelta 2.5
+      zOverlap -0.6 // 0.6 mm space between active areas: 0.15 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+      Ring 1 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_bricked
+      }
+    }
+    Layer 3 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+      Ring 1-2 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      }
+    }
+    Layer 4 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      numRods 28
+      Ring 1-2 {
+        @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      }
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V8/FPIX1_8_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V8/FPIX1_8_0_0.cfg
@@ -1,0 +1,71 @@
+Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_615
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2.75
+    bigDelta 6.25 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+    Disk 1 { placeZ 253.00 }
+    Disk 2 { placeZ 322.95 }
+    Disk 3 { placeZ 412.23 }
+    Disk 4 { placeZ 526.20 }
+    Disk 5 { placeZ 671.68 }
+    Disk 6 { placeZ 842.38 }     // -15 mm, optimal was: Z = 857.38 mm
+    Disk 7 { placeZ 1109.42 }    // +15 mm, optimal was: Z = 1094.42 mm
+    Disk 8 { placeZ 1397.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V8/FPIX2_8_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V8/FPIX2_8_0_0.cfg
@@ -1,0 +1,91 @@
+Endcap FPIX_2 {
+    phiSegments 4
+    etaCut 10
+    zError 70
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX_2
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TEPX_613
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TEPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 4
+    smallDelta 4 
+    bigDelta 2 
+    outerRadius 253.95
+    numRings 5
+    minZ 1616
+    //barrelGap 1633.325 // Please activate either minZ (absolute), either barrelGap (relative startZ position from barrel).
+    maxZ 2550
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+ 
+    
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R1_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 20
+      ringOuterRadius 106.35        // From Daniel: so that active sensor Rmin = 62.9 mm. 
+    }   
+    Disk 1-3 {
+      Ring 1 {
+        trackingTags pixel,tracker    
+      }
+    }    
+    Disk 4 {
+      Ring 1 {
+        //trackingTags pixel,tracker
+        plotColor 5                  // brown. Different color, since no dedicated tracking tag
+      } 
+    }
+        
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R2_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
+      numModules 28
+      ringOuterRadius 144.0          // to be tuned
+    }
+    
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
+      numModules 36
+      ringOuterRadius 181.3          // to be tuned
+    }
+    
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
+      numModules 44
+      ringOuterRadius 217.9           // to be tuned
+    }
+    
+    Ring 5 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide_bricked
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX2_R5_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      trackingTags pixel,tracker
+      numModules 48
+      ringOuterRadius 253.95          // ????? So that active  Rmax < 254.52 mm, is that the right constraint?
+    }
+    
+    Disk 1 { placeZ 1750.00 }
+    Disk 2 { placeZ 2009.59 }
+    Disk 3 { placeZ 2307.69 }
+    Disk 4 { placeZ 2650.00 }
+
+    Disk 1 { destination FPIX9 }
+    Disk 2 { destination FPIX10 }
+    Disk 3 { destination FPIX11 }
+    Disk 4 { destination FPIX12 }
+  }
+

--- a/geometries/CMS_Phase2/Pixel/Pixel_V8/Pixel_V8_0_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V8/Pixel_V8_0_0.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_8_0_0.cfg
+  @include FPIX1_8_0_0.cfg
+  @include FPIX2_8_0_0.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}


### PR DESCRIPTION
This adds the configs for T27 (OT800_IT800), following the proposed setup [here](https://indico.cern.ch/event/988838/contributions/4258167/attachments/2202703/3736635/em20210305.pdf#page=10) - this geometry was also introduced in CMSSW via [this PR](https://github.com/cms-sw/cmssw/pull/34120).

EDIT: I forgot to mention that this includes bricked pixels in part of the IT. 