### PR TITLE
Dead-area material in split-sensor PXB modules

### DIFF
--- a/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_2sens_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_2sens_3D
@@ -1,0 +1,13 @@
+
+Materials BPIX_L1_1x2_2500 {
+  type module
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Reference_Sensor_symbolic
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Module_Common
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Active_Planar_3D
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2_2sens_3D
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Bumps_2500
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_ROC
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Cooling_Blocks_TBPX_1x2
+  @include-std CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Elinks_TBPX_L1
+}

--- a/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2_2sens_3D
+++ b/config/stdinclude/CMS_Phase2/Pixel/ModuleMaterials/Components/pixel_Sensor_Dead_Area_1x2_2sens_3D
@@ -1,0 +1,11 @@
+Component {
+  componentName "IT Module: Sensor (dead area)" 
+  service false
+  scaleOnSensor 0
+  Element {
+    elementName Si
+    quantity  0.00947856     // Mass calculated for a 0.175 mm extra dead area around 2 x 16.8 mm x 21.6 mm sensors.
+    unit g
+    targetVolume 4
+  }
+}

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/BPIX_7_1_1.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/BPIX_7_1_1.cfg
@@ -26,7 +26,7 @@ Barrel PXB {
       bigDelta 2.5
       zOverlap -0.75 // 0.75 mm space between active areas: 0.175 mm dead area on each sensor side + 0.4 mm gap
       @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_2sens_3D
-      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_3D
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_2sens_3D
       @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
       @include-std CMS_Phase2/Pixel/Resolutions/25x100
       destination BPIX1

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -5063,12 +5063,8 @@ namespace insur {
 	      + vol[xml_PixelModuleDeadAreaFront]->getVolume()
 	      + vol[xml_PixelModuleDeadAreaBack]->getVolume();
             if (module.numSensors()==2){
-            deadAreaTotalVolume_mm3 = vol[xml_PixelModuleDeadAreaRight]->getVolume()
-	      + vol[xml_PixelModuleDeadAreaBackOfCentre]->getVolume()
-	      + vol[xml_PixelModuleDeadAreaFrontOfCentre]->getVolume()
-	      + vol[xml_PixelModuleDeadAreaLeft]->getVolume()
-	      + vol[xml_PixelModuleDeadAreaFront]->getVolume()
-	      + vol[xml_PixelModuleDeadAreaBack]->getVolume();
+              deadAreaTotalVolume_mm3 += vol[xml_PixelModuleDeadAreaFrontOfCentre]->getVolume() 
+	        + vol[xml_PixelModuleDeadAreaBackOfCentre]->getVolume();
             }
           }
 
@@ -5113,8 +5109,8 @@ namespace insur {
       volumes.push_back(vol[xml_PixelModuleChip]);
       volumes.push_back(vol[xml_PixelModuleDeadAreaRight]);
      if(module.numSensors()==2){
-        volumes.push_back(vol[xml_PixelModuleDeadAreaBackOfCentre]);
         volumes.push_back(vol[xml_PixelModuleDeadAreaFrontOfCentre]);
+        volumes.push_back(vol[xml_PixelModuleDeadAreaBackOfCentre]);
      }
       volumes.push_back(vol[xml_PixelModuleDeadAreaLeft]);
       volumes.push_back(vol[xml_PixelModuleDeadAreaFront]);

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -782,7 +782,7 @@ namespace insur {
         stream << xml_box_open << name << xml_box_first_inter << dx << xml_box_second_inter << dy;
         stream << xml_box_third_inter << dz << xml_box_close;
 	if (dx < 0. || dy < 0. || dz < 0.) {
-	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined box."
+	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined box."
 		    << " dx = " << dx << " dy = " << dy << " dz = " << dz << std::endl;
 	}
     }
@@ -806,7 +806,7 @@ namespace insur {
         //stream << xml_trapezoid_fourth_inter << dx << xml_trapezoid_fifth_inter << dz;
         stream << xml_trapezoid_close;
 	if (dx < 0. || dxx < 0. || dy < 0. || dyy < 0. || dz < 0.) {
-	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined trapezoid."
+	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined trapezoid."
 		    << " dx = " << dx << "dxx = " << dxx << " dy = " << dy << " dyy = " << dyy << " dz = " << dz << std::endl;
 	}
     }
@@ -824,7 +824,7 @@ namespace insur {
         stream << xml_tubs_open << name << xml_tubs_first_inter << rmin << xml_tubs_second_inter << rmax;
         stream << xml_tubs_third_inter << dz << xml_tubs_close;
 	if (rmin > rmax || dz < 0.) {
-	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined tub."
+	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined tub."
 		    << " rmin = " << rmin << "rmax = " << rmax << " dz = " << dz << std::endl;
 	}
     }
@@ -845,7 +845,7 @@ namespace insur {
         stream << xml_cone_third_inter << rmin1 << xml_cone_fourth_inter << rmin2;
         stream << xml_cone_fifth_inter << dz << xml_cone_close;
 	if (rmin1 > rmax1 || rmin2 > rmax2 || dz < 0.) {
-	  std::cerr << "VERY IMPORTANT : " << name << "is not a properly defined tub."
+	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined tub."
 		    << " rmin1 = " << rmin1 << "rmax1 = " << rmax1 << " rmin2 = " << rmin2 << "rmax2 = " << rmax2 << " dz = " << dz << std::endl;
 	}
     }

--- a/src/XMLWriter.cc
+++ b/src/XMLWriter.cc
@@ -824,7 +824,7 @@ namespace insur {
         stream << xml_tubs_open << name << xml_tubs_first_inter << rmin << xml_tubs_second_inter << rmax;
         stream << xml_tubs_third_inter << dz << xml_tubs_close;
 	if (rmin > rmax || dz < 0.) {
-	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined tub."
+	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined tube."
 		    << " rmin = " << rmin << "rmax = " << rmax << " dz = " << dz << std::endl;
 	}
     }
@@ -845,7 +845,7 @@ namespace insur {
         stream << xml_cone_third_inter << rmin1 << xml_cone_fourth_inter << rmin2;
         stream << xml_cone_fifth_inter << dz << xml_cone_close;
 	if (rmin1 > rmax1 || rmin2 > rmax2 || dz < 0.) {
-	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined tub."
+	  std::cerr << "VERY IMPORTANT : " << name << " is not a properly defined cone."
 		    << " rmin1 = " << rmin1 << "rmax1 = " << rmax1 << " rmin2 = " << rmin2 << "rmax2 = " << rmax2 << " dz = " << dz << std::endl;
 	}
     }


### PR DESCRIPTION
Fixed the inconsistent amount of material in the dead-area Si strips in the split-sensor PXB modules, used in `IT711` geometry.
Previously used weight of Si, inherited from `IT704`, was calculated for 33% smaller area (150um around one big sensor plane) compared to the split-sensor geometry: 175um around two smaller sensor planes.

This affects both the material budget/weights reported by tkLayout and the material density in the exported XMLs for CMSSW.