### PR TITLE
Add GBT links for OT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ OUTERCABLING+=outer_cabling_constants
 OUTERCABLING+=outer_cabling_functions
 OUTERCABLING+=OuterCablingMap
 OUTERCABLING+=OuterDTC
+OUTERCABLING+=OuterGBT
 OUTERCABLING+=ModulesToBundlesConnector
 OUTERCABLING+=PhiPosition
 OUTERCABLING+=ServicesChannel

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -34,6 +34,8 @@ namespace insur { class OuterBundle; }
 using insur::OuterBundle;
 namespace insur { class OuterDTC; }
 using insur::OuterDTC;
+namespace insur { class OuterGBT;}
+using insur::OuterGBT;
 // IT CABLING MAP
 namespace insur { class PowerChain; }
 using insur::PowerChain;
@@ -400,6 +402,8 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
                                                               // 'Positive cabling side': the module end up connected on a DTC on (Z+) end.
   void setBundle(OuterBundle* bundle) { bundle_ = bundle ; }  // MFB
   const OuterBundle* getBundle() const { return bundle_; }
+  void setOuterGBT(OuterGBT* gbt) { outerGBT_ = gbt ; }
+  OuterGBT* getOuterGBT() const {return outerGBT_; }
   const int bundlePlotColor() const; 
   void setEndcapFiberFanoutBranch(const int branchIndex) { endcapFiberFanoutBranch_ = branchIndex; } // Branch of the MFB fanout
   const int getEndcapFiberFanoutBranch() const { return endcapFiberFanoutBranch_; }
@@ -461,6 +465,7 @@ private:
   HvLine* hvLine_ = nullptr;
   int numELinks_;
   GBT* GBT_ =  nullptr;
+  OuterGBT* outerGBT_ =  nullptr;
   // The raw pointers are intended. DetectorModule is NOT owning the cabling resources.
   // All cabling ressources are owned by the CablingMap, which is a member variable of Tracker.
   // They get destructed when Tracker is destructed.

--- a/include/OuterCabling/ModulesToBundlesConnector.hh
+++ b/include/OuterCabling/ModulesToBundlesConnector.hh
@@ -5,6 +5,7 @@
 #include "global_funcs.hh"
 #include "OuterCabling/PhiPosition.hh"
 #include "OuterCabling/OuterDTC.hh"
