### PR TITLE
Add dose/fluence plots

### DIFF
--- a/include/AnalyzerVisitors/IrradiationPower.hh
+++ b/include/AnalyzerVisitors/IrradiationPower.hh
@@ -43,6 +43,8 @@ class IrradiationPowerVisitor : public GeometryVisitor {
   std::map<std::string, std::vector<const DetectorModule*> > mapTypeToFluence_;
 
  public:
+  double maxDose;
+  double maxFluence;
   MultiSummaryTable sensorsPowerSummary;
   MultiSummaryTable sensorsDoseSummary;
   MultiSummaryTable sensorsFluenceSummary;

--- a/include/ReportIrradiation.hh
+++ b/include/ReportIrradiation.hh
@@ -22,6 +22,8 @@ private:
   std::map<std::string, SummaryTable> powerSummaries;
   std::map<std::string, SummaryTable> fluenceSummaries;
   std::map<std::string, SummaryTable> doseSummaries;
+  double maxFluence_;
+  double maxDose_;
   SummaryTable fluenceSummaryPerType;
   SummaryTable doseSummaryPerType;
   SummaryTable chipPowerPerType;
@@ -29,6 +31,7 @@ private:
   std::string mapNames_="";
   void dumpRadiationTableSummary(RootWPage& myPage, std::map<std::string, SummaryTable>& radiationSummaries, const std::string& title, std::string units);
   std::string createSensorsIrradiationCsv();
+  std::map<std::string,TH1F*> createSensorsIrradiationHistograms(double max_fluence, double max_dose);
   void computeIrradiationPowerConsumption();
   void computeChipPowerConsumptionTable();
   void preparePowerHistograms();

--- a/src/AnalyzerVisitors/IrradiationPower.cc
+++ b/src/AnalyzerVisitors/IrradiationPower.cc
@@ -119,6 +119,8 @@ void IrradiationPowerVisitor::postVisit() {
   sensorsDosePerType.setCell(0, 4, "z_max [mm]");
   sensorsDosePerType.setCell(0, 5, "r_max [mm]");
   int iRow=0;
+  maxFluence = 0;
+  maxDose = 0;
   for (auto& it : mapTypeToFluence_ ) {
     iRow++;
     const std::string& typeName = it.first;
@@ -135,6 +137,7 @@ void IrradiationPowerVisitor::postVisit() {
     auto& hottestModule =  irrads.at(nModules-1);
     auto& hottest95Module = irrads.at(ceil(double(nModules)*95/100-1));
     irrad_Max    << std::dec << std::scientific << std::setprecision(2) << hottestModule->sensorsIrradiationMean();
+    if(hottestModule->sensorsIrradiationMean() > maxFluence) maxFluence = hottestModule->sensorsIrradiationMean();
     irrad_95perc << std::dec << std::scientific << std::setprecision(2) <<  hottest95Module->sensorsIrradiationMean();
     max_z << std::dec << std::fixed << std::setprecision(2) << hottestModule->center().Z();
     max_r << std::dec << std::fixed << std::setprecision(2) << hottestModule->center().Rho();
@@ -162,6 +165,7 @@ void IrradiationPowerVisitor::postVisit() {
     auto& hottestModule =  irrads.at(nModules-1);
     auto& hottest95Module = irrads.at(ceil(double(nModules)*95/100-1));
     irrad_Max    << std::dec << std::scientific << std::setprecision(2) << hottestModule->sensorsDoseMean();
+    if(hottestModule->sensorsDoseMean() > maxDose) maxDose = hottestModule->sensorsDoseMean();
     irrad_95perc << std::dec << std::scientific << std::setprecision(2) <<  hottest95Module->sensorsDoseMean();
     max_z << std::dec << std::fixed << std::setprecision(2) << hottestModule->center().Z();
     max_r << std::dec << std::fixed << std::setprecision(2) << hottestModule->center().Rho();

--- a/src/ReportIrradiation.cc
+++ b/src/ReportIrradiation.cc
@@ -1,5 +1,6 @@
 #include <ReportIrradiation.hh>
 #include <PlotDrawer.hh>
+#include <TLegend.h>
 
 void ReportIrradiation::analyze() {
   computeIrradiationPowerConsumption();
@@ -26,6 +27,8 @@ void ReportIrradiation::computeIrradiationPowerConsumption() {
   doseSummaryPerType = irradiation_.sensorsDosePerType;
   lumiInfo_ = irradiation_.lumiInformation;
   mapNames_ = irradiation_.mapInformation;
+  maxFluence_ = irradiation_.maxFluence;
+  maxDose_ = irradiation_.maxDose;
 }
 
 void ReportIrradiation::computeChipPowerConsumptionTable() {
@@ -107,6 +110,120 @@ std::string ReportIrradiation::createSensorsIrradiationCsv() {
   tracker.accept(v);
   return v.output();
 }
+
+std::map<std::string,TH1F*> ReportIrradiation::createSensorsIrradiationHistograms(double max_fluence, double max_dose){
+  class TrackerVisitor : public ConstGeometryVisitor {
+    std::map<std::string,TH1F*> hist_map;
+    string sectionName_;
+    int layerId_;
+    bool isOuterRadiusRod_;
+    double theMaxFluence_;
+    double theMaxDose_;
+  public:
+    void setHistogramMaximums(double fluence, double dose){
+      theMaxFluence_ = fluence;
+      theMaxDose_ = dose;
+    }
+    void preVisit() {
+      for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_fluence_")+x] = new TH1F(TString::Format("tot_mod_fluence_%s", x),";NIEL fluence[1 MeV n_{eq} / cm^2]; Number of modules",30,0.,1.05*theMaxFluence_);
+      for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_TID_")+x] = new TH1F(TString::Format("tot_mod_TID_%s", x),";Absorbed dose[Gy]; Number of modules",30,0,1.05*theMaxDose_);
+      //for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge", "TEPX" , "TFPX", "TBPX"}) hist_map[std::string("cumulative_fluence_")+x] = new TH1F(TString::Format("cumulative_fluence_%s", x),";NIEL fluence[1 MeV n_{eq} / cm^2]; Number of modules",30,0.,1.05*theMaxFluence_);
+      //for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("cumulative_TID_")+x] = new TH1F(TString::Format("cumulative_TID_%s", x),";Absorbed dose[Gy]; Number of modules",30,0,1.05*theMaxDose_);
+    }
+    void visit(const Barrel& b) { sectionName_ = b.myid(); }
+    void visit(const Endcap& e) { sectionName_ = e.myid(); }
+    void visit(const Layer& l)  { layerId_ = l.myid(); }
+    void visit(const RodPair& r)  { isOuterRadiusRod_ = r.isOuterRadiusRod(); }
+    void visit(const Disk& d)  { isOuterRadiusRod_ = false; layerId_ = d.myid(); } // no rod here !
+    void visit(const Module& m) {
+      if(sectionName_=="PXB"){
+        hist_map[std::string("tot_mod_fluence_TBPX")]->Fill(m.sensorsIrradiationMean());
+        hist_map[std::string("tot_mod_TID_TBPX")]->Fill(m.sensorsDoseMean());
+      } else if (sectionName_=="FPIX_1"){
+        hist_map[std::string("tot_mod_fluence_TFPX")]->Fill(m.sensorsIrradiationMean());
+        hist_map[std::string("tot_mod_TID_TFPX")]->Fill(m.sensorsDoseMean());
+      } else if (sectionName_=="FPIX_2"){
+        hist_map[std::string("tot_mod_fluence_TEPX")]->Fill(m.sensorsIrradiationMean());
+        hist_map[std::string("tot_mod_TID_TEPX")]->Fill(m.sensorsDoseMean());
+      } else if (m.moduleType()=="pt2S"){
+        hist_map[std::string("tot_mod_fluence_2S")]->Fill(m.sensorsIrradiationMean());
+        hist_map[std::string("tot_mod_TID_2S")]->Fill(m.sensorsDoseMean());
+        if(m.dsDistance()<2.){
+          hist_map[std::string("tot_mod_fluence_2Ssmall")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_2Ssmall")]->Fill(m.sensorsDoseMean());
+        } else {
+          hist_map[std::string("tot_mod_fluence_2Slarge")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_2Slarge")]->Fill(m.sensorsDoseMean());
+        }
+      } else if (m.moduleType()=="ptPS"){
+        hist_map[std::string("tot_mod_fluence_PS")]->Fill(m.sensorsIrradiationMean());
+        hist_map[std::string("tot_mod_TID_PS")]->Fill(m.sensorsDoseMean());
+        if(m.dsDistance()<2.){
+          hist_map[std::string("tot_mod_fluence_PSsmall")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_PSsmall")]->Fill(m.sensorsDoseMean());
+        } else if (m.dsDistance()<3.){
+          hist_map[std::string("tot_mod_fluence_PSmed")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_PSmed")]->Fill(m.sensorsDoseMean());
+        } else {
+          hist_map[std::string("tot_mod_fluence_PSlarge")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_PSlarge")]->Fill(m.sensorsDoseMean());
+        }
+      }
+    }
+
+    std::map<std::string,TH1F*> output()  { 
+     for (auto x : {"PS","PSsmall","PSmed","PSlarge", "2S" , "2Ssmall","2Slarge", "TEPX","TFPX","TBPX"}){
+       hist_map[std::string("cumulative_fluence_")+x] = dynamic_cast<TH1F*>(hist_map[std::string("tot_mod_fluence_")+x]->GetCumulative(kFALSE));
+       hist_map[std::string("cumulative_fluence_")+x]->SetName(TString::Format("cumulative_fluence_%s",x));
+       hist_map[std::string("cumulative_fluence_")+x]->GetYaxis()->SetTitle("Fraction of modules");
+       hist_map[std::string("cumulative_fluence_")+x]->Scale(1./hist_map[std::string("cumulative_fluence_")+x]->GetBinContent(1));
+       hist_map[std::string("cumulative_fluence_")+x]->SetTitle("Fraction of modules with fluence below");
+       hist_map[std::string("cumulative_TID_")+x] = dynamic_cast<TH1F*>(hist_map[std::string("tot_mod_TID_")+x]->GetCumulative(kFALSE));
+       hist_map[std::string("cumulative_TID_")+x]->SetName(TString::Format("cumulative_TID_%s",x));
+       hist_map[std::string("cumulative_TID_")+x]->SetTitle("Fraction of modules with dose below");
+       hist_map[std::string("cumulative_TID_")+x]->GetYaxis()->SetTitle("Fraction of modules");
+       hist_map[std::string("cumulative_TID_")+x]->Scale(1./hist_map[std::string("cumulative_TID_")+x]->GetBinContent(1));
+     }
+      std::map<std::string,int>  hist_colours;
+      hist_colours["PS"] = 632;
+      hist_colours["PSsmall"] = 632;
+      hist_colours["PSmed"] = 910;
+      hist_colours["PSlarge"] = 803;
+      hist_colours["2S"] = 419;
+      hist_colours["2Ssmall"] = 419;
+      hist_colours["2Slarge"] = 860;
+      hist_colours["TEPX"] = 600;
+      hist_colours["TFPX"] = 810;
+      hist_colours["TBPX"] = 922;
+      std::map<std::string,float> bar_offsets;
+      bar_offsets["PS"] = 0.2;
+      bar_offsets["PSsmall"] = 0.0;
+      bar_offsets["PSmed"] = 0.2;
+      bar_offsets["PSlarge"] = 0.4;
+      bar_offsets["2Ssmall"] = 0.6;
+      bar_offsets["2Slarge"] = 0.8;
+      bar_offsets["2S"] = 0.4;
+      bar_offsets["TEPX"] = 0.2;
+      bar_offsets["TFPX"] = 0.4;
+      bar_offsets["TBPX"] = 0.6;
+      for (auto x : {"PS" ,"PSsmall","PSmed","PSlarge", "2S","2Ssmall","2Slarge", "TEPX" ,"TFPX", "TBPX"}){
+        for (auto y : {"tot_mod_fluence_", "tot_mod_TID_", "cumulative_fluence_", "cumulative_TID_"}){
+          hist_map[std::string(y)+std::string(x)]->SetLineColor(hist_colours[x]);
+          hist_map[std::string(y)+std::string(x)]->SetFillColor(hist_colours[x]);
+          hist_map[std::string(y)+std::string(x)]->SetBarWidth(0.2);
+          hist_map[std::string(y)+std::string(x)]->SetBarOffset(bar_offsets[x]);
+        }
+      }
+     return hist_map; }
+  };
+
+  TrackerVisitor v;
+  v.setHistogramMaximums(max_fluence,max_dose);
+  v.preVisit();
+  tracker.accept(v);
+  return v.output();
+}
+
 
 
 void ReportIrradiation::dumpRadiationTableSummary(RootWPage& myPage, std::map<std::string, SummaryTable>& radiationSummaries,
@@ -210,7 +327,203 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   RootWImage& totalPowerImage = myContent.addImage(std::move(totalPowerCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
   totalPowerImage.setComment("Total power dissipation in irradiated modules (W)");
   totalPowerImage.setName("totalPowerMap");
-  
+
+   
+  RootWContent& myupdContent = myPage.addContent("Dose and fluence histograms", true);
+
+  std::map<std::string,TH1F*> histos = createSensorsIrradiationHistograms(maxFluence_, maxDose_);
+  std::unique_ptr<TCanvas> irradiationFullCanvas(new TCanvas());
+  irradiationFullCanvas->cd();
+  TLegend* legFullCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legFullCanvas->SetFillStyle(0);
+  int drawnhists=0;
+  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+    if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("tot_mod_fluence_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_fluence_")+x]->GetMaximum());
+        histos[std::string("tot_mod_fluence_")+x]->DrawCopy("B");
+        drawnhists+=1;
+      } else {
+        histos[std::string("tot_mod_fluence_")+x]->DrawCopy("BSAME");
+      }
+      legFullCanvas->AddEntry(histos[std::string("tot_mod_fluence_")+x],x,"F");
+    }
+  }
+  if(drawnhists>0){
+    legFullCanvas->Draw("SAME");
+  }
+
+
+  std::unique_ptr<TCanvas> irradiationFullCumulCanvas(new TCanvas());
+  irradiationFullCumulCanvas->cd();
+  TLegend* legFullCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legFullCumulCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+    if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("cumulative_fluence_")+x]->DrawCopy("L");
+        drawnhists+=1;
+      } else {
+        histos[std::string("cumulative_fluence_")+x]->DrawCopy("LSAME");
+      }
+      legFullCumulCanvas->AddEntry(histos[std::string("cumulative_fluence_")+x],x,"L");
+    }
+  }
+  if(drawnhists>0){
+    legFullCumulCanvas->Draw("SAME");
+  }
+
+
+  std::unique_ptr<TCanvas> irradiationSplitCanvas(new TCanvas());
+  irradiationSplitCanvas->cd();
+  TLegend* legSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legSplitCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PSsmall" ,"PSmed","PSlarge", "2Ssmall", "2Slarge"}){
+    if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("tot_mod_fluence_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_fluence_")+x]->GetMaximum());
+        histos[std::string("tot_mod_fluence_")+x]->DrawCopy("B");
+        drawnhists+=1;
+      } else {
+        histos[std::string("tot_mod_fluence_")+x]->DrawCopy("BSAME");
+      }
+      legSplitCanvas->AddEntry(histos[std::string("tot_mod_fluence_")+x],x,"F");
+    }
+  }
+  if(drawnhists>0){
+    legSplitCanvas->Draw("SAME");
+  }
+
+  std::unique_ptr<TCanvas> irradiationSplitCumulCanvas(new TCanvas());
+  irradiationSplitCumulCanvas->cd();
+  TLegend* legSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legSplitCumulCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PSsmall" ,"PSmed","PSlarge","2Ssmall", "2Slarge"}){
+    if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("cumulative_fluence_")+x]->DrawCopy("L");
+        drawnhists+=1;
+      } else {
+        histos[std::string("cumulative_fluence_")+x]->DrawCopy("LSAME");
+      }
+      legSplitCumulCanvas->AddEntry(histos[std::string("cumulative_fluence_")+x],x,"L");
+    }
+  }
+  if(drawnhists>0){
+    legSplitCumulCanvas->Draw("SAME");
+  }
+
+
+
+  std::unique_ptr<TCanvas> doseFullCanvas(new TCanvas());
+  doseFullCanvas->cd();
+  TLegend* legDoseFullCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legDoseFullCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+    if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("tot_mod_TID_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_TID_")+x]->GetMaximum());
+        histos[std::string("tot_mod_TID_")+x]->DrawCopy("B");
+        drawnhists+=1;
+      } else {
+       histos[std::string("tot_mod_TID_")+x]->DrawCopy("BSAME");
+      }
+      legDoseFullCanvas->AddEntry(histos[std::string("tot_mod_TID_")+x],x,"F");
+    }
+  }
+  if(drawnhists>0){
+    legDoseFullCanvas->Draw("SAME");
+  }
+
+  std::unique_ptr<TCanvas> doseFullCumulCanvas(new TCanvas());
+  doseFullCumulCanvas->cd();
+  TLegend* legDoseFullCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legDoseFullCumulCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+    if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("cumulative_TID_")+x]->DrawCopy("L");
+        drawnhists+=1;
+      } else {
+       histos[std::string("cumulative_TID_")+x]->DrawCopy("LSAME");
+      }
+      legDoseFullCumulCanvas->AddEntry(histos[std::string("cumulative_TID_")+x],x,"L");
+    }
+  }
+  if(drawnhists>0){
+    legDoseFullCumulCanvas->Draw("SAME");
+  }
+
+  std::unique_ptr<TCanvas> doseSplitCanvas(new TCanvas());
+  doseSplitCanvas->cd();
+  TLegend* legDoseSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legDoseSplitCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PSsmall" , "PSmed","PSlarge","2Ssmall", "2Slarge"}){
+    if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("tot_mod_TID_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_TID_")+x]->GetMaximum());
+        histos[std::string("tot_mod_TID_")+x]->DrawCopy("B");
+        drawnhists+=1;
+      } else {
+       histos[std::string("tot_mod_TID_")+x]->DrawCopy("BSAME");
+      }
+      legDoseSplitCanvas->AddEntry(histos[std::string("tot_mod_TID_")+x],x,"F");
+    }
+  }
+  legDoseSplitCanvas->Draw("SAME");
+
+
+  std::unique_ptr<TCanvas> doseSplitCumulCanvas(new TCanvas());
+  doseSplitCumulCanvas->cd();
+  TLegend* legDoseSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
+  legDoseSplitCumulCanvas->SetFillStyle(0);
+  drawnhists=0;
+  for (auto x : {"PSsmall" , "PSmed","PSlarge","2Ssmall", "2Slarge"}){
+    if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
+      if(drawnhists==0){
+        histos[std::string("cumulative_TID_")+x]->DrawCopy("C");
+        drawnhists+=1;
+      } else {
+       histos[std::string("cumulative_TID_")+x]->DrawCopy("CSAME");
+      }
+      legDoseSplitCumulCanvas->AddEntry(histos[std::string("cumulative_TID_")+x],x,"L");
+    }
+  }
+  legDoseSplitCumulCanvas->Draw("SAME");
+
+  RootWImage& sensorsIrradFullHistogram = myupdContent.addImage(std::move(irradiationFullCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsIrradFullHistogram.setName("sensorsIrradiationFull");
+
+  RootWImage& sensorsIrradFullCumulHistogram = myupdContent.addImage(std::move(irradiationFullCumulCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsIrradFullCumulHistogram.setName("sensorsIrradiationFullCumulative");
+
+  RootWImage& sensorsIrradSplitHistogram = myupdContent.addImage(std::move(irradiationSplitCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsIrradSplitHistogram.setName("sensorsIrradiationSplit");
+
+  RootWImage& sensorsIrradSplitCumulHistogram = myupdContent.addImage(std::move(irradiationSplitCumulCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsIrradSplitCumulHistogram.setName("sensorsIrradiationSplitCumulative");
+
+
+   
+  RootWImage& sensorsDoseFullHistogram = myupdContent.addImage(std::move(doseFullCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsDoseFullHistogram.setName("sensorsDoseFull");
+
+  RootWImage& sensorsDoseFullCumulHistogram = myupdContent.addImage(std::move(doseFullCumulCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsDoseFullCumulHistogram.setName("sensorsDoseFullCumul");
+
+   RootWImage& sensorsDoseSplitHistogram = myupdContent.addImage(std::move(doseSplitCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsDoseSplitHistogram.setName("sensorsDoseSplit");
+
+  RootWImage& sensorsDoseSplitCumulHistogram = myupdContent.addImage(std::move(doseSplitCumulCanvas), insur::vis_std_canvas_sizeX, insur::vis_min_canvas_sizeY);
+  sensorsDoseSplitCumulHistogram.setName("sensorsDoseSplitCumul");
+
+ 
   // Add csv file with sensors irradiation handful info
   RootWContent* filesContent = new RootWContent("power csv files", false);
   myPage.addContent(filesContent);

--- a/src/ReportIrradiation.cc
+++ b/src/ReportIrradiation.cc
@@ -339,7 +339,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legFullCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legFullCanvas->SetFillStyle(0);
   int drawnhists=0;
-  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+  for (auto x : {"2S" , "PS", "TEPX" , "TFPX", "TBPX"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_fluence_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_fluence_")+x]->GetMaximum());
@@ -361,7 +361,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legFullCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legFullCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+  for (auto x : {"2S" , "PS", "TEPX" , "TFPX", "TBPX"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_fluence_")+x]->DrawCopy("L");
@@ -382,7 +382,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legSplitCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSmed" ,"PSsmall","PSlarge", "2Ssmall", "2Slarge"}){
+  for (auto x : {"2Ssmall","2Slarge","PSsmall", "PSmed" ,"PSlarge"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_fluence_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_fluence_")+x]->GetMaximum());
@@ -403,7 +403,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legSplitCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSmed" ,"PSsmall","PSlarge","2Ssmall", "2Slarge"}){
+  for (auto x : {"2Ssmall","2Slarge","PSsmall","PSmed", "PSlarge"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_fluence_")+x]->DrawCopy("L");
@@ -425,7 +425,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseFullCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseFullCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+  for (auto x : {"2S" , "PS", "TEPX" , "TFPX", "TBPX"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_TID_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_TID_")+x]->GetMaximum());
@@ -446,7 +446,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseFullCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseFullCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PS" , "2S", "TEPX" , "TFPX", "TBPX"}){
+  for (auto x : {"2S" , "PS", "TEPX" , "TFPX", "TBPX"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_TID_")+x]->DrawCopy("L");
@@ -466,7 +466,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseSplitCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSmed" , "PSsmall","PSlarge","2Ssmall", "2Slarge"}){
+  for (auto x : {"2Ssmall","2Slarge","PSsmall","PSmed","PSlarge"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_TID_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_TID_")+x]->GetMaximum());
@@ -486,7 +486,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseSplitCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSmed" , "PSsmall","PSlarge","2Ssmall", "2Slarge"}){
+  for (auto x : {"2Ssmall","2Slarge","PSsmall","PSmed" , "PSlarge"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_TID_")+x]->DrawCopy("C");

--- a/src/ReportIrradiation.cc
+++ b/src/ReportIrradiation.cc
@@ -125,8 +125,8 @@ std::map<std::string,TH1F*> ReportIrradiation::createSensorsIrradiationHistogram
       theMaxDose_ = dose;
     }
     void preVisit() {
-      for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_fluence_")+x] = new TH1F(TString::Format("tot_mod_fluence_%s", x),";NIEL fluence[1 MeV n_{eq} / cm^2]; Number of modules",30,0.,1.05*theMaxFluence_);
-      for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_TID_")+x] = new TH1F(TString::Format("tot_mod_TID_%s", x),";Absorbed dose[Gy]; Number of modules",30,0,1.05*theMaxDose_);
+      for (auto x : {"PS" , "2S", "PS-1.6mm","PS-2.6mm","PS-4.0mm","2S-1.8mm","2S-4.0mm","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_fluence_")+x] = new TH1F(TString::Format("tot_mod_fluence_%s", x),";NIEL fluence[1 MeV n_{eq} / cm^2]; Number of modules",30,0.,1.05*theMaxFluence_);
+      for (auto x : {"PS" , "2S", "PS-1.6mm","PS-2.6mm","PS-4.0mm","2S-1.8mm","2S-4.0mm","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_TID_")+x] = new TH1F(TString::Format("tot_mod_TID_%s", x),";Absorbed dose[Gy]; Number of modules",30,0,1.05*theMaxDose_);
     }
     void visit(const Barrel& b) { sectionName_ = b.myid(); }
     void visit(const Endcap& e) { sectionName_ = e.myid(); }
@@ -147,30 +147,30 @@ std::map<std::string,TH1F*> ReportIrradiation::createSensorsIrradiationHistogram
         hist_map[std::string("tot_mod_fluence_2S")]->Fill(m.sensorsIrradiationMean());
         hist_map[std::string("tot_mod_TID_2S")]->Fill(m.sensorsDoseMean());
         if(m.dsDistance()<2.){
-          hist_map[std::string("tot_mod_fluence_2Ssmall")]->Fill(m.sensorsIrradiationMean());
-          hist_map[std::string("tot_mod_TID_2Ssmall")]->Fill(m.sensorsDoseMean());
+          hist_map[std::string("tot_mod_fluence_2S-1.8mm")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_2S-1.8mm")]->Fill(m.sensorsDoseMean());
         } else {
-          hist_map[std::string("tot_mod_fluence_2Slarge")]->Fill(m.sensorsIrradiationMean());
-          hist_map[std::string("tot_mod_TID_2Slarge")]->Fill(m.sensorsDoseMean());
+          hist_map[std::string("tot_mod_fluence_2S-4.0mm")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_2S-4.0mm")]->Fill(m.sensorsDoseMean());
         }
       } else if (m.moduleType()=="ptPS"){
         hist_map[std::string("tot_mod_fluence_PS")]->Fill(m.sensorsIrradiationMean());
         hist_map[std::string("tot_mod_TID_PS")]->Fill(m.sensorsDoseMean());
         if(m.dsDistance()<2.){
-          hist_map[std::string("tot_mod_fluence_PSsmall")]->Fill(m.sensorsIrradiationMean());
-          hist_map[std::string("tot_mod_TID_PSsmall")]->Fill(m.sensorsDoseMean());
+          hist_map[std::string("tot_mod_fluence_PS-1.6mm")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_PS-1.6mm")]->Fill(m.sensorsDoseMean());
         } else if (m.dsDistance()<3.){
-          hist_map[std::string("tot_mod_fluence_PSmed")]->Fill(m.sensorsIrradiationMean());
-          hist_map[std::string("tot_mod_TID_PSmed")]->Fill(m.sensorsDoseMean());
+          hist_map[std::string("tot_mod_fluence_PS-2.6mm")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_PS-2.6mm")]->Fill(m.sensorsDoseMean());
         } else {
-          hist_map[std::string("tot_mod_fluence_PSlarge")]->Fill(m.sensorsIrradiationMean());
-          hist_map[std::string("tot_mod_TID_PSlarge")]->Fill(m.sensorsDoseMean());
+          hist_map[std::string("tot_mod_fluence_PS-4.0mm")]->Fill(m.sensorsIrradiationMean());
+          hist_map[std::string("tot_mod_TID_PS-4.0mm")]->Fill(m.sensorsDoseMean());
         }
       }
     }
 
     std::map<std::string,TH1F*> output()  { 
-     for (auto x : {"PS","PSsmall","PSmed","PSlarge", "2S" , "2Ssmall","2Slarge", "TEPX","TFPX","TBPX"}){
+     for (auto x : {"PS","PS-1.6mm","PS-2.6mm","PS-4.0mm", "2S" , "2S-1.8mm","2S-4.0mm", "TEPX","TFPX","TBPX"}){
        hist_map[std::string("cumulative_fluence_")+x] = dynamic_cast<TH1F*>(hist_map[std::string("tot_mod_fluence_")+x]->GetCumulative(kFALSE));
        hist_map[std::string("cumulative_fluence_")+x]->SetName(TString::Format("cumulative_fluence_%s",x));
        hist_map[std::string("cumulative_fluence_")+x]->GetYaxis()->SetTitle("Fraction of modules");
@@ -184,27 +184,27 @@ std::map<std::string,TH1F*> ReportIrradiation::createSensorsIrradiationHistogram
      }
       std::map<std::string,int>  hist_colours;
       hist_colours["PS"] = 632;
-      hist_colours["PSsmall"] = 632;
-      hist_colours["PSmed"] = 910;
-      hist_colours["PSlarge"] = 803;
+      hist_colours["PS-1.6mm"] = 632;
+      hist_colours["PS-2.6mm"] = 910;
+      hist_colours["PS-4.0mm"] = 803;
       hist_colours["2S"] = 419;
-      hist_colours["2Ssmall"] = 419;
-      hist_colours["2Slarge"] = 860;
+      hist_colours["2S-1.8mm"] = 419;
+      hist_colours["2S-4.0mm"] = 860;
       hist_colours["TEPX"] = 600;
       hist_colours["TFPX"] = 810;
       hist_colours["TBPX"] = 922;
       std::map<std::string,float> bar_offsets;
       bar_offsets["PS"] = 0.2;
-      bar_offsets["PSsmall"] = 0.0;
-      bar_offsets["PSmed"] = 0.2;
-      bar_offsets["PSlarge"] = 0.4;
-      bar_offsets["2Ssmall"] = 0.6;
-      bar_offsets["2Slarge"] = 0.8;
+      bar_offsets["PS-1.6mm"] = 0.0;
+      bar_offsets["PS-2.6mm"] = 0.2;
+      bar_offsets["PS-4.0mm"] = 0.4;
+      bar_offsets["2S-1.8mm"] = 0.6;
+      bar_offsets["2S-4.0mm"] = 0.8;
       bar_offsets["2S"] = 0.4;
       bar_offsets["TEPX"] = 0.2;
       bar_offsets["TFPX"] = 0.4;
       bar_offsets["TBPX"] = 0.6;
-      for (auto x : {"PS" ,"PSsmall","PSmed","PSlarge", "2S","2Ssmall","2Slarge", "TEPX" ,"TFPX", "TBPX"}){
+      for (auto x : {"PS" ,"PS-1.6mm","PS-2.6mm","PS-4.0mm", "2S","2S-1.8mm","2S-4.0mm", "TEPX" ,"TFPX", "TBPX"}){
         for (auto y : {"tot_mod_fluence_", "tot_mod_TID_", "cumulative_fluence_", "cumulative_TID_"}){
           hist_map[std::string(y)+std::string(x)]->SetLineColor(hist_colours[x]);
           hist_map[std::string(y)+std::string(x)]->SetFillColor(hist_colours[x]);
@@ -266,9 +266,6 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   settingsContent.addItem(notesInfo);
   notesInfo = new RootWInfo("Note");
   notesInfo->setValue("the estimate of bias current is based on a linear scaling: all relevant parameters are under the <a href=\"info.html\">info tab</a>\n");
-  settingsContent.addItem(notesInfo);  
-  notesInfo = new RootWInfo("Note");
-  notesInfo->setValue("In the dose and fluence plots, \"small\",\"med\", and \"large\" refer to the module spacings");
   settingsContent.addItem(notesInfo);  
 
 
@@ -382,7 +379,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legSplitCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"2Ssmall","2Slarge","PSsmall", "PSmed" ,"PSlarge"}){
+  for (auto x : {"2S-1.8mm","2S-4.0mm","PS-1.6mm", "PS-2.6mm" ,"PS-4.0mm"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_fluence_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_fluence_")+x]->GetMaximum());
@@ -403,7 +400,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legSplitCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"2Ssmall","2Slarge","PSsmall","PSmed", "PSlarge"}){
+  for (auto x : {"2S-1.8mm","2S-4.0mm","PS-1.6mm","PS-2.6mm", "PS-4.0mm"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_fluence_")+x]->DrawCopy("L");
@@ -466,7 +463,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseSplitCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"2Ssmall","2Slarge","PSsmall","PSmed","PSlarge"}){
+  for (auto x : {"2S-1.8mm","2S-4.0mm","PS-1.6mm","PS-2.6mm","PS-4.0mm"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_TID_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_TID_")+x]->GetMaximum());
@@ -486,7 +483,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseSplitCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"2Ssmall","2Slarge","PSsmall","PSmed" , "PSlarge"}){
+  for (auto x : {"2S-1.8mm","2S-4.0mm","PS-1.6mm","PS-2.6mm" , "PS-4.0mm"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_TID_")+x]->DrawCopy("C");

--- a/src/ReportIrradiation.cc
+++ b/src/ReportIrradiation.cc
@@ -127,8 +127,6 @@ std::map<std::string,TH1F*> ReportIrradiation::createSensorsIrradiationHistogram
     void preVisit() {
       for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_fluence_")+x] = new TH1F(TString::Format("tot_mod_fluence_%s", x),";NIEL fluence[1 MeV n_{eq} / cm^2]; Number of modules",30,0.,1.05*theMaxFluence_);
       for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("tot_mod_TID_")+x] = new TH1F(TString::Format("tot_mod_TID_%s", x),";Absorbed dose[Gy]; Number of modules",30,0,1.05*theMaxDose_);
-      //for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge", "TEPX" , "TFPX", "TBPX"}) hist_map[std::string("cumulative_fluence_")+x] = new TH1F(TString::Format("cumulative_fluence_%s", x),";NIEL fluence[1 MeV n_{eq} / cm^2]; Number of modules",30,0.,1.05*theMaxFluence_);
-      //for (auto x : {"PS" , "2S", "PSsmall","PSmed","PSlarge","2Ssmall","2Slarge","TEPX" , "TFPX", "TBPX"}) hist_map[std::string("cumulative_TID_")+x] = new TH1F(TString::Format("cumulative_TID_%s", x),";Absorbed dose[Gy]; Number of modules",30,0,1.05*theMaxDose_);
     }
     void visit(const Barrel& b) { sectionName_ = b.myid(); }
     void visit(const Endcap& e) { sectionName_ = e.myid(); }
@@ -177,10 +175,10 @@ std::map<std::string,TH1F*> ReportIrradiation::createSensorsIrradiationHistogram
        hist_map[std::string("cumulative_fluence_")+x]->SetName(TString::Format("cumulative_fluence_%s",x));
        hist_map[std::string("cumulative_fluence_")+x]->GetYaxis()->SetTitle("Fraction of modules");
        hist_map[std::string("cumulative_fluence_")+x]->Scale(1./hist_map[std::string("cumulative_fluence_")+x]->GetBinContent(1));
-       hist_map[std::string("cumulative_fluence_")+x]->SetTitle("Fraction of modules with fluence below");
+       hist_map[std::string("cumulative_fluence_")+x]->SetTitle("Fraction of modules with fluence above");
        hist_map[std::string("cumulative_TID_")+x] = dynamic_cast<TH1F*>(hist_map[std::string("tot_mod_TID_")+x]->GetCumulative(kFALSE));
        hist_map[std::string("cumulative_TID_")+x]->SetName(TString::Format("cumulative_TID_%s",x));
-       hist_map[std::string("cumulative_TID_")+x]->SetTitle("Fraction of modules with dose below");
+       hist_map[std::string("cumulative_TID_")+x]->SetTitle("Fraction of modules with dose above");
        hist_map[std::string("cumulative_TID_")+x]->GetYaxis()->SetTitle("Fraction of modules");
        hist_map[std::string("cumulative_TID_")+x]->Scale(1./hist_map[std::string("cumulative_TID_")+x]->GetBinContent(1));
      }
@@ -269,6 +267,10 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   notesInfo = new RootWInfo("Note");
   notesInfo->setValue("the estimate of bias current is based on a linear scaling: all relevant parameters are under the <a href=\"info.html\">info tab</a>\n");
   settingsContent.addItem(notesInfo);  
+  notesInfo = new RootWInfo("Note");
+  notesInfo->setValue("In the dose and fluence plots, \"small\",\"med\", and \"large\" refer to the module spacings");
+  settingsContent.addItem(notesInfo);  
+
 
 
   // Irradiation on each module type (fine grained)
@@ -329,7 +331,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   totalPowerImage.setName("totalPowerMap");
 
    
-  RootWContent& myupdContent = myPage.addContent("Dose and fluence histograms", true);
+  RootWContent& myupdContent = myPage.addContent("Number of modules per dose and fluence figures", true);
 
   std::map<std::string,TH1F*> histos = createSensorsIrradiationHistograms(maxFluence_, maxDose_);
   std::unique_ptr<TCanvas> irradiationFullCanvas(new TCanvas());
@@ -380,7 +382,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legSplitCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSsmall" ,"PSmed","PSlarge", "2Ssmall", "2Slarge"}){
+  for (auto x : {"PSmed" ,"PSsmall","PSlarge", "2Ssmall", "2Slarge"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_fluence_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_fluence_")+x]->GetMaximum());
@@ -401,7 +403,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legSplitCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSsmall" ,"PSmed","PSlarge","2Ssmall", "2Slarge"}){
+  for (auto x : {"PSmed" ,"PSsmall","PSlarge","2Ssmall", "2Slarge"}){
     if(histos[std::string("tot_mod_fluence_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_fluence_")+x]->DrawCopy("L");
@@ -464,7 +466,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseSplitCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseSplitCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSsmall" , "PSmed","PSlarge","2Ssmall", "2Slarge"}){
+  for (auto x : {"PSmed" , "PSsmall","PSlarge","2Ssmall", "2Slarge"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("tot_mod_TID_")+x]->GetYaxis()->SetRangeUser(0,1.5*histos[std::string("tot_mod_TID_")+x]->GetMaximum());
@@ -484,7 +486,7 @@ void ReportIrradiation::visualizeTo(RootWSite& site) {
   TLegend* legDoseSplitCumulCanvas = new TLegend(0.7,0.7,0.9,0.9);
   legDoseSplitCumulCanvas->SetFillStyle(0);
   drawnhists=0;
-  for (auto x : {"PSsmall" , "PSmed","PSlarge","2Ssmall", "2Slarge"}){
+  for (auto x : {"PSmed" , "PSsmall","PSlarge","2Ssmall", "2Slarge"}){
     if(histos[std::string("tot_mod_TID_")+x]->GetEntries() > 0 ){
       if(drawnhists==0){
         histos[std::string("cumulative_TID_")+x]->DrawCopy("C");


### PR DESCRIPTION
This adds plots showing the number of modules seeing a given dose/fluence, as well as the normalised cumulative distribution (fraction of modules above a certain dose/fluence). 

Example results here: https://adewit.web.cern.ch/adewit/layouts/OT801_IT701_COPY/irradiation_Outer.html 

For the inner tracker, some of these plots are not filled because I made separate canvases for the different module spacings in the OT, and can't figure out how to not store an empty canvas (since the code is the same for IT and OT).  I won't have time to look into this in detail for the next several weeks but I don't think it is a showstopper for now since all the information should at least be there.

@alkemyst let me know what you think.