### PR TITLE
Update of OT 2S and PS modules to latest baseline geometries

### DIFF
--- a/config/chemical_compounds.list
+++ b/config/chemical_compounds.list
@@ -23,6 +23,9 @@ C2H4                       0.89                       C:2                  H:4
 AlN	                       3.26	                     Al:1                  N:1
 # aluminium-nitride
 
+hBN                        2.1                        B:1                  N:1
+# hexagonal Boron nitride
+
 Si3N4                      3.183                     Si:3                  N:4
 # silicon nitride
 

--- a/config/chemical_mixtures.list
+++ b/config/chemical_mixtures.list
@@ -67,6 +67,12 @@ CF                         1.91                    C:1.0
 Epoxy	                     1.16                CH2OCN:1	 
 # EX1515 from Duccio, Composite materials, 14/01/2015
 
+Epoxy_601LV                  1.15                CH2OCN:1
+# from Polytec PT technical data sheet
+
+Epoxy_TC437                  1.35                Epoxy:0.80        hBN:0.2
+# density from Polytec PT technical data sheet; BN doping ratio to be confirmed
+
 #CFRP	                     1.84	                   C:0.78            Epoxy:0.22
 # from Duccio, Composite materials, 14/01/2015
 # Density & compo ok??

--- a/config/chemical_mixtures.list
+++ b/config/chemical_mixtures.list
@@ -312,7 +312,7 @@ FPIX_PE	                 0.95	                    PE:1
 TEDD_Steel	             7.8	                 Steel:1
 
 
-
+EN_AW-7075               2.8                 Al:0.903 Zn:0.056 Mg:0.025 Cu:0.016
 
 
 

--- a/config/chemical_mixtures.list
+++ b/config/chemical_mixtures.list
@@ -31,7 +31,8 @@ FR4                         1.85               Si:0.18077359           O:0.40563
 # Fiber glass reinforced, from trackermaterial.xml (density 1.7 g/cm3 ?)
 # Yadira: density 1.91 in [TFPX_2019_03_19_YP]
 
-
+PyraluxLF                   5.19
+# Assumes 125um Kapton and 75um Copper; to be checked with Hybrids WG
 
 
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
@@ -40,7 +40,7 @@ Component {
   // FEH compensator top
   Element {
     elementName <unknown>
-    quantity <unknown>
+    quantity <unknown>   // FEH-L: V = 398.6725 mm^3
     unit g
   }
   //FEH CFRP stiffener fold-over
@@ -52,7 +52,7 @@ Component {
   // FEH compensator fold-over
   Element {
     elementName <unknown>
-    quantity <unknown>
+    quantity <unknown>   // FEH-L: V = 101.7001 mm^3
     unit g
   }
 }
@@ -71,7 +71,7 @@ Component {
   // SEH compensator
   Element {
     elementName <unknown>
-    quantity <unknown>
+    quantity <unknown>   // V = 210.1235 mm^3
     unit g
   }
   //SEH glue

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
@@ -34,38 +34,38 @@ Component {
   //FEH CFRP stiffener top
   Element {
     elementName CFRP
-    quantity 4.146   // FEH-L: V = 1327.8998 mm^3
-    unit g
+    quantity 2655.7996 // FEH-L: V = 1327.8998 mm^3
+    unit mm3
   }
   // FEH compensator top
   Element {
-    elementName <unknown>
-    quantity <unknown>   // FEH-L: V = 398.6725 mm^3
-    unit g
+    elementName PyraluxLF
+    quantity 797.3450 // FEH-L: V = 398.6725 mm^3
+    unit mm3
   }
   //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
-    quantity 0.786   // FEH-L: V = 281.0697 mm^3
-    unit g
+    quantity 562.1394 // FEH-L: V = 281.0697 mm^3
+    unit mm3
   }
   // FEH compensator fold-over
   Element {
-    elementName <unknown>
-    quantity <unknown>   // FEH-L: V = 101.7001 mm^3
-    unit g
+    elementName PyraluxLF
+    quantity 203.4002 // FEH-L: V = 101.7001 mm^3
+    unit mm3
   }
   // FEH glue
   Element {
     elementName Epoxy
-    quantity 0.095   // FEH-L: V = 270.7285 mm^3 (flex - glue - CFRP - glue - comp. for top and fold-over)
-    unit g
+    quantity 541.4570 // FEH-L: V = 270.7285 mm^3 (flex - glue - CFRP - glue - comp. for top and fold-over)
+    unit mm3
   }
   // FEH glue
   Element {
     elementName Epoxy_TC437
-    quantity 0.089   // V = XYZ mm^3 (bridges - glue - FEH stiffener)
-    unit g
+    quantity 12.9100 // V = 4 x 3.2275 mm^3 (bridges - glue - FEH stiffener)
+    unit mm3
   }
   
 }
@@ -78,26 +78,26 @@ Component {
   //SEH CFRP stiffener
   Element {
     elementName CFRP
-    quantity 1.146   // V = 734.3982 mm^3
-    unit g
+    quantity 734.3982 // V = 734.3982 mm^3
+    unit mm3
   }
   // SEH compensator
   Element {
-    elementName <unknown>
-    quantity <unknown>   // V = 210.1235 mm^3
-    unit g
+    elementName PyraluxLF
+    quantity 210.1235 // V = 104.9149 mm^3 + 105.2086 mm^3 = 210.1235 mm^3
+    unit mm3
   }
   //SEH glue
   Element {
     elementName Epoxy
-    quantity 0.089   // V = XYZ mm^3 (glue within SEH)
-    unit g
+    quantity 134.7673 // V = 134.7673 mm^3 (glue within SEH)
+    unit mm3
   }
   //SEH glue
   Element {
     elementName Epoxy_TC437
-    quantity 0.089   // V = XYZ mm^3 (bridges - glue - SEH stiffener)
-    unit g
+    quantity 8.7473   // V = 2 x 2.9337 mm^3 + 2.8800 mm^3 = 8.7473 mm^3 (bridges - glue - SEH stiffener)
+    unit mm3
   }
   //SEH copper
   Element {

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
@@ -55,6 +55,19 @@ Component {
     quantity <unknown>   // FEH-L: V = 101.7001 mm^3
     unit g
   }
+  // FEH glue
+  Element {
+    elementName Epoxy
+    quantity 0.095   // FEH-L: V = 270.7285 mm^3 (flex - glue - CFRP - glue - comp. for top and fold-over)
+    unit g
+  }
+  // FEH glue
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.089   // V = XYZ mm^3 (bridges - glue - FEH stiffener)
+    unit g
+  }
+  
 }
 
 Component {
@@ -77,7 +90,13 @@ Component {
   //SEH glue
   Element {
     elementName Epoxy
-    quantity 0.089
+    quantity 0.089   // V = XYZ mm^3 (glue within SEH)
+    unit g
+  }
+  //SEH glue
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.089   // V = XYZ mm^3 (bridges - glue - SEH stiffener)
     unit g
   }
   //SEH copper

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
@@ -37,10 +37,22 @@ Component {
     quantity 4.146
     unit g
   }
+  // FEH compensator top
+  Element {
+    elementName <unknown>
+    quantity <unknown>
+    unit g
+  }
   //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
     quantity 0.786
+    unit g
+  }
+  // FEH compensator fold-over
+  Element {
+    elementName <unknown>
+    quantity <unknown>
     unit g
   }
 }