+#include "OuterCabling/OuterGBT.hh"
 
 
 /* This class is used to CONNECT MODULES TO BUNDLES.
@@ -12,11 +13,13 @@
  * Then, a bundle corresponding to that position is built or found.
  * Lastly, the module is connected to that bundle, and vice-versa.
  * At the end of the process, 2 maps containing all the bundles which have been built are returned.
+ * As each module has its own lpGBT, we also create module<->lpGBT links here.
 */
 class ModulesToBundlesConnector : public GeometryVisitor {
 public:
   std::map<int, OuterBundle*> getBundles() { return bundles_; }        // positive cabling side
   std::map<int, OuterBundle*> getNegBundles() { return negBundles_; }  // negative cabling side
+  std::map<int, OuterGBT*> getGBTs() { return gbts_; }
 
   void visit(Barrel& b);
   void visit(Layer& l);
@@ -36,11 +39,14 @@ private:
 
   const Category computeBundleType(const bool isBarrel, const std::string subDetectorName, const int layerDiskNumber, const int ringNumber = 0) const;
   void buildBundle(DetectorModule& m, std::map<int, OuterBundle*>& bundles, std::map<int, OuterBundle*>& negBundles, const Category& bundleType, const bool isBarrel, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const int totalNumFlatRings = 0, const bool isTiltedPart = false, const bool isExtraFlatPart = false);
+  void buildGBT(DetectorModule& m, std::map<int, OuterGBT*>& gbts);
   const int computeBundleTypeIndex(const bool isBarrel, const Category& bundleType, const int totalNumFlatRings = 0, const bool isTilted = false, const bool isExtraFlatPart = false) const;
   const int computeBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
   const int computeStereoBundleId(const bool isBarrel, const bool isPositiveCablingSide, const int layerDiskNumber, const int phiRef, const int bundleTypeIndex) const;
   OuterBundle* createAndStoreBundle(std::map<int, OuterBundle*>& bundles, std::map<int, OuterBundle*>& negBundles, const int bundleId, const int stereoBundleId, const Category& bundleType, const std::string subDetectorName, const int layerDiskNumber, const PhiPosition& modulePhiPosition, const bool isPositiveCablingSide, const bool isTiltedPart = false);
+  OuterGBT* createAndStoreGBT(std::map<int, OuterGBT*>&gbts, const int gbtId);
   void connectModuleToBundle(DetectorModule& m, OuterBundle* bundle) const;
+  void connectModuleToGBT(DetectorModule& m, OuterGBT* bundle) const;
 
   // STAGERRING
   void staggerModules(std::map<int, OuterBundle*>& bundles);
@@ -54,6 +60,7 @@ private:
 
   std::map<int, OuterBundle*> bundles_;     // positive cabling side bundles.
   std::map<int, OuterBundle*> negBundles_;  // negative cabling side bundles.
+  std::map<int, OuterGBT*> gbts_;
 
   bool isBarrel_;
   std::string barrelName_;

--- a/include/OuterCabling/OuterCablingMap.hh
+++ b/include/OuterCabling/OuterCablingMap.hh
@@ -26,6 +26,7 @@ public:
   const std::map<const int, std::unique_ptr<OuterBundle> >& getNegBundles() const { return negBundles_; }
   const std::map<const int, std::unique_ptr<OuterCable> >& getNegCables() const { return negCables_; }
   const std::map<const std::string, std::unique_ptr<const OuterDTC> >& getNegDTCs() const { return negDTCs_; }
+  const std::map<const int, std::unique_ptr<OuterGBT> >& getGBTs() const { return gbts_; }
   
 
 private:
@@ -41,6 +42,7 @@ private:
   void createAndStoreCablesAndDTCs(OuterBundle* myBundle, std::map<const int, std::unique_ptr<OuterCable> >& cables, std::map<const std::string, std::unique_ptr<const OuterDTC> >& DTCs, const int cableId, const double phiSectorWidth, const int phiSectorRefCable, const Category& type, const int slot, const bool isPositiveCablingSide); 
   void connectOneBundleToOneCable(OuterBundle* bundle, OuterCable* cable) const;
   void checkBundlesToCablesCabling(const std::map<const int, std::unique_ptr<OuterCable> >& cables);  // check bundles to cables connections
+  void computeCMSSWIds(std::map<const std::string, std::unique_ptr<const OuterDTC> >& DTCs);
 
   // COMPUTE SERVICES CHANNELS ASSIGNMENTS OF POWER CABLES
   void computePowerServicesChannels();
@@ -56,6 +58,7 @@ private:
   std::map<const int, std::unique_ptr<OuterBundle> > negBundles_;
   std::map<const int, std::unique_ptr<OuterCable> > negCables_;
   std::map<const std::string, std::unique_ptr<const OuterDTC> > negDTCs_;
+  std::map<const int, std::unique_ptr<OuterGBT> > gbts_;
   // All bundles, cables, and DTC are owned by the Cabling map, and the Cabling map only!!
 };
 

--- a/include/OuterCabling/OuterGBT.hh
+++ b/include/OuterCabling/OuterGBT.hh
@@ -1,0 +1,35 @@
+#ifndef OuterGBT_HH
+#define OuterGBT_HH
+
+#include <vector>
+#include <string>
+
+#include "Property.hh"
+#include "Module.hh"
+
+class OuterGBT : public PropertyObject, public Buildable, public Identifiable<int> {
+  typedef std::vector<Module*> Container; 
+
+public:
+  OuterGBT(const int GBTId);
+
+  // MODULES CONNECTED TO THE GBT
+  const Container& modules() const { return modules_; }
+  const int numModules() const { return modules_.size(); } 
+  void addModule(Module* m);
+
+  void setCMSSWId(const int cmsswId) { myGBTCMSSWId_ = cmsswId; }
+  const int getCMSSWId() const { return myGBTCMSSWId_; }
+  const int GBTId() const { return myGBTId_; }
+
+private:
+  Container modules_;
+
+  int myGBTCMSSWId_;
+  int myGBTId_;
+
+};
+
+
+
+#endif

