### PR TITLE
Adding layout OT800_IT630

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_15x60_wide
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_15x60_wide
@@ -1,0 +1,32 @@
+// 1x2 chips pixel module (15um x 60um)
+// Chip size 16.8 x 21.6
+moduleType pixel_1x2_15x60_wide  // pixel modules should always have a type starting with keyword 'pixel_'
+
+// Active silicon size
+// (includes space between chips 0.25mm)
+width 16.8
+length 43.45
+
+numSensors 1
+
+powerPerModule 0 // mW
+
+sensorThickness 0.150
+hybridThickness 0.5
+chipThickness 0.5
+
+deadAreaExtraLength 0.5
+deadAreaExtraWidth 0.5
+chipNegativeXExtraWidth 0.0   
+chipPositiveXExtraWidth 1.0
+
+Sensor 1 {
+  sensorType pixel
+  pitchEstimate 0.015
+  stripLengthEstimate 0.060
+  numROCX 1 
+  numROCY 2
+  powerPerChannel 0.0 // mW
+}
+
+plotColor 9  // purple

--- a/config/stdinclude/CMS_Phase2/Pixel/Resolutions/15x60
+++ b/config/stdinclude/CMS_Phase2/Pixel/Resolutions/15x60
@@ -1,0 +1,36 @@
+// Parametrization by Riccardo del Burgo modified by Stefano Mersi via a simple scaling
+// Simulation parameters:
+// sensor thickness: 150 um
+// threshold: 1000 e-
+// digitization (4 bits)
+// voltage: 400V
+// gaussian noise: μ = 0 e-, σ = 120 e-
+// μRH: 0.053
+
+// This resolution was obtained by scaling all mm parameters from 25 to 15 in x and from 100 to 60 in y
+// all non-mm paramaters are left the same. Very crude attempt.
+
+// pitch in X = 15 um. 
+resolutionLocalXParam0 0.00336575 // mm
+resolutionLocalXParam1 0.00344948 // mm
+resolutionLocalXParam2 0.0042206 // mm
+resolutionLocalXParam3 1.99516
+resolutionLocalXParam4 -663.952
+resolutionLocalXParam5 0.0022512 // mm
+resolutionLocalXParam6 0
+resolutionLocalXParam7 -0.0704734
+resolutionLocalXParam8 2.7292e-05 // mm
+resolutionLocalXParam9 1.07359
+
+// pitch in Y = 60 um.
+resolutionLocalYParam0 0.013481 // mm
+resolutionLocalYParam1 0.00354839 // mm
+resolutionLocalYParam2 0.00586703 // mm
+resolutionLocalYParam3 5.14923        
+resolutionLocalYParam4 93.3833    
+resolutionLocalYParam5 -0.00212562 // mm
+resolutionLocalYParam6 1.39766     
+resolutionLocalYParam7 -0.156411   
+resolutionLocalYParam8 -0.0114485 // mm
+resolutionLocalYParam9 1.50209 
+

--- a/geometries/CMS_Phase2/OT800_IT630.cfg
+++ b/geometries/CMS_Phase2/OT800_IT630.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V800.cfg
+@include Pixel/Pixel_V6/Pixel_V6_3_0.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/BPIX_6_3_0.cfg
@@ -1,0 +1,66 @@
+  Barrel PXB {
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
+    
+    zOverlap -1.3 // 1.3mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity 1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_15x60_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/15x60
+      destination BPIX1
+      numRods 12
+    }
+    Layer 2 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+    }
+    Layer 3 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+    }
+    Layer 4 {
+      bigDelta 2.5
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/FPIX1_6_3_0.cfg
@@ -1,0 +1,71 @@
+  Endcap FPIX_1 {    
+    phiSegments 4
+    etaCut 10
+    zError 70
+    
+    trackingTags pixel,tracker
+
+    @include-std CMS_Phase2/Pixel/Materials/disk_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_FPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TFPX_615
+    @include-std CMS_Phase2/Pixel/Materials/Routing/routing_around_TFPX
+    
+    moduleShape rectangular
+    alignEdges true 
+    numDisks 8
+    smallDelta 2.75
+    bigDelta 6.25 
+    outerRadius 160
+    numRings 4
+    barrelGap 33.325
+    maxZ 1300
+    bigParity 1
+    smallParity -1
+    zRotation 1.570796327
+    Ring 1 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_15x60_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R1_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/15x60
+      numModules 20
+      ringOuterRadius 74.45 
+    }
+    Ring 2 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32
+      ringOuterRadius 92.45
+    }
+    Ring 3 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 24
+      ringOuterRadius 126.65
+    }
+    Ring 4 {
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_FPIX_R4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      numModules 32 
+      ringOuterRadius 159.99                // ????? What is the constrainst on Rmax ?
+    }
+    
+    Disk 1 { placeZ 253.00 }
+    Disk 2 { placeZ 322.95 }
+    Disk 3 { placeZ 412.23 }
+    Disk 4 { placeZ 526.20 }
+    Disk 5 { placeZ 671.68 }
+    Disk 6 { placeZ 842.38 }     // -15 mm, optimal was: Z = 857.38 mm
+    Disk 7 { placeZ 1109.42 }    // +15 mm, optimal was: Z = 1094.42 mm
+    Disk 8 { placeZ 1397.00 }
+
+    Disk 1 { destination FPIX1 }
+    Disk 2 { destination FPIX2 }
+    Disk 3 { destination FPIX3 }
+    Disk 4 { destination FPIX4 }
+    Disk 5 { destination FPIX5 }
+    Disk 6 { destination FPIX6 }
+    Disk 7 { destination FPIX7 }
+    Disk 8 { destination FPIX8 }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_3_0.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V6/Pixel_V6_3_0.cfg
@@ -1,0 +1,26 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_6_3_0.cfg
+  @include FPIX1_6_3_0.cfg
+  @include FPIX2_6_1_3.cfg
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}

--- a/geometries/CMS_Phase2/readme.txt
+++ b/geometries/CMS_Phase2/readme.txt
@@ -268,6 +268,8 @@ OT800_IT615.cfg	       Based from Outer Tracker version 616.
 		       TBPS:
 		          Adjustments in Layer 1 to enable a safe IT installation, while respecting needed spacing with TBPS Layer 2 (supports and services).
 		       	  Layer 1, Ring 12-16: radius +0.5 mm, tiltAngle 74 -> 72 deg.
+
+OT800_IT630.cfg        Based on OT800_IT615. Very small pixels for phase3: TBPX L1, TBPX L2, TFPX R1 have a 15µm × 60µm size
 		       	  
 OT801_IT701.cfg	       Based from Outer Tracker version 800.
                        TB2S: inter-ladder radial spacing increased by 1 mm (smallDelta: 2.25 mm -> 2.75 mm). Z positions recomputed accordingly.		       	  


### PR DESCRIPTION
Inner Tracker 6.3.0 is based on 6.1.5 (i.e. T21), but with small rectangular pixels in Layer 1 and FPIX Disk 1
Small pixels = 15um x 60 um