@@ -54,6 +66,12 @@ Component {
   Element {
     elementName CFRP
     quantity 1.146
+    unit g
+  }
+  // SEH compensator
+  Element {
+    elementName <unknown>
+    quantity <unknown>
     unit g
   }
   //SEH glue

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
@@ -31,13 +31,13 @@ Component {
     unit g
   }
 
-  //FEH CFRP support
+  //FEH CFRP stiffener top
   Element {
     elementName CFRP
     quantity 4.146
     unit g
   }
-  //FEH CFRP stiffener
+  //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
     quantity 0.786
@@ -50,7 +50,7 @@ Component {
   service false
   scaleOnSensor 0
   targetVolume 3
-  //SEH CFRP support
+  //SEH CFRP stiffener
   Element {
     elementName CFRP
     quantity 1.146

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
@@ -34,7 +34,7 @@ Component {
   //FEH CFRP stiffener top
   Element {
     elementName CFRP
-    quantity 4.146
+    quantity 4.146   // FEH-L: V = 1327.8998 mm^3
     unit g
   }
   // FEH compensator top
@@ -46,7 +46,7 @@ Component {
   //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
-    quantity 0.786
+    quantity 0.786   // FEH-L: V = 281.0697 mm^3
     unit g
   }
   // FEH compensator fold-over
@@ -65,7 +65,7 @@ Component {
   //SEH CFRP stiffener
   Element {
     elementName CFRP
-    quantity 1.146
+    quantity 1.146   // V = 734.3982 mm^3
     unit g
   }
   // SEH compensator

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
@@ -4,12 +4,6 @@ Component {
   componentName "2S Module: FE hybrid spacers"
   targetVolume 56
 
-  //FEH spacer 1.8 mm
-  Element {
-    elementName Al-CF
-    quantity 0.786
-    unit g
-  }
   //FEH glue 1.8 mm
   Element {
     elementName Epoxy

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
@@ -7,7 +7,7 @@ Component {
   //FEH glue 1.8 mm
   Element {
     elementName Epoxy
-    quantity 0.504   // V = 25.3547 mm^3 (between folded stiffeners)
-    unit g
+    quantity 50.7094 // V = 2 x 25.3547 mm^3 = 50.7094 mm^3 (between folded stiffeners)
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
@@ -7,7 +7,7 @@ Component {
   //FEH glue 1.8 mm
   Element {
     elementName Epoxy
-    quantity 0.504
+    quantity 0.504   // V = 25.3547 mm^3 (between folded stiffeners)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_40
@@ -7,13 +7,13 @@ Component {
   //FEH spacer 4.0 mm
   Element {
     elementName AlN
-    quantity 1.6   // V = 338.5752 mm^3
-    unit g
+    quantity 677.1504 // V = 2 x 338.5752 mm^3 = 677.1504 mm^3
+    unit mm3
   }
   //FEH glue 4.0 mm
   Element {
     elementName Epoxy
-    quantity 0.413   // top and bottom: V = 15.7291 mm^3
-    unit g
+    quantity 31.4584 // top and bottom: V = 2 x 2 x 7.8646 mm^3 = 31.4584 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_40
@@ -6,7 +6,7 @@ Component {
 
   //FEH spacer 4.0 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 1.6
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_40
@@ -7,13 +7,13 @@ Component {
   //FEH spacer 4.0 mm
   Element {
     elementName AlN
-    quantity 1.6
+    quantity 1.6   // V = 338.5752 mm^3
     unit g
   }
   //FEH glue 4.0 mm
   Element {
     elementName Epoxy
-    quantity 0.413
+    quantity 0.413   // top and bottom: V = 15.7291 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18
@@ -25,12 +25,6 @@ Component {
     quantity 0.76
     unit g
   }
-  //Parylene 1.8mm
-  Element {
-    elementName Epoxy
-    quantity 0.061
-    unit g
-  }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
@@ -10,20 +10,20 @@ Component {
   //Long-1.8mm (Main Bridge)
   Element {
     elementName Al-CF
-    quantity 1.86
+    quantity 1.86   // V = XYZ mm^3 (both bridges)
     unit g
   }
   //Short-1.8mm (Stump Bridge)
   Element {
     elementName Al-CF
-    quantity 0.36
+    quantity 0.36   // V = XYZ mm^3 (one stump bridge)
     unit g
   }
-  //FEH support tab
+  //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76
+    quantity 0.76   // V = XYZ mm^3 (everything related to targetVolume 0; incl. stump bridge)
     unit g
   }
   //Bridges glue 1.8 mm

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
@@ -10,44 +10,44 @@ Component {
   //Long-1.8mm (Main Bridge) - Volume of two complete bridges is 2 x 680.3780 mm^3 = 1360.7560 mm^3
   Element {
     elementName Al-CF
-    quantity 1.86   // V = 2 x 339.1481 mm^3 = 678.2962 mm^3 (both bridges)
-    unit g
+    quantity 678.2962 // V = 2 x 339.1481 mm^3 = 678.2962 mm^3 (both bridges)
+    unit mm3
   }
   //Long-1.8mm (Main Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 3.160   // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
-    unit g
+    quantity 93.6500 // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
+    unit mm3
   }
   //Short-1.8mm (Stump Bridge) - Volume of one complete stump bridge is 202.6138 mm^3
   Element {
     elementName Al-CF
-    quantity 0.36   // V = 89.7336 mm^3 (one stump bridge)
-    unit g
+    quantity 89.7336 // V = 89.7336 mm^3 (one stump bridge)
+    unit mm3
   }
   //Short-1.8mm (Stump Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 0.65   // V = 2 x 4.3523 mm^3 = 8.7046 mm^3 (for one stump bridge top and bottom)
-    unit g
+    quantity 8.7046 // V = 2 x 4.3523 mm^3 = 8.7046 mm^3 (for one stump bridge top and bottom)
+    unit mm3
   }
   //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76   // V = 4 x 169.3900 mm^3 + 1 x 112.8802 mm^3 = 790.4402 mm^3 (everything related to targetVolume 0; incl. stump bridge)
-    unit g
+    quantity 790.4402 // V = 4 x 169.3900 mm^3 + 1 x 112.8802 mm^3 = 790.4402 mm^3 (everything related to targetVolume 0; incl. stump bridge)
+    unit mm3
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // V = 4 x 23.0748 mm^3 + 2 x 4.1791 mm^3 = 100.6574 mm^3 (glue between sensors and Kapton isolators)
-    unit g
+    quantity 100.6574 // V = 4 x 23.0748 mm^3 + 2 x 4.1791 mm^3 = 100.6574 mm^3 (glue between sensors and Kapton isolators)
+    unit mm3
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // V = 4 x 6.8576 mm^3 + 2 x 1.7783 mm^3 = 30.9870 mm^3 (glue bridges and Kapton isolators)
-    unit g
+    quantity 30.9870 // V = 4 x 6.8576 mm^3 + 2 x 1.7783 mm^3 = 30.9870 mm^3 (glue bridges and Kapton isolators)
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
@@ -40,8 +40,14 @@ Component {
   }
   //Bridges glue 1.8 mm
   Element {
-    elementName Epoxy
-    quantity 0.089
+    elementName Epoxy_601LV
+    quantity 0.163   // V = XYZ mm^3 (glue between sensors and Kapton isolators)
+    unit g
+  }
+  //Bridges glue 1.8 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.163   // V = XYZ mm^3 (glue bridges and Kapton isolators)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
@@ -7,47 +7,47 @@ Component {
   scaleOnSensor 0
   targetVolume 7
 
-  //Long-1.8mm (Main Bridge)
+  //Long-1.8mm (Main Bridge) - Volume of two complete bridges is 2 x 680.3780 mm^3 = 1360.7560 mm^3
   Element {
     elementName Al-CF
-    quantity 1.86   // V = XYZ mm^3 (both bridges)
+    quantity 1.86   // V = 2 x 339.1481 mm^3 = 678.2962 mm^3 (both bridges)
     unit g
   }
   //Long-1.8mm (Main Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 3.160   // V = XYZ mm^3 (for both bridges top and bottom)
+    quantity 3.160   // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
     unit g
   }
-  //Short-1.8mm (Stump Bridge)
+  //Short-1.8mm (Stump Bridge) - Volume of one complete stump bridge is 202.6138 mm^3
   Element {
     elementName Al-CF
-    quantity 0.36   // V = XYZ mm^3 (one stump bridge)
+    quantity 0.36   // V = 89.7336 mm^3 (one stump bridge)
     unit g
   }
   //Short-1.8mm (Stump Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 0.65   // V = XYZ mm^3 (for one stump bridge top and bottom)
+    quantity 0.65   // V = 2 x 4.3523 mm^3 = 8.7046 mm^3 (for one stump bridge top and bottom)
     unit g
   }
   //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76   // V = XYZ mm^3 (everything related to targetVolume 0; incl. stump bridge)
+    quantity 0.76   // V = 4 x 169.3900 mm^3 + 1 x 112.8802 mm^3 = 790.4402 mm^3 (everything related to targetVolume 0; incl. stump bridge)
     unit g
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // V = XYZ mm^3 (glue between sensors and Kapton isolators)
+    quantity 0.163   // V = 4 x 23.0748 mm^3 + 2 x 4.1791 mm^3 = 100.6574 mm^3 (glue between sensors and Kapton isolators)
     unit g
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // V = XYZ mm^3 (glue bridges and Kapton isolators)
+    quantity 0.163   // V = 4 x 6.8576 mm^3 + 2 x 1.7783 mm^3 = 30.9870 mm^3 (glue bridges and Kapton isolators)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
@@ -1,4 +1,5 @@
 // Sensor spacers for 2S module 1.8 mm spacing
+// with 5 cooling points; one stump bridge
 
 Component {
   componentName "2S Module: Sensor spacers"

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
@@ -13,10 +13,22 @@ Component {
     quantity 1.86   // V = XYZ mm^3 (both bridges)
     unit g
   }
+  //Long-1.8mm (Main Bridge Kapton isolators)
+  Element {
+    elementName Kapton
+    quantity 3.160   // V = XYZ mm^3 (for both bridges top and bottom)
+    unit g
+  }
   //Short-1.8mm (Stump Bridge)
   Element {
     elementName Al-CF
     quantity 0.36   // V = XYZ mm^3 (one stump bridge)
+    unit g
+  }
+  //Short-1.8mm (Stump Bridge Kapton isolators)
+  Element {
+    elementName Kapton
+    quantity 0.65   // V = XYZ mm^3 (for one stump bridge top and bottom)
     unit g
   }
   //FEH support tab & module mounting

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
@@ -13,10 +13,22 @@ Component {
     quantity 1.86   // V = XYZ mm^3 (both bridges)
     unit g
   }
+  //Long-1.8mm (Main Bridge Kapton isolators)
+  Element {
+    elementName Kapton
+    quantity 3.160   // V = XYZ mm^3 (for both bridges top and bottom)
+    unit g
+  }
   //Short-1.8mm (Stump Bridge)
   Element {
     elementName Al-CF
     quantity 0.36   // V = XYZ mm^3 (two stump bridges)
+    unit g
+  }
+  //Short-1.8mm (Stump Bridge Kapton isolators)
+  Element {
+    elementName Kapton
+    quantity 0.65   // V = XYZ mm^3 (for two stump bridges top and bottom)
     unit g
   }
   //FEH support tab & module mounting

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
@@ -40,8 +40,14 @@ Component {
   }
   //Bridges glue 1.8 mm
   Element {
-    elementName Epoxy
-    quantity 0.089
+    elementName Epoxy_601LV
+    quantity 0.163   // V = XYZ mm^3 (glue between sensors and Kapton isolators)
+    unit g
+  }
+  //Bridges glue 1.8 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.163   // V = XYZ mm^3 (glue bridges and Kapton isolators)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
@@ -7,47 +7,47 @@ Component {
   scaleOnSensor 0
   targetVolume 7
 
-  //Long-1.8mm (Main Bridge)
+  //Long-1.8mm (Main Bridge) - Volume of two complete bridges is 2 x 680.3780 mm^3 = 1360.7560 mm^3
   Element {
     elementName Al-CF
-    quantity 1.86   // V = XYZ mm^3 (both bridges)
+    quantity 1.86   // V = 2 x 339.1481 mm^3 = 678.2962 mm^3 (both bridges)
     unit g
   }
   //Long-1.8mm (Main Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 3.160   // V = XYZ mm^3 (for both bridges top and bottom)
+    quantity 3.160   // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
     unit g
   }
-  //Short-1.8mm (Stump Bridge)
+  //Short-1.8mm (Stump Bridges) - Volume of two complete stump bridges is 2 x 202.6138 mm^3 = 405.2276 mm^3
   Element {
     elementName Al-CF
-    quantity 0.36   // V = XYZ mm^3 (two stump bridges)
+    quantity 0.36   // V = 2 x 89.7336 mm^3 = 179.4672 mm^3 (two stump bridges)
     unit g
   }
   //Short-1.8mm (Stump Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 0.65   // V = XYZ mm^3 (for two stump bridges top and bottom)
+    quantity 0.65   // V = 4 x 4.3523 mm^3 = 17.4092 mm^3 (for two stump bridges top and bottom)
     unit g
   }
   //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76   // V = XYZ mm^3 (everything related to targetVolume 0; incl. stump bridges)
+    quantity 0.76   // V = 4 x 169.3900 mm^3 + 2 x 112.8802 mm^3 = 903.3204 mm^3 (everything related to targetVolume 0; incl. stump bridges)
     unit g
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // V = XYZ mm^3 (glue between sensors and Kapton isolators)
+    quantity 0.163   // V = 4 x 23.0748 mm^3 + 4 x 4.1791 mm^3 = 109.0156 mm^3 (glue between sensors and Kapton isolators)
     unit g
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // V = XYZ mm^3 (glue bridges and Kapton isolators)
+    quantity 0.163   // V = 4 x 6.8576 mm^3 + 4 x 1.7783 mm^3 = 34.5436 mm^3 (glue bridges and Kapton isolators)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
@@ -10,44 +10,44 @@ Component {
   //Long-1.8mm (Main Bridge) - Volume of two complete bridges is 2 x 680.3780 mm^3 = 1360.7560 mm^3
   Element {
     elementName Al-CF
-    quantity 1.86   // V = 2 x 339.1481 mm^3 = 678.2962 mm^3 (both bridges)
-    unit g
+    quantity 678.2962 // V = 2 x 339.1481 mm^3 = 678.2962 mm^3 (both bridges)
+    unit mm3
   }
   //Long-1.8mm (Main Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 3.160   // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
-    unit g
+    quantity 93.6500 // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
+    unit mm3
   }
   //Short-1.8mm (Stump Bridges) - Volume of two complete stump bridges is 2 x 202.6138 mm^3 = 405.2276 mm^3
   Element {
     elementName Al-CF
-    quantity 0.36   // V = 2 x 89.7336 mm^3 = 179.4672 mm^3 (two stump bridges)
-    unit g
+    quantity 179.4672 // V = 2 x 89.7336 mm^3 = 179.4672 mm^3 (two stump bridges)
+    unit mm3
   }
   //Short-1.8mm (Stump Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 0.65   // V = 4 x 4.3523 mm^3 = 17.4092 mm^3 (for two stump bridges top and bottom)
-    unit g
+    quantity 17.4092 // V = 4 x 4.3523 mm^3 = 17.4092 mm^3 (for two stump bridges top and bottom)
+    unit mm3
   }
   //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76   // V = 4 x 169.3900 mm^3 + 2 x 112.8802 mm^3 = 903.3204 mm^3 (everything related to targetVolume 0; incl. stump bridges)
-    unit g
+    quantity 903.3204 // V = 4 x 169.3900 mm^3 + 2 x 112.8802 mm^3 = 903.3204 mm^3 (everything related to targetVolume 0; incl. stump bridges)
+    unit mm3
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // V = 4 x 23.0748 mm^3 + 4 x 4.1791 mm^3 = 109.0156 mm^3 (glue between sensors and Kapton isolators)
-    unit g
+    quantity 109.0156   // V = 4 x 23.0748 mm^3 + 4 x 4.1791 mm^3 = 109.0156 mm^3 (glue between sensors and Kapton isolators)
+    unit mm3
   }
   //Bridges glue 1.8 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // V = 4 x 6.8576 mm^3 + 4 x 1.7783 mm^3 = 34.5436 mm^3 (glue bridges and Kapton isolators)
-    unit g
+    quantity 34.5436 // V = 4 x 6.8576 mm^3 + 4 x 1.7783 mm^3 = 34.5436 mm^3 (glue bridges and Kapton isolators)
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
@@ -1,0 +1,35 @@
+// Sensor spacers for 2S module 1.8 mm spacing
+// with 6 cooling points; two stump bridges
+
+Component {
+  componentName "2S Module: Sensor spacers"
+  service false
+  scaleOnSensor 0
+  targetVolume 7
+
+  //Long-1.8mm (Main Bridge)
+  Element {
+    elementName Al-CF
+    quantity 1.86
+    unit g
+  }
+  //2 x Short-1.8mm (Stump Bridge)
+  Element {
+    elementName Al-CF
+    quantity 0.36
+    unit g
+  }
+  //FEH support tab
+  Element {
+    targetVolume 0
+    elementName Al-CF
+    quantity 0.76
+    unit g
+  }
+  //Bridges glue 1.8 mm
+  Element {
+    elementName Epoxy
+    quantity 0.089
+    unit g
+  }
+}

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
@@ -10,20 +10,20 @@ Component {
   //Long-1.8mm (Main Bridge)
   Element {
     elementName Al-CF
-    quantity 1.86
+    quantity 1.86   // V = XYZ mm^3 (both bridges)
     unit g
   }
-  //2 x Short-1.8mm (Stump Bridge)
+  //Short-1.8mm (Stump Bridge)
   Element {
     elementName Al-CF
-    quantity 0.36
+    quantity 0.36   // V = XYZ mm^3 (two stump bridges)
     unit g
   }
-  //FEH support tab
+  //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76
+    quantity 0.76   // V = XYZ mm^3 (everything related to targetVolume 0; incl. stump bridges)
     unit g
   }
   //Bridges glue 1.8 mm

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
@@ -6,47 +6,47 @@ Component {
   scaleOnSensor 0
   targetVolume 7
 
-  //Long-4.0mm (Main Bridge)
+  //Long-4.0mm (Main Bridge) - Volume of two complete bridges is 2 x 978.4087 mm^3 = 1956.8174 mm^3
   Element {
     elementName Al-CF
-    quantity 3.160   // V = XYZ mm^3 (both bridges)
+    quantity 3.160   // V = 2 x 491.4584 mm^3 = 982.9168 mm^3 (both bridges)
     unit g
   }
   //Long-4.0mm (Main Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 3.160   // V = XYZ mm^3 (for both bridges top and bottom)
+    quantity 3.160   // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
     unit g
   }
-  //Short-4.0mm (Stump Bridge)
+  //Short-4.0mm (Stump Bridge) - Volume of two complete stump bridges is 2 x 265.2119 mm^3 = 530.4238 mm^3
   Element {
     elementName Al-CF
-    quantity 0.65   // V = XYZ mm^3 (both stump bridges)
+    quantity 0.65   // V = 2 x 149.1073 mm^3 = 298.2146 mm^3 (both stump bridges)
     unit g
   }
   //Short-4.0mm (Stump Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 0.65   // V = XYZ mm^3 (for both stump bridges top and bottom)
+    quantity 0.65   // V = 4 x 4.3523 mm^3 = 17.4092 mm^3 (for both stump bridges top and bottom)
     unit g
   }
   //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76   // V = XYZ mm^3 (everything related to targetVolume 0; incl. stump bridges)
+    quantity 0.76   // V = 4 x 242.2501 mm^3 + 2 x 116.1046 mm^3 = 1201.2096 mm^3 (everything related to targetVolume 0; incl. stump bridges)
     unit g
   }
   //Bridges glue 4.0 mm
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // V = XYZ mm^3 (glue between sensors and Kapton isolators)
+    quantity 0.163   // V = 4 x 23.4125 mm^3 + 4 x 4.1791 mm^3 = 110.3664 mm^3 (glue between sensors and Kapton isolators)
     unit g
   }
   //Bridges glue 4.0 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // V = XYZ mm^3 (glue bridges and Kapton isolators)
+    quantity 0.163   // V = 4 x 10.6011 mm^3 + 4 x 3.0923 mm^3 = 54.7736 mm^3 (glue bridges and Kapton isolators)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
@@ -9,20 +9,20 @@ Component {
   //Long-4.0mm (Main Bridge)
   Element {
     elementName Al-CF
-    quantity 3.160
+    quantity 3.160   // V = XYZ mm^3 (both bridges)
     unit g
   }
   //Short-4.0mm (Stump Bridge)
   Element {
     elementName Al-CF
-    quantity 0.65
+    quantity 0.65   // V = XYZ mm^3 (both stump bridges)
     unit g
   }
-  //FEH support tab
+  //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76
+    quantity 0.76   // V = XYZ mm^3 (everything related to targetVolume 0; incl. stump bridges)
     unit g
   }
   //Bridges glue 4.0 mm

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
@@ -39,8 +39,14 @@ Component {
   }
   //Bridges glue 4.0 mm
   Element {
-    elementName Epoxy
-    quantity 0.163
+    elementName Epoxy_601LV
+    quantity 0.163   // V = XYZ mm^3 (glue between sensors and Kapton isolators)
+    unit g
+  }
+  //Bridges glue 4.0 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.163   // V = XYZ mm^3 (glue bridges and Kapton isolators)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
@@ -12,10 +12,22 @@ Component {
     quantity 3.160   // V = XYZ mm^3 (both bridges)
     unit g
   }
+  //Long-4.0mm (Main Bridge Kapton isolators)
+  Element {
+    elementName Kapton
+    quantity 3.160   // V = XYZ mm^3 (for both bridges top and bottom)
+    unit g
+  }
   //Short-4.0mm (Stump Bridge)
   Element {
     elementName Al-CF
     quantity 0.65   // V = XYZ mm^3 (both stump bridges)
+    unit g
+  }
+  //Short-4.0mm (Stump Bridge Kapton isolators)
+  Element {
+    elementName Kapton
+    quantity 0.65   // V = XYZ mm^3 (for both stump bridges top and bottom)
     unit g
   }
   //FEH support tab & module mounting

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
@@ -25,12 +25,6 @@ Component {
     quantity 0.76
     unit g
   }
-  //Parylene 4.0mm
-  Element {
-    elementName Epoxy
-    quantity 0.09
-    unit g
-  }
   //Bridges glue 4.0 mm
   Element {
     elementName Epoxy

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_40
@@ -9,44 +9,44 @@ Component {
   //Long-4.0mm (Main Bridge) - Volume of two complete bridges is 2 x 978.4087 mm^3 = 1956.8174 mm^3
   Element {
     elementName Al-CF
-    quantity 3.160   // V = 2 x 491.4584 mm^3 = 982.9168 mm^3 (both bridges)
-    unit g
+    quantity 982.9168 // V = 2 x 491.4584 mm^3 = 982.9168 mm^3 (both bridges)
+    unit mm3
   }
   //Long-4.0mm (Main Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 3.160   // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
-    unit g
+    quantity 93.6500 // V = 4 x 23.4125 mm^3 = 93.6500 mm^3 (for both bridges top and bottom)
+    unit mm3
   }
   //Short-4.0mm (Stump Bridge) - Volume of two complete stump bridges is 2 x 265.2119 mm^3 = 530.4238 mm^3
   Element {
     elementName Al-CF
-    quantity 0.65   // V = 2 x 149.1073 mm^3 = 298.2146 mm^3 (both stump bridges)
-    unit g
+    quantity 298.2146 // V = 2 x 149.1073 mm^3 = 298.2146 mm^3 (both stump bridges)
+    unit mm3
   }
   //Short-4.0mm (Stump Bridge Kapton isolators)
   Element {
     elementName Kapton
-    quantity 0.65   // V = 4 x 4.3523 mm^3 = 17.4092 mm^3 (for both stump bridges top and bottom)
-    unit g
+    quantity 17.4092 // V = 4 x 4.3523 mm^3 = 17.4092 mm^3 (for both stump bridges top and bottom)
+    unit mm3
   }
   //FEH support tab & module mounting
   Element {
     targetVolume 0
     elementName Al-CF
-    quantity 0.76   // V = 4 x 242.2501 mm^3 + 2 x 116.1046 mm^3 = 1201.2096 mm^3 (everything related to targetVolume 0; incl. stump bridges)
-    unit g
+    quantity 1201.2096 // V = 4 x 242.2501 mm^3 + 2 x 116.1046 mm^3 = 1201.2096 mm^3 (everything related to targetVolume 0; incl. stump bridges)
+    unit mm3
   }
   //Bridges glue 4.0 mm
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // V = 4 x 23.4125 mm^3 + 4 x 4.1791 mm^3 = 110.3664 mm^3 (glue between sensors and Kapton isolators)
-    unit g
+    quantity 110.3664 // V = 4 x 23.4125 mm^3 + 4 x 4.1791 mm^3 = 110.3664 mm^3 (glue between sensors and Kapton isolators)
+    unit mm3
   }
   //Bridges glue 4.0 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // V = 4 x 10.6011 mm^3 + 4 x 3.0923 mm^3 = 54.7736 mm^3 (glue bridges and Kapton isolators)
-    unit g
+    quantity 54.7736 // V = 4 x 10.6011 mm^3 + 4 x 3.0923 mm^3 = 54.7736 mm^3 (glue bridges and Kapton isolators)
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -31,13 +31,7 @@ Component {
   //FEH CFRP stiffener top
   Element {
     elementName CFRP
-    quantity 2.140
-    unit g
-  }
-  // FEH compensator top
-  Element {
-    elementName <unknown>
-    quantity <unknown>
+    quantity 2.140   // FEH-L: V = 634.0936 mm^3
     unit g
   }
   //FEH CFRP stiffener fold-over
@@ -46,10 +40,10 @@ Component {
     quantity 1.499   // FEH-L: V = 500.7399 mm^3
     unit g
   }
-  // FEH compensator fold-over
+  // FEH glue
   Element {
-    elementName <unknown>
-    quantity <unknown>
+    elementName Epoxy
+    quantity 0.095   // FEH-L: V = 103.1391 mm^3 (flex - glue - CFRP top/fold-over)
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -43,7 +43,7 @@ Component {
   //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
-    quantity 1.499
+    quantity 1.499   // FEH-L: V = 500.7399 mm^3
     unit g
   }
   // FEH compensator fold-over
@@ -62,7 +62,7 @@ Component {
   // ROH CFRP stiffener
   Element {
     elementName CFRP
-    quantity 0.247
+    quantity 0.247 // V = 356.5467 mm^3
     unit g
   }
   // ROH compensator
@@ -94,13 +94,13 @@ Component {
   // POH FR4 stiffener
   Element {
     elementName FR4
-    quantity 0.247
+    quantity 0.247 // V = 198.3447 mm^3
     unit g
   }
   // POH glue
   Element {
     elementName Epoxy
-    quantity 0.095
+    quantity 0.095   // V = 34.4308 mm^3 (BP - glue - FR4 - glue - flex)
     unit g
   }
   // POH copper

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -31,20 +31,20 @@ Component {
   //FEH CFRP stiffener top
   Element {
     elementName CFRP
-    quantity 2.140   // FEH-L: V = 634.0936 mm^3
-    unit g
+    quantity 1268.1872 // FEH-L: V = 634.0936 mm^3
+    unit mm3
   }
   //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
-    quantity 1.499   // FEH-L: V = 500.7399 mm^3
-    unit g
+    quantity 1001.4798 // FEH-L: V = 500.7399 mm^3
+    unit mm3
   }
   // FEH glue
   Element {
     elementName Epoxy
-    quantity 0.095   // FEH-L: V = 103.1391 mm^3 (flex - glue - CFRP top/fold-over)
-    unit g
+    quantity 103.1391 // FEH-L: V = 103.1391 mm^3 (flex - glue - CFRP top/fold-over)
+    unit mm3
   }
 }
 
@@ -56,20 +56,20 @@ Component {
   // ROH CFRP stiffener
   Element {
     elementName CFRP
-    quantity 0.247 // V = 356.5467 mm^3
-    unit g
+    quantity 356.5467 // V = 356.5467 mm^3
+    unit mm3
   }
   // ROH compensator
   Element {
-    elementName <unknown>
-    quantity <unknown> // V = 130.0335 mm^3
-    unit g
+    elementName PyraluxLF
+    quantity 130.0335 // V = 130.0335 mm^3
+    unit mm3
   }
   // ROH glue
   Element {
     elementName Epoxy
-    quantity 0.095   // V = 32.4133 mm^3 (comp. - glue - CFRP - glue - flex)
-    unit g
+    quantity 32.4133 // V = 32.4133 mm^3 (comp. - glue - CFRP - glue - flex)
+    unit mm3
   }
   // ROH copper
   Element {
@@ -94,20 +94,20 @@ Component {
   // POH FR4 stiffener
   Element {
     elementName FR4
-    quantity 0.247 // V = 198.3447 mm^3
-    unit g
+    quantity 198.3447 // V = 198.3447 mm^3
+    unit mm3
   }
   // POH glue
   Element {
     elementName Epoxy
-    quantity 0.095   // V = 17.2154 mm^3 (FR4 - glue - flex)
-    unit g
+    quantity 17.2154 // V = 17.2154 mm^3 (FR4 - glue - flex)
+    unit mm3
   }
   // POH glue
   Element {
     elementName Epoxy_TC437
-    quantity 0.095   // V = 17.2154 mm^3 (BP - glue - FR4)
-    unit g
+    quantity 17.2154 // V = 17.2154 mm^3 (BP - glue - FR4)
+    unit mm3
   }
   // POH copper
   Element {
@@ -126,7 +126,7 @@ Component {
   Element {
     targetVolume 7
     elementName PS_POH_Polyimide
-    quantity 2.419   // V = 201.7204 mm^3
-    unit g
+    quantity 201.7204 // V = 201.7204 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -62,7 +62,13 @@ Component {
   // ROH compensator
   Element {
     elementName <unknown>
-    quantity <unknown>
+    quantity <unknown> // V = 130.0335 mm^3
+    unit g
+  }
+  // ROH glue
+  Element {
+    elementName Epoxy
+    quantity 0.095   // V = 32.4133 mm^3 (comp. - glue - CFRP - glue - flex)
     unit g
   }
   // ROH copper

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -100,7 +100,13 @@ Component {
   // POH glue
   Element {
     elementName Epoxy
-    quantity 0.095   // V = 34.4308 mm^3 (BP - glue - FR4 - glue - flex)
+    quantity 0.095   // V = 17.2154 mm^3 (FR4 - glue - flex)
+    unit g
+  }
+  // POH glue
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.095   // V = 17.2154 mm^3 (BP - glue - FR4)
     unit g
   }
   // POH copper

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -121,4 +121,12 @@ Component {
     quantity 3.108
     unit g
   }
+  
+    // POH zigzag power cable
+  Element {
+    targetVolume 7
+    elementName PS_POH_Polyimide
+    quantity 2.419   // V = 201.7204 mm^3
+    unit g
+  }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -28,13 +28,13 @@ Component {
     quantity 0.935
     unit g
   }
-  //FEH CFRP support
+  //FEH CFRP stiffener top
   Element {
     elementName CFRP
     quantity 2.140
     unit g
   }
-  //FEH CFRP stiffener
+  //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
     quantity 1.499
@@ -47,7 +47,7 @@ Component {
   service false
   scaleOnSensor 0
   targetVolume 3
-  // ROH CFRP support
+  // ROH CFRP stiffener
   Element {
     elementName CFRP
     quantity 0.247

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -34,10 +34,22 @@ Component {
     quantity 2.140
     unit g
   }
+  // FEH compensator top
+  Element {
+    elementName <unknown>
+    quantity <unknown>
+    unit g
+  }
   //FEH CFRP stiffener fold-over
   Element {
     elementName CFRP
     quantity 1.499
+    unit g
+  }
+  // FEH compensator fold-over
+  Element {
+    elementName <unknown>
+    quantity <unknown>
     unit g
   }
 }
@@ -51,6 +63,12 @@ Component {
   Element {
     elementName CFRP
     quantity 0.247
+    unit g
+  }
+  // ROH compensator
+  Element {
+    elementName <unknown>
+    quantity <unknown>
     unit g
   }
   // ROH copper

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Circuits
@@ -73,9 +73,9 @@ Component {
   service false
   scaleOnSensor 0
   targetVolume 4
-  // POH CFRP support
+  // POH FR4 stiffener
   Element {
-    elementName CFRP
+    elementName FR4
     quantity 0.247
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
@@ -6,7 +6,7 @@ Component {
 
   //FEH spacer 1.6 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 0.240
     unit g
   }
@@ -32,7 +32,7 @@ Component {
 
   //ROH spacer 1.6 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 0.300
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
@@ -7,22 +7,22 @@ Component {
   //FEH spacer 1.6 mm
   Element {
     elementName AlN
-    quantity 0.240   // FEH-L: V = 51.9889 mm^3 (2 x corner)
-    unit g
+    quantity 103.9778 // FEH-L: V = 51.9889 mm^3 (2 x corner)
+    unit mm3
   }
 
   //FEH glue 1.6 mm
   Element {
     elementName Epoxy
-    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 45.3437 mm^3 (1 x middle)
-    unit g
+    quantity 95.0934 // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 45.3437 mm^3 (1 x middle) = 47.5467 mm^3
+    unit mm3
   }
 
   //FEH glue 1.6 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
-    unit g
+    quantity 4.406 // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
+    unit mm3
   }
 }
 
@@ -33,21 +33,21 @@ Component {
   //ROH glue 1.6 mm
   Element {
     elementName Epoxy
-    quantity 0.061   // top and bottom: V = 4.4243 mm^3 (ROH spacer - glue - compensator)
-    unit g
+    quantity 4.4243 // top and bottom: V = 4.4243 mm^3 (ROH spacer - glue - compensator)
+    unit mm3
   }
 
   //ROH glue 1.6 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.061   // top and bottom: V = 4.4243 mm^3 (BP - glue - ROH spacer)
-    unit g
+    quantity 4.4243 // top and bottom: V = 4.4243 mm^3 (BP - glue - ROH spacer)
+    unit mm3
   }
 
   //ROH spacer 1.6 mm
   Element {
     elementName AlN
-    quantity 0.300   // V = 96.0000 mm^3
-    unit g
+    quantity 96.0000 // V = 96.0000 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
@@ -14,7 +14,14 @@ Component {
   //FEH glue 1.6 mm
   Element {
     elementName Epoxy
-    quantity 0.260
+    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 45.3437 mm^3 (1 x middle)
+    unit g
+  }
+
+  //FEH glue 1.6 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
     unit g
   }
 }
@@ -26,7 +33,14 @@ Component {
   //ROH glue 1.6 mm
   Element {
     elementName Epoxy
-    quantity 0.061
+    quantity 0.061   // top and bottom: V = 4.4243 mm^3 (ROH spacer - glue - compensator)
+    unit g
+  }
+
+  //ROH glue 1.6 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.061   // top and bottom: V = 4.4243 mm^3 (BP - glue - ROH spacer)
     unit g
   }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_16
@@ -7,7 +7,7 @@ Component {
   //FEH spacer 1.6 mm
   Element {
     elementName AlN
-    quantity 0.240
+    quantity 0.240   // FEH-L: V = 51.9889 mm^3 (2 x corner)
     unit g
   }
 
@@ -33,7 +33,7 @@ Component {
   //ROH spacer 1.6 mm
   Element {
     elementName AlN
-    quantity 0.300
+    quantity 0.300   // V = 96.0000 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
@@ -7,7 +7,7 @@ Component {
   //FEH spacer 2.6 mm
   Element {
     elementName AlN
-    quantity 1.72
+    quantity 1.72   // FEH-L: V = 96.7082 mm^3 (2 x corner) + 265.3160 mm^3 (1 x middle)
     unit g
   }
 
@@ -33,7 +33,7 @@ Component {
   //ROH spacer 2.6 mm
   Element {
     elementName AlN
-    quantity 0.450
+    quantity 0.450   // V = 167.5621 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
@@ -7,22 +7,22 @@ Component {
   //FEH spacer 2.6 mm
   Element {
     elementName AlN
-    quantity 1.72   // FEH-L: V = 96.7082 mm^3 (2 x corner) + 265.3160 mm^3 (1 x middle)
-    unit g
+    quantity 724.0484 // FEH-L: V = 96.7082 mm^3 (2 x corner) + 265.3160 mm^3 (1 x middle) = 362.0242 mm^3
+    unit mm3
   }
 
   //FEH glue 2.6 mm
   Element {
     elementName Epoxy
-    quantity 0.215   // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 28.6980 mm^3 (2 x middle)
-    unit g
+    quantity 61.8020 // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 28.6980 mm^3 (2 x middle) = 30.9010 mm^3
+    unit mm3
   }
 
   //FEH glue 2.6 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
-    unit g
+    quantity 4.406 // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
+    unit mm3
   }
 }
 
@@ -33,21 +33,21 @@ Component {
   //ROH glue 2.6 mm
   Element {
     elementName Epoxy
-    quantity 0.059   // top and bottom: V = 3.8347 mm^3 (ROH spacer - glue - compensator)
-    unit g
+    quantity 3.8347 // top and bottom: V = 3.8347 mm^3 (ROH spacer - glue - compensator)
+    unit mm3
   }
 
   //ROH glue 2.6 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.059   // top and bottom: V = 3.8347 mm^3 (BP - glue - ROH spacer)
-    unit g
+    quantity 3.8347 // top and bottom: V = 3.8347 mm^3 (BP - glue - ROH spacer)
+    unit mm3
   }
 
   //ROH spacer 2.6 mm
   Element {
     elementName AlN
-    quantity 0.450   // V = 167.5621 mm^3
-    unit g
+    quantity 167.5621 // V = 167.5621 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
@@ -6,7 +6,7 @@ Component {
 
   //FEH spacer 2.6 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 1.72
     unit g
   }
@@ -32,7 +32,7 @@ Component {
 
   //ROH spacer 2.6 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 0.450
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_26
@@ -14,7 +14,14 @@ Component {
   //FEH glue 2.6 mm
   Element {
     elementName Epoxy
-    quantity 0.215
+    quantity 0.215   // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 28.6980 mm^3 (2 x middle)
+    unit g
+  }
+
+  //FEH glue 2.6 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
     unit g
   }
 }
@@ -26,7 +33,14 @@ Component {
   //ROH glue 2.6 mm
   Element {
     elementName Epoxy
-    quantity 0.059
+    quantity 0.059   // top and bottom: V = 3.8347 mm^3 (ROH spacer - glue - compensator)
+    unit g
+  }
+
+  //ROH glue 2.6 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.059   // top and bottom: V = 3.8347 mm^3 (BP - glue - ROH spacer)
     unit g
   }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
@@ -7,7 +7,7 @@ Component {
   //FEH spacer 4.0 mm
   Element {
     elementName AlN
-    quantity 2.9
+    quantity 2.9   // FEH-L: V = 158.3900 mm^3 (2 x corner) + 625.6911 mm^3 (1 x middle)
     unit g
   }
 
@@ -33,7 +33,7 @@ Component {
   //ROH spacer 4.0 mm
   Element {
     elementName AlN
-    quantity 0.610
+    quantity 0.610   // V = 225.6022 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
@@ -14,7 +14,14 @@ Component {
   //FEH glue 4.0 mm
   Element {
     elementName Epoxy
-    quantity 0.212
+    quantity 0.212   // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 26.8288 mm^3 (2 x middle)
+    unit g
+  }
+
+  //FEH glue 2.6 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
     unit g
   }
 }
@@ -26,7 +33,14 @@ Component {
   //ROH glue 4.0 mm
   Element {
     elementName Epoxy
-    quantity 0.057
+    quantity 0.057   // top and bottom: V = 3.2371 mm^3 (ROH spacer - glue - compensator)
+    unit g
+  }
+
+  //ROH glue 4.0 mm
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.057   // top and bottom: V = 3.2371 mm^3 (BP - glue - ROH spacer)
     unit g
   }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
@@ -6,7 +6,7 @@ Component {
 
   //FEH spacer 4.0 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 2.9
     unit g
   }
@@ -32,7 +32,7 @@ Component {
 
   //ROH spacer 4.0 mm
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 0.610
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_40
@@ -7,22 +7,22 @@ Component {
   //FEH spacer 4.0 mm
   Element {
     elementName AlN
-    quantity 2.9   // FEH-L: V = 158.3900 mm^3 (2 x corner) + 625.6911 mm^3 (1 x middle)
-    unit g
+    quantity 1568.1622 // FEH-L: V = 158.3900 mm^3 (2 x corner) + 625.6911 mm^3 (1 x middle) = 784.0811 mm^3
+    unit mm3
   }
 
   //FEH glue 4.0 mm
   Element {
     elementName Epoxy
-    quantity 0.212   // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 26.8288 mm^3 (2 x middle)
-    unit g
+    quantity 58.0636 // FEH-L: V = 2.2030 mm^3 (2 x corner top) + 26.8288 mm^3 (2 x middle) = 29.0318 mm^3
+    unit mm3
   }
 
   //FEH glue 2.6 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.260   // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
-    unit g
+    quantity 4.406 // FEH-L: V = 2.2030 mm^3 (2 x corner bottom; BP - glue - corner spacer)
+    unit mm3
   }
 }
 
@@ -33,21 +33,21 @@ Component {
   //ROH glue 4.0 mm
   Element {
     elementName Epoxy
-    quantity 0.057   // top and bottom: V = 3.2371 mm^3 (ROH spacer - glue - compensator)
-    unit g
+    quantity 3.2371 // top and bottom: V = 3.2371 mm^3 (ROH spacer - glue - compensator)
+    unit mm3
   }
 
   //ROH glue 4.0 mm
   Element {
     elementName Epoxy_TC437
-    quantity 0.057   // top and bottom: V = 3.2371 mm^3 (BP - glue - ROH spacer)
-    unit g
+    quantity 3.2371 // top and bottom: V = 3.2371 mm^3 (BP - glue - ROH spacer)
+    unit mm3
   }
 
   //ROH spacer 4.0 mm
   Element {
     elementName AlN
-    quantity 0.610   // V = 225.6022 mm^3
-    unit g
+    quantity 225.6022 // V = 225.6022 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
@@ -9,7 +9,7 @@ Component {
   //1.6mm spacer
   Element {
     elementName AlN
-    quantity 1.120
+    quantity 1.120   // for 4 spacers: V = 314.0667 mm^3
     unit g
   }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
@@ -9,21 +9,21 @@ Component {
   //1.6mm spacer
   Element {
     elementName AlN
-    quantity 1.120   // for 4 spacers: V = 314.0667 mm^3
-    unit g
+    quantity 314.0667 // for 4 spacers: V = 314.0667 mm^3
+    unit mm3
   }
 
   //Spacer glue 1.6 mm top (between PSs and spacers)
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
-    unit g
+    quantity 19.6292 // for 4 spacers: V = 19.6292 mm^3
+    unit mm3
   }
 
   //Spacer glue 1.6 mm bottom (between MPAs and spacers)
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
-    unit g
+    quantity 19.6292 // for 4 spacers: V = 19.6292 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
@@ -13,10 +13,17 @@ Component {
     unit g
   }
 
-  //Bridges glue 1.6 mm
+  //Spacer glue 1.6 mm top (between PSs and spacers)
   Element {
-    elementName Epoxy
-    quantity 0.163
+    elementName Epoxy_601LV
+    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
+    unit g
+  }
+
+  //Spacer glue 1.6 mm bottom (between MPAs and spacers)
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
@@ -13,13 +13,6 @@ Component {
     unit g
   }
 
-  //Parylene 1.6mm
-  Element {
-    elementName Epoxy
-    quantity 0.09
-    unit g
-  }
-
   //Bridges glue 1.6 mm
   Element {
     elementName Epoxy

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
@@ -8,7 +8,7 @@ Component {
 
   //1.6mm spacer
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 1.120
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_16
@@ -6,7 +6,7 @@ Component {
   scaleOnSensor 0
   targetVolume 7
 
-  //1.6mm bridge
+  //1.6mm spacer
   Element {
     elementName Al-CF
     quantity 1.120

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
@@ -6,7 +6,7 @@ Component {
   scaleOnSensor 0
   targetVolume 7
 
-  //2.6mm bridge
+  //2.6mm spacer
   Element {
     elementName Al-CF
     quantity 1.86

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
@@ -9,7 +9,7 @@ Component {
   //2.6mm spacer
   Element {
     elementName AlN
-    quantity 1.86
+    quantity 1.86   // 4 spacers: V = 706.6036 mm^3
     unit g
   }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
@@ -13,10 +13,17 @@ Component {
     unit g
   }
 
-  //Bridges glue 2.6 mm
+  //Spacer glue 2.6 mm top (between PSs and spacers)
   Element {
-    elementName Epoxy
-    quantity 0.163
+    elementName Epoxy_601LV
+    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
+    unit g
+  }
+
+  //Spacer glue 2.6 mm bottom (between MPAs and spacers)
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
@@ -8,7 +8,7 @@ Component {
 
   //2.6mm spacer
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 1.86
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
@@ -9,21 +9,21 @@ Component {
   //2.6mm spacer
   Element {
     elementName AlN
-    quantity 1.86   // 4 spacers: V = 706.6036 mm^3
-    unit g
+    quantity 706.6036 // 4 spacers: V = 706.6036 mm^3
+    unit mm3
   }
 
   //Spacer glue 2.6 mm top (between PSs and spacers)
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
-    unit g
+    quantity 19.6292 // for 4 spacers: V = 19.6292 mm^3
+    unit mm3
   }
 
   //Spacer glue 2.6 mm bottom (between MPAs and spacers)
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
-    unit g
+    quantity 19.6292 // for 4 spacers: V = 19.6292 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_26
@@ -13,13 +13,6 @@ Component {
     unit g
   }
 
-  //Parylene 2.6mm
-  Element {
-    elementName Epoxy
-    quantity 0.09
-    unit g
-  }
-
   //Bridges glue 2.6 mm
   Element {
     elementName Epoxy

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
@@ -8,7 +8,7 @@ Component {
 
   //4.0mm spacer
   Element {
-    elementName Al-CF
+    elementName AlN
     quantity 2.64
     unit g
   }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
@@ -13,10 +13,17 @@ Component {
     unit g
   }
 
-  //Bridges glue 4.0 mm
+  //Spacer glue 4.0 mm top (between PSs and spacers)
   Element {
-    elementName Epoxy
-    quantity 0.163
+    elementName Epoxy_601LV
+    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
+    unit g
+  }
+
+  //Spacer glue 4.0 mm bottom (between MPAs and spacers)
+  Element {
+    elementName Epoxy_TC437
+    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
@@ -13,13 +13,6 @@ Component {
     unit g
   }
 
-  //Parylene 4.0mm
-  Element {
-    elementName Epoxy
-    quantity 0.09
-    unit g
-  }
-
   //Bridges glue 4.0 mm
   Element {
     elementName Epoxy

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
@@ -9,7 +9,7 @@ Component {
   //4.0mm spacer
   Element {
     elementName AlN
-    quantity 2.64
+    quantity 2.64   // 4 spacers: V = 1256.1842 mm^3
     unit g
   }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
@@ -6,7 +6,7 @@ Component {
   scaleOnSensor 0
   targetVolume 7
 
-  //4.0mm bridge
+  //4.0mm spacer
   Element {
     elementName Al-CF
     quantity 2.64

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Sensor_Spacers_40
@@ -9,21 +9,21 @@ Component {
   //4.0mm spacer
   Element {
     elementName AlN
-    quantity 2.64   // 4 spacers: V = 1256.1842 mm^3
-    unit g
+    quantity 1256.1842 // 4 spacers: V = 4 x 314.0461 mm^3 = 1256.1842 mm^3; m = 4.0952 g
+    unit mm3
   }
 
   //Spacer glue 4.0 mm top (between PSs and spacers)
   Element {
     elementName Epoxy_601LV
-    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
-    unit g
+    quantity 19.6292 // for 4 spacers: V = 19.6292 mm^3
+    unit mm3
   }
 
   //Spacer glue 4.0 mm bottom (between MPAs and spacers)
   Element {
     elementName Epoxy_TC437
-    quantity 0.163   // for 4 spacers: V = 19.6292 mm^3
-    unit g
+    quantity 19.6292 // for 4 spacers: V = 19.6292 mm^3
+    unit mm3
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
@@ -29,9 +29,14 @@ Component {
     quantity 1.195   // V = 913.5000 mm^3
     unit g
   }
- Element {
-    elementName Epoxy
-    quantity 0.141
+  Element {
+    elementName Kapton
+    quantity 0.141   // V = 116.2625 mm^3
+    unit g
+  }
+  Element {
+    elementName Epoxy_601LV
+    quantity 0.141   // V = 112.6575 mm^3 + 114.6371 mm^3 = 227.2946 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
@@ -8,18 +8,18 @@ Component {
   targetVolume 0
   Element {
     elementName CFRP // Volume of complete base plate is 1290.9417 mm^3
-    quantity 1.295   // V = 190.0615 mm^3 + 187.3802 mm^3 = 377.4417 mm^3
-    unit g
+    quantity 377.4417 // V = 190.0615 mm^3 + 187.3802 mm^3 = 377.4417 mm^3
+    unit mm3
   }
   Element {
     elementName Epoxy_601LV
-    quantity 0.0  // V = 2 x 0.8663 mm^3 + 0.6283 mm^3 = 2.3609 mm^3
-    unit g
+    quantity 2.3609 // V = 2 x 0.8663 mm^3 + 0.6283 mm^3 = 2.3609 mm^3
+    unit mm3
   }
   Element {
     elementName EN_AW-7075 // AlZn5,5MgCu - 3.4365
-    quantity 0.0  // V = 2 x 3.6168 mm^3 + 3.7412 mm^3 = 10.9748 mm^3
-    unit g
+    quantity 10.9748 // V = 2 x 3.6168 mm^3 + 3.7412 mm^3 = 10.9748 mm^3
+    unit mm3
   }
 }
 
@@ -31,18 +31,18 @@ Component {
   targetVolume 8
   Element {
     elementName CFRP // Volume of complete base plate is 1290.9417 mm^3
-    quantity 1.195   // V = 913.5000 mm^3
-    unit g
+    quantity 913.5000 // V = 913.5000 mm^3
+    unit mm3
   }
   Element {
     elementName Kapton
-    quantity 0.141   // V = 116.2625 mm^3
-    unit g
+    quantity 116.2625 // V = 116.2625 mm^3
+    unit mm3
   }
   Element {
     elementName Epoxy_601LV
-    quantity 0.141   // V = 112.6575 mm^3 + 114.6371 mm^3 = 227.2946 mm^3
-    unit g
+    quantity 227.2946 // V = 112.6575 mm^3 + 114.6371 mm^3 = 227.2946 mm^3
+    unit mm3
   }
 }
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
@@ -7,8 +7,8 @@ Component {
   scaleOnSensor 0
   targetVolume 0
   Element {
-    elementName CFRP
-    quantity 1.295
+    elementName CFRP // Volume of complete base plate is 1290.9417 mm^3
+    quantity 1.295   // V = 190.0615 mm^3 + 187.3802 mm^3 = 377.4417 mm^3
     unit g
   }
  Element {
@@ -25,8 +25,8 @@ Component {
   scaleOnSensor 0
   targetVolume 8
   Element {
-    elementName CFRP
-    quantity 1.195
+    elementName CFRP // Volume of complete base plate is 1290.9417 mm^3
+    quantity 1.195   // V = 913.5000 mm^3
     unit g
   }
  Element {

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Support_Plate
@@ -11,9 +11,14 @@ Component {
     quantity 1.295   // V = 190.0615 mm^3 + 187.3802 mm^3 = 377.4417 mm^3
     unit g
   }
- Element {
-    elementName Epoxy
-    quantity 0.153
+  Element {
+    elementName Epoxy_601LV
+    quantity 0.0  // V = 2 x 0.8663 mm^3 + 0.6283 mm^3 = 2.3609 mm^3
+    unit g
+  }
+  Element {
+    elementName EN_AW-7075 // AlZn5,5MgCu - 3.4365
+    quantity 0.0  // V = 2 x 3.6168 mm^3 + 3.7412 mm^3 = 10.9748 mm^3
     unit g
   }
 }

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_5CP_components
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_5CP_components
@@ -1,0 +1,11 @@
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_referenceSensors
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2xSensor_Active_2S_290um
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Inactive_Silicon_320um
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_5CP
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/Module_Fibers
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/Module_Power
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Module_Supports
+
+

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_6CP_components
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_6CP_components
@@ -3,7 +3,7 @@
 @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Inactive_Silicon_320um
 @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Circuits
 @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Hybrid_Spacers_18
-@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18
+@include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Sensor_Spacers_18_6CP
 @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/Module_Fibers
 @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/Module_Power
 @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Module_Supports

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_320_18
@@ -1,8 +1,0 @@
-// pt-2S module 10x10 for the outer region
-// GBT on the module
-
-Materials module-pt2S_320_18 {
-  type module
-  @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_components
-} 
-   

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_320_18_5CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_320_18_5CP
@@ -1,0 +1,9 @@
+// pt-2S module 10x10 for the outer region
+// 5 cooling points; one stump bridges
+// GBT on the module
+
+Materials module-pt2S_320_18_5CP {
+  type module
+  @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_5CP_components
+} 
+   

--- a/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_320_18_6CP
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/Materials/pt2S_320_18_6CP
@@ -1,0 +1,9 @@
+// pt-2S module 10x10 for the outer region
+// 6 cooling points; two stump bridges
+// GBT on the module
+
+Materials module-pt2S_320_18_6CP {
+  type module
+  @include-std CMS_Phase2/OuterTracker/Materials/ModuleMaterials/pt2S_320_18_6CP_components
+} 
+   

--- a/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
@@ -10,7 +10,7 @@ zCorrelation samesegment
 
 numSensors 2
 
-powerPerModule 4700  // mW
+powerPerModule 5159  // mW
 
 sensorThickness 0.29     // 290 um active + 30 um inactive
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
@@ -10,7 +10,7 @@ zCorrelation samesegment
 
 numSensors 2
 
-powerPerModule 6300 
+powerPerModule 9709  // mW 
 
 sensorThickness 0.29     // 290 um active + 30 um inactive
 

--- a/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
+++ b/config/stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
@@ -39,7 +39,7 @@ Sensor 2 {
 serviceHybridWidth 12.0  // 10.63 hybrid + 1.37 inactive silicon // OK
 frontEndHybridWidth 11.5 // 10.05 hybrid + 1.45 inactive silicon // OK
 hybridThickness 1.0
-supportPlateThickness 1.0
+supportPlateThickness 0.2  // mm 
 outerSensorExtraLength 0.164
 
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V800.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V800.cfg
@@ -51,7 +51,7 @@ Endcap TEDD_1 {
   alignEdges true
   moduleShape rectangular
   Ring 1-10 {
-    smallDelta 7.55   // MUSSGILLER 2020-01-08
+    smallDelta 7.65   // 5.000 mm (CFRP facing from mid-plane of Dee) + 0.200 mm (TIM) + 2.450 mm (within module) = 7.650 mm
     dsDistance 4.0
     @include-std CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
     @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V800.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V800.cfg
@@ -57,7 +57,7 @@ Endcap TEDD_1 {
     @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40
   }
   Ring 11-15 {
-    smallDelta 7.495  // MUSSGILLER 2020-01-08     
+    smallDelta 7.450  // 6.725 mm (insert from mid-plane of Dee) + 0.725 mm (within module) = 7.450 mm    
     dsDistance 1.8
     @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
     @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V800.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD1_V800.cfg
@@ -60,7 +60,7 @@ Endcap TEDD_1 {
     smallDelta 7.450  // 6.725 mm (insert from mid-plane of Dee) + 0.725 mm (within module) = 7.450 mm    
     dsDistance 1.8
     @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
-    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+    @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18_6CP
   }
  
   @include-std CMS_Phase2/OuterTracker/Materials/disk

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V800.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V800.cfg
@@ -57,7 +57,7 @@ Endcap TEDD_2 {
     @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40
   }
   Ring 11 {
-    smallDelta 8.595  // MUSSGILLER 2020-01-08
+    smallDelta 8.550  // 6.725 mm (insert from mid-plane of Dee) + 1.825 mm (within module) = 8.550 mm
     dsDistance 4.0
     @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
     @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_40
@@ -65,7 +65,7 @@ Endcap TEDD_2 {
   
   Disk 1-2 {
     Ring 12-15 {
-      smallDelta 7.495  // MUSSGILLER 2020-01-08
+      smallDelta 7.450  // 6.725 mm (insert from mid-plane of Dee) + 0.725 mm (within module) = 7.450 mm
       dsDistance 1.8
       @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
       @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
@@ -73,13 +73,13 @@ Endcap TEDD_2 {
   }
   Disk 3 {
     Ring 12 {
-      smallDelta 8.595  // MUSSGILLER 2020-01-08
+      smallDelta 8.550  // 6.725 mm (insert from mid-plane of Dee) + 1.825 mm (within module) = 8.550 mm
       dsDistance 4.0
       @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
       @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_40
     }
     Ring 13-15 {
-      smallDelta 7.495  // MUSSGILLER 2020-01-08
+      smallDelta 7.450  // 6.725 mm (insert from mid-plane of Dee) + 0.725 mm (within module) = 7.450 mm
       dsDistance 1.8
       @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
       @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V800.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V800.cfg
@@ -68,7 +68,7 @@ Endcap TEDD_2 {
       smallDelta 7.450  // 6.725 mm (insert from mid-plane of Dee) + 0.725 mm (within module) = 7.450 mm
       dsDistance 1.8
       @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
-      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18_6CP
     }
   }
   Disk 3 {
@@ -82,7 +82,7 @@ Endcap TEDD_2 {
       smallDelta 7.450  // 6.725 mm (insert from mid-plane of Dee) + 0.725 mm (within module) = 7.450 mm
       dsDistance 1.8
       @include-std CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
-      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18
+      @include-std CMS_Phase2/OuterTracker/Materials/pt2S_320_18_6CP
     }
   }
 

--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V800.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TEDD2_V800.cfg
@@ -51,7 +51,7 @@ Endcap TEDD_2 {
   alignEdges true
   moduleShape rectangular
   Ring 1-10 {
-    smallDelta 7.55   // MUSSGILLER 2020-01-08
+    smallDelta 7.55   // 4.900 mm (CFRP facing from mid-plane of Dee) + 0.200 mm (TIM) + 2.450 mm (within module) = 7.550 mm
     dsDistance 4.0
     @include-std CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
     @include-std CMS_Phase2/OuterTracker/Materials/ptPS_320_40


### PR DESCRIPTION
# 'Measurements' on a CAD model result in the volume of a part. Direct access to mass is only possible if the model knows the material used for a give part and the corresponding material data available in the CAD system is actually correct. When import STEP files material assignment and data are not available, therefore I only measured and provided the volume.

#  stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/ptPSlarger_320
- line 41: What is hybrid thickness?
- line 43: What is outerSensorExtraLength?

# stdinclude/CMS_Phase2/OuterTracker/ModuleTypes/pt2S_320
- line 37: What is hybrid thickness?

# stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/MPA_and_bumps
- Please check if there really is underfill used and how much

# stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/PS_Hybrid_Spacers_XY
- In the 2.6 and 4.0 mm modules there is a AlN middle-spacer around which the flex is folded. In all versions there are two corner spacers in each hybrid. Does there have to be a splitting in the config files for this? Target volume for both middle and corner spacer is 56. Middled spacer is in the central part of target 56, corner spacer at the ends of target 56.

# stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/Components/2S_Module_Supports
- It seems that the parts in this file are the inserts + screws + washers to mount the modules. If so there must be a distinction between TB2S and TEDD. Inserts look substantially different in both sub-detectors.
- A similar file doesn't exist for the PS modules. Also here we need inserts and screws for positioning and mounting. The inserts are different in TEDD, tilted and flat TBPS.

# stdinclude/CMS_Phase2/OuterTracker/Materials/ModuleMaterials/ptPS_320_XY_components
- There will by a layer of thermal interface material (TIM) between the support structure and the PS module base plate. It should be foreseen that the three different sub-detectors use different type of TIM and also different thicknesses.

# stdinclude/CMS_Phase2/OuterTracker/Materials/disk
# stdinclude/CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDDTop_V616.cfg
# stdinclude/CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD1_V351.cfg
# stdinclude/CMS_Phase2/OuterTracker/Materials/MechanicalSupports/SupportsEndcapTEDD2_V366.cfg
- These files definitely need an update but they are a mystery to me...