--- a/include/Squid.hh
+++ b/include/Squid.hh
@@ -99,6 +99,7 @@ namespace insur {
     bool pureAnalyzeGeometry(int tracks);
     bool reportOuterCablingMapSite(const bool outerCablingOption, const std::string layoutName);
     bool reportInnerCablingMapSite(const bool innerCablingOption, const std::string layoutName);
+    bool reportInnerAndOuterCablingMapSite(const bool innerCablingOption, const bool outerCablingOption, const std::string layoutName);
     bool pureAnalyzeMaterialBudget(int tracks, bool triggerRes, bool triggerPatternReco, bool debugResolution);
     bool reportGeometrySite(bool debugResolution);
     bool reportBandwidthSite();

--- a/include/Vizard.hh
+++ b/include/Vizard.hh
@@ -139,6 +139,7 @@ namespace insur {
     bool geometrySummary(Analyzer& a, Tracker& tracker, InactiveSurfaces* inactive, RootWSite& site, bool& debugResolution, std::string alternativeName = "");
     bool outerCablingSummary(Analyzer& a, Tracker& tracker, RootWSite& site);
     bool innerCablingSummary(Analyzer& a, Tracker& tracker, RootWSite& site);
+    bool innerAndOuterCablingSummary(Tracker& tracker, Tracker& pixel, RootWSite& site);
     bool bandwidthSummary(Analyzer& analyzer, Tracker& tracker, RootWSite& site);
     bool triggerProcessorsSummary(Analyzer& analyzer, Tracker& tracker, RootWSite& site);
     bool errorSummary(Analyzer& a, RootWSite& site, std::string additionalTag, bool isTrigger);
@@ -301,7 +302,7 @@ namespace insur {
     std::string createBundlesToEndcapModulesCsv(const OuterCablingMap* myCablingMap, const bool isPositiveCablingSide);
     std::string countBundlesToEndcapModulesCombinations(const OuterCablingMap* myCablingMap, const bool isPositiveCablingSide);
     std::string createPowerCablesDistributionCsv(const OuterCablingMap* myCablingMap, const bool isPositiveCablingSide);
-    std::string createCMSSWOuterTrackerCablingMapCsv(const Tracker& tracker);
+    std::string createCMSSWOuterTrackerCablingMapCsv(const Tracker& tracker, const bool withPreVisit);
 
     // Inner Tracker
     std::string createInnerTrackerModulesToDTCsCsv(const Tracker& tracker);

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -597,17 +597,22 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
     //*                                   //
     //************************************//
 void CMSSWOuterTrackerCablingMapVisitor::preVisit() {
-  output_ << "Module DetId/U, DTC Id/U" << std::endl;
+  output_ << "Module_DetId/U, GBT_CMSSW_IdPerDTC/U, DTC_CMSSW_Id/U" << std::endl;
 }
 
 void CMSSWOuterTrackerCablingMapVisitor::visit(const Module& m) {
   std::stringstream moduleInfo;
   moduleInfo << m.myDetId() << ", ";
-  const OuterDTC* myDTC = m.getDTC();
-  if (myDTC) {
-    std::stringstream DTCInfo;
-    DTCInfo << myDTC->getCMSSWId();	 
-    output_ << moduleInfo.str() << DTCInfo.str() << std::endl;
+  const OuterGBT* myGBT = m.getOuterGBT();
+  if (myGBT) {
+    std::stringstream GBTInfo;
+    GBTInfo << myGBT->getCMSSWId() << ", ";
+    const OuterDTC* myDTC = m.getDTC();
+    if (myDTC) {
+      std::stringstream DTCInfo;
+      DTCInfo << myDTC->getCMSSWId();	 
+      output_ << moduleInfo.str() << GBTInfo.str() << DTCInfo.str() << std::endl;
+    }
   }
   else output_ << moduleInfo.str() << std::endl;
 }

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -757,7 +757,7 @@ const int DetectorModule::powerChannelSectionPlotColor() const {
 }
 
 
-const OuterDTC* DetectorModule::getDTC() const{
+const OuterDTC* DetectorModule::getDTC() const {
   const OuterDTC* myDTC = nullptr;
   const OuterBundle* myBundle = getBundle();
   if (myBundle) {

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -757,7 +757,7 @@ const int DetectorModule::powerChannelSectionPlotColor() const {
 }
 
 
-const OuterDTC* DetectorModule::getDTC() const {
+const OuterDTC* DetectorModule::getDTC() const{
   const OuterDTC* myDTC = nullptr;
   const OuterBundle* myBundle = getBundle();
   if (myBundle) {

--- a/src/OuterCabling/ModulesToBundlesConnector.cc
+++ b/src/OuterCabling/ModulesToBundlesConnector.cc
@@ -69,6 +69,9 @@ void ModulesToBundlesConnector::visit(BarrelModule& m) {
 
   // BUILD BUNDLE IF NECESSARY, AND CONNECT MODULE TO BUNDLE
   buildBundle(m, bundles_, negBundles_, bundleType_, isBarrel_, barrelName_, layerNumber_, modulePhiPosition, isPositiveCablingSide, totalNumFlatRings_, isTilted, isExtraFlatPart);
+  
+  // ALSO BUILD A GBT
+  buildGBT(m, gbts_);
 }
 
 
@@ -102,6 +105,9 @@ void ModulesToBundlesConnector::visit(EndcapModule& m) {
 
   // BUILD BUNDLE IF NECESSARY, AND CONNECT MODULE TO BUNDLE
   buildBundle(m, bundles_, negBundles_, bundleType_, isBarrel_, endcapName_, diskNumber_, modulePhiPosition, isPositiveCablingSide);
+
+  // ALSO BUILD A GBT
+  buildGBT(m, gbts_);
 }
 
 
@@ -211,6 +217,19 @@ void ModulesToBundlesConnector::buildBundle(DetectorModule& m, std::map<int, Out
   connectModuleToBundle(m, bundle);
 }
 
+void ModulesToBundlesConnector::buildGBT(DetectorModule& m, std::map<int, OuterGBT*>& gbts){
+  const int gbtId=m.myDetId();
+  OuterGBT* gbt = nullptr; 
+  auto found = gbts.find(gbtId);
+  if ( found == gbts.end()){
+     gbt= createAndStoreGBT(gbts, gbtId);
+  } else {
+     gbt = found->second; // This shouldn't happen, but just in case
+  }
+  // CONNECT MODULE TO GBT
+  connectModuleToGBT(m, gbt);
+}
+
 
 /* Compute the index associated to each bundle type.
  */
@@ -287,12 +306,25 @@ OuterBundle* ModulesToBundlesConnector::createAndStoreBundle(std::map<int, Outer
   return bundle;
 }
 
+OuterGBT* ModulesToBundlesConnector::createAndStoreGBT(std::map<int, OuterGBT*>& gbts, const int gbtId) {
+  OuterGBT* gbt = new OuterGBT(gbtId);
+  gbts.insert(std::make_pair(gbtId, gbt));
+  return gbt;
+}
+
 
 /* Connect module to bundle and vice-versa.
  */
 void ModulesToBundlesConnector::connectModuleToBundle(DetectorModule& m, OuterBundle* bundle) const {
   bundle->addModule(&m);
   m.setBundle(bundle);
+}
+
+/* Connect module to GBT and vice-versa.
+ */
+void ModulesToBundlesConnector::connectModuleToGBT(DetectorModule& m, OuterGBT* gbt) const {
+  gbt->addModule(&m);
+  m.setOuterGBT(gbt);
 }
  
 

--- a/src/OuterCabling/OuterGBT.cc
+++ b/src/OuterCabling/OuterGBT.cc
@@ -1,0 +1,16 @@
+#include "OuterCabling/OuterGBT.hh"
+
+
+OuterGBT::OuterGBT(const int GBTId) :
+  myGBTCMSSWId_(0) // Want to have consecutive integers, ordered by detID, so done after the full map is created
+{
+  myGBTId_ = GBTId;
+};
+
+
+/*
+ *  Connect a Module to the GBT.
+ */
+void OuterGBT::addModule(Module* m) { 
+  modules_.push_back(m);
+}

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -539,7 +539,7 @@ namespace insur {
    */
   bool Squid::reportInnerCablingMapSite(const bool innerCablingOption, const std::string layoutName) {
     startTaskClock("Creating IT Cabling map report.");
-    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT613 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT701 only. Forcing it on another layout is at your own risks (could require adaptations).");
     if (px) {
       // CREATE REPORT ON WEBSITE.
       v.innerCablingSummary(pixelAnalyzer, *px, site);
@@ -552,6 +552,30 @@ namespace insur {
       return false;
     }
   }
+
+  /**
+   * Add a file with the IT+OT cabling map to the website.
+   */
+
+  bool Squid::reportInnerAndOuterCablingMapSite(const bool innerCablingOption, const bool outerCablingOption, const std::string layoutName) {
+    startTaskClock("Creating IT+OT Cabling map report.");
+    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT701 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    if (px) {
+      // CREATE REPORT ON WEBSITE.
+      v.innerAndOuterCablingSummary(*tr, *px, site);
+      stopTaskClock();
+      return true;
+    }
+    else {
+      logERROR(err_no_tracker);
+      stopTaskClock();
+      return false;
+    }
+  }
+
+
+
 
 
   bool Squid::analyzeTriggerEfficiency(int tracks, bool detailed) {

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -1515,7 +1515,7 @@ namespace insur {
       filesContent->addItem(bothSidesName);
       // CMSSW MODULES DETIDS TO DTC IDS
       myTextFile = new RootWTextFile(Form("CMSSWCablingMap%s.csv", name.c_str()), "CMSSW: Modules DetIds to DTCs Ids");
-      myTextFile->addText(createCMSSWOuterTrackerCablingMapCsv(tracker));
+      myTextFile->addText(createCMSSWOuterTrackerCablingMapCsv(tracker,true));
       filesContent->addItem(myTextFile);
 
 
@@ -1906,6 +1906,7 @@ namespace insur {
       myTextFile = new RootWTextFile(Form("CMSSWCablingMap%s.csv", name.c_str()), "CMSSW: Modules DetIds to DTCs Ids");
       myTextFile->addText(createCMSSWInnerTrackerCablingMapCsv(tracker));
       filesContent->addItem(myTextFile);
+      
 
 
       // CABLING COUNT
@@ -2074,6 +2075,36 @@ namespace insur {
     } // end of isPixelTracker
     return true;
   }
+
+  bool Vizard::innerAndOuterCablingSummary(Tracker& tracker, Tracker& pixel, RootWSite& site) {
+    bool haveTracker = !(tracker.isPixelTracker());
+    bool havePixel = (pixel.isPixelTracker());
+    if (havePixel && haveTracker) {
+      std::string name = "combined";
+
+      std::string pageTitle = "Cabling";
+      pageTitle += " (" + name + ")";
+      RootWPage* myPage = new RootWPage(pageTitle);
+
+      std::string pageAddress ="cabling" + name + ".html";
+      myPage->setAddress(pageAddress);
+
+      site.addPage(myPage);
+
+      RootWContent* filesContent = new RootWContent("Cabling files", true);
+      myPage->addContent(filesContent);   
+      RootWTextFile* myTextFile;
+      myTextFile = new RootWTextFile(Form("CMSSWCablingMapInnerAndOuter.csv") , "CMSSW: Modules DetIds to DTCs Ids");
+      myTextFile->addText(createCMSSWInnerTrackerCablingMapCsv(pixel));
+      myTextFile->addText(createCMSSWOuterTrackerCablingMapCsv(tracker,false));
+      filesContent->addItem(myTextFile);
+    }
+    return true;
+  }
+
+   
+
+  
 
 
   /**
@@ -9099,12 +9130,16 @@ namespace insur {
 
   /* Create csv file (Outer Tracker), summary on both cabling sides. Info needed by CMSSW: Modules DetIds to DTCIds.
    */
-  std::string Vizard::createCMSSWOuterTrackerCablingMapCsv(const Tracker& tracker) {
+  std::string Vizard::createCMSSWOuterTrackerCablingMapCsv(const Tracker& tracker, const bool withPreVisit) {
     CMSSWOuterTrackerCablingMapVisitor v;
-    v.preVisit();
+    if(withPreVisit){
+      v.preVisit();
+    }
     tracker.accept(v);
     return v.output();
   }
+
+
 
 
   /* Create csv file (Inner Tracker), navigating from Module hierarchy level to DTC hierarchy level.

--- a/src/tklayout.cc
+++ b/src/tklayout.cc
@@ -169,6 +169,7 @@ int main(int argc, char* argv[]) {
     
     if (buildOuterCablingMap && !squid.reportOuterCablingMapSite(vm.count("outerCablingMap"), basename)) return EXIT_FAILURE;
     if (buildInnerCablingMap && !squid.reportInnerCablingMapSite(vm.count("innerCablingMap"), basename)) return EXIT_FAILURE;
+    if (buildInnerCablingMap && buildOuterCablingMap && !squid.reportInnerAndOuterCablingMapSite(vm.count("innerCablingMap"), vm.count("outerCablingMap"), basename)) return EXIT_FAILURE;
 
     if ((vm.count("all") || vm.count("trigger") || vm.count("trigger-ext")) &&
         ( !squid.analyzeTriggerEfficiency(mattracks, vm.count("trigger-ext")) || !squid.reportTriggerPerformanceSite(vm.count("trigger-ext"))) ) return EXIT_FAILURE;


### PR DESCRIPTION
In the OT there is one GBT per module, but (random) values are stored for the GBT ID in the cabling map in CMSSW. Much safer to have them written into the csv file that is used to create the cabling map to avoid anyone using a nonsensical number. This is the goal of this PR.
In addition, when both the IT and OT cabling maps are requested, a new page is added to the layouts page (e.g. https://adewit.web.cern.ch/adewit/layouts/OT800_IT700/cablingcombined.html ), which stores a combined csv file containing the mapping for both OT and IT, so that we don't need to merge the files manually when we want to create the CMSSW cabling map.

As for adding the GBT IDs to the OT cabling map, the approach here might seem particularly cumbersome (creating a module < > GBT class link, so that we create a whole new object for each module, in the end to just store 1 number). The alternative would have been to insert the GBT IDs at the stage of writing the map, but that would have been a hideous hack, so I thought this was the better option.

@alkemyst apologies, this PR also contains some of your commits that were on the master branch but not on the dev branch. 