### PR TITLE
Adding IT704 - bug fix of IT702

### DIFF
--- a/geometries/CMS_Phase2/OT800_IT704.cfg
+++ b/geometries/CMS_Phase2/OT800_IT704.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V800.cfg
+@include Pixel/Pixel_V7/Pixel_V7_0_4.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/BPIX_7_0_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/BPIX_7_0_4.cfg
@@ -1,0 +1,69 @@
+Barrel PXB {
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
+    
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity 1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      zOverlap -0.6 // 0.6 mm space between active areas: 0.15 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_3D
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_3D
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      numRods 12
+    }
+    Layer 2 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+    }
+    Layer 3 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+    }
+    Layer 4 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.5 mm dead area on each sensor side + 0.3 mm gap
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_wide
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/Pixel_V7_0_4.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/Pixel_V7_0_4.cfg
@@ -1,0 +1,27 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_7_0_4.cfg
+  @include ../Pixel_V6/FPIX1_6_1_5.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}


### PR DESCRIPTION
Wrong zOverlap was set for TBPX L2 - led to clash of dead areas (not active areas). This fixes that. 

NB *this replaces CMSSW model T25, the website still needs to be updated to reflect that*