### PR TITLE
Material volume units

### DIFF
--- a/include/MaterialObject.hh
+++ b/include/MaterialObject.hh
@@ -140,7 +140,7 @@ namespace material {
 
     class Element : public PropertyObject {
     public:
-      enum Unit{GRAMS, MILLIMETERS, GRAMS_METER};
+      enum Unit{GRAMS, MILLIMETERS, GRAMS_METER, CUBIC_MILLIMETERS};
       //static const std::map<Unit, const std::string> unitString;
       static const std::map<std::string, Unit> unitStringMap;
       

--- a/include/SupportStructure.hh
+++ b/include/SupportStructure.hh
@@ -99,7 +99,7 @@ namespace material {
     
     class Element : public PropertyObject {
     public:
-      enum Unit{GRAMS, MILLIMETERS, GRAMS_METER};
+      enum Unit{GRAMS, MILLIMETERS, GRAMS_METER, CUBIC_MILLIMETERS};
       static const std::map<std::string, Unit> unitStringMap;
       Property<std::string, Default> subdetectorName;
       Property<std::string, NoDefault> componentName; //only the inner component's name

--- a/src/MaterialObject.cc
+++ b/src/MaterialObject.cc
@@ -351,7 +351,8 @@ namespace material {
   const std::map<std::string, MaterialObject::Element::Unit> MaterialObject::Element::unitStringMap = {
       {"g", GRAMS},
       {"mm", MILLIMETERS},
-      {"g/m", GRAMS_METER}
+      {"g/m", GRAMS_METER},
+      {"mm3", CUBIC_MILLIMETERS}
   };
 
   void MaterialObject::Element::deployMaterialTo(MaterialObject& outputObject, const std::vector<std::string>& unitsToDeploy, bool onlyServices /*= false*/, double gramsMultiplier /*= 1.*/, Location requestedLocation /*= Location::ALL*/) const {
@@ -438,20 +439,6 @@ namespace material {
     // rho:     density
     // S:       surface
 
-    /*
-    std::map<std::pair<Unit, Unit>, double> conversionMatrix = {
-      {{GRAMS, GRAMS}, 1}, {{GRAMS, GRAMS_METER}, length/1000}, {{GRAMS, MILLIMETERS}, density*surface},
-      {{GRAMS_METER, GRAMS}, 1000/length}, {{GRAMS_METER, GRAMS_METER}, 1}, {{GRAMS_METER, MILLIMETERS}, (density*surface*1000)/length},
-      {{MILLIMETERS, GRAMS}, 1/(density*surface)}, {{MILLIMETERS, GRAMS_METER}, length/(density*surface*1000)}, {{MILLIMETERS, MILLIMETERS}, 1}
-    };
-
-    try {
-      returnVal = quantity() * conversionMatrix.at({unitStringMap.at(desiredUnit), unitStringMap.at(unit())});
-    } catch (const std::out_of_range& ex) {
-      logERROR(msg_no_valid_unit + unit() + ", " + desiredUnit + ".");
-    }
-    */
-
     try {
       desiredUnitVal = unitStringMap.at(desiredUnit);
       elementUnitVal = unitStringMap.at(unit());
@@ -472,6 +459,8 @@ namespace material {
         returnVal = quantity() * length / 1000.;
       else if ((desiredUnitVal == GRAMS) && (elementUnitVal == MILLIMETERS))
         returnVal = quantity() * density * surface;
+      else if ((desiredUnitVal == GRAMS) && (elementUnitVal == CUBIC_MILLIMETERS))
+        returnVal = quantity() * density;
       else if ((desiredUnitVal == GRAMS_METER) && (elementUnitVal == MILLIMETERS))
         returnVal = quantity() * (density * surface * 1000.) / length;
 

--- a/src/SupportStructure.cc
+++ b/src/SupportStructure.cc
@@ -338,11 +338,14 @@ namespace material {
   const std::map<std::string, SupportStructure::Element::Unit> SupportStructure::Element::unitStringMap = {
       {"g", GRAMS},
       {"mm", MILLIMETERS},
-      {"g/m", GRAMS_METER}
+      {"g/m", GRAMS_METER},
+      {"mm3", CUBIC_MILLIMETERS}
   };
 
   double SupportStructure::Element::quantityInGrams(double length, double surface) const {
     double returnVal;
+    std::string elementNameString = elementName();
+    double elementDensity = materialsTable_.getDensity(elementNameString);
     try {
       switch (unitStringMap.at(unit())) {
       case Element::GRAMS:
@@ -354,10 +357,13 @@ namespace material {
         break;
 
       case Element::MILLIMETERS:
-        std::string elementNameString = elementName();
-        double elementDensity = materialsTable_.getDensity(elementNameString);
         returnVal = elementDensity * surface * quantity();
         break;
+
+      case Element::CUBIC_MILLIMETERS:
+        returnVal = elementDensity * quantity();
+        break;
+
       }
     } catch (const std::out_of_range& ex) {
       logERROR(msg_no_valid_unit + unit());


### PR DESCRIPTION
Not to be merged yet (test first!)
This should enable adding materials with the `mm3` unit, so that they are converted to grams via the material density