### PR TITLE
Run cabling when `--all` is specified for compatible geometries

### DIFF
--- a/include/global_constants.hh
+++ b/include/global_constants.hh
@@ -186,6 +186,8 @@ namespace insur {
   // mainConfigHandler
   static const std::string default_cabledOTName                  = "OT616";
   static const std::string default_cabledITName                  = "IT701";
+  static const std::vector<std::string> compatible_cabledOTName       = {"OT800","OT801"};
+  static const std::vector<std::string> compatible_cabledITName       = {"IT700"};
   static const std::string default_mattabdir                     = "config";
   static const std::string default_mattabfile                    = "mattab.list";
   static const std::string default_chemicalElementsFile          = "chemical_elements.list";

--- a/src/Squid.cc
+++ b/src/Squid.cc
@@ -521,7 +521,9 @@ namespace insur {
    */
   bool Squid::reportOuterCablingMapSite(const bool outerCablingOption, const std::string layoutName) {
     startTaskClock("Creating OT Cabling map report.");
-    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    const bool compatibleOTCablingMap = std::any_of(insur::compatible_cabledOTName.begin(), insur::compatible_cabledOTName.end(), [&](std::string s) {
+        return (layoutName.find(s) != std::string::npos); });
+    if ((layoutName.find(default_cabledOTName) == std::string::npos) && !compatibleOTCablingMap) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout that is not compatible with it is at your own risks (could require adaptations).");
     if (tr) {
       // CREATE REPORT ON WEBSITE.
       v.outerCablingSummary(a, *tr, site);
@@ -541,7 +543,9 @@ namespace insur {
    */
   bool Squid::reportInnerCablingMapSite(const bool innerCablingOption, const std::string layoutName) {
     startTaskClock("Creating IT Cabling map report.");
-    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT701 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    const bool compatibleITCablingMap = std::any_of(insur::compatible_cabledITName.begin(), insur::compatible_cabledITName.end(), [&](std::string s) {
+        return (layoutName.find(s) != std::string::npos); });
+    if ((layoutName.find(default_cabledITName) == std::string::npos) && !compatibleITCablingMap) logERROR("Cabling map is designed and implemented for IT701 only. Forcing it on another layout that is not compatible with it is at your own risks (could require adaptations).");
     if (px) {
       // CREATE REPORT ON WEBSITE.
       v.innerCablingSummary(pixelAnalyzer, *px, site);
@@ -561,8 +565,12 @@ namespace insur {
 
   bool Squid::reportInnerAndOuterCablingMapSite(const bool innerCablingOption, const bool outerCablingOption, const std::string layoutName) {
     startTaskClock("Creating IT+OT Cabling map report.");
-    if (layoutName.find(default_cabledITName) == std::string::npos) logERROR("Cabling map is designed and implemented for IT701 only. Forcing it on another layout is at your own risks (could require adaptations).");
-    if (layoutName.find(default_cabledOTName) == std::string::npos) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout is at your own risks (could require adaptations).");
+    const bool compatibleOTCablingMap = std::any_of(insur::compatible_cabledOTName.begin(), insur::compatible_cabledOTName.end(), [&](std::string s) {
+        return (layoutName.find(s) != std::string::npos); });
+    const bool compatibleITCablingMap = std::any_of(insur::compatible_cabledITName.begin(), insur::compatible_cabledITName.end(), [&](std::string s) {
+        return (layoutName.find(s) != std::string::npos); });
+    if ((layoutName.find(default_cabledITName) == std::string::npos) && !compatibleITCablingMap) logERROR("Cabling map is designed and implemented for IT701 only. Forcing it on another layout that is not compatible with it is at your own risks (could require adaptations).");
+    if ((layoutName.find(default_cabledOTName) == std::string::npos) && !compatibleOTCablingMap) logERROR("Cabling map is designed and implemented for OT616 only. Forcing it on another layout that is not compatible with it is at your own risks (could require adaptations).");
     if (px) {
       // CREATE REPORT ON WEBSITE.
       v.innerAndOuterCablingSummary(*tr, *px, site);

--- a/src/tklayout.cc
+++ b/src/tklayout.cc
@@ -133,11 +133,16 @@ int main(int argc, char* argv[]) {
 
   // Build cabling map.
   // With option 'all', cabling map is only computed on a specific layout, for which the map is designed.
+  // It is also computed for layouts that are marked as compatible with this map
   // The user can also force the computation by using 'cablingMap' option.
-  const bool buildOuterCablingMap = ( (vm.count("all") && basename.find(insur::default_cabledOTName) != std::string::npos) // Layout on which Outer Tracker cabling map was designed.
+  const bool compatibleOTCablingMap = std::any_of(insur::compatible_cabledOTName.begin(), insur::compatible_cabledOTName.end(), [&](std::string s) {
+      return (basename.find(s) != std::string::npos); });
+  const bool compatibleITCablingMap = std::any_of(insur::compatible_cabledITName.begin(), insur::compatible_cabledITName.end(), [&](std::string s) {
+      return (basename.find(s) != std::string::npos); });
+  const bool buildOuterCablingMap = ( (vm.count("all") && (basename.find(insur::default_cabledOTName) != std::string::npos || compatibleOTCablingMap)) // Layout on which Outer Tracker cabling map was designed or one that is compatible.
 				 || vm.count("outerCablingMap") ); // Forces cabling map computation.
   if (buildOuterCablingMap && !squid.buildOuterCablingMap(vm.count("outerCablingMap")) ) return EXIT_FAILURE;
-  const bool buildInnerCablingMap = ( (vm.count("all") && basename.find(insur::default_cabledITName) != std::string::npos) // Layout on which Inner Tracker cabling map was designed.
+  const bool buildInnerCablingMap = ( (vm.count("all") && (basename.find(insur::default_cabledITName) != std::string::npos || compatibleITCablingMap)) // Layout on which Inner Tracker cabling map was designed.
 				 || vm.count("innerCablingMap") ); // Forces cabling map computation.
   if (buildInnerCablingMap && !squid.buildInnerCablingMap(vm.count("innerCablingMap")) ) return EXIT_FAILURE;
   


### PR DESCRIPTION
In addition to the geometry the cabling map was designed/implemented for, have a list of "compatible" geometries for which the cabling maps will be produced when `--all` is specified. 