### PR TITLE
Fixing a warning of dangling reference in recent compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc/algorithms/scattering.log
 *.patch
 build.log
 build/
+xml/tmptrackerRecoMaterial.xml

--- a/include/Property.hh
+++ b/include/Property.hh
@@ -164,6 +164,8 @@ public:
 typedef std::map<string, Parsable*> PropertyMap;
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
 template<typename T, template<typename> class ValueHolder>
 class Property : public PropertyBase<T>, public Parsable {
   ValueHolder<T> valueHolder_;
@@ -184,6 +186,7 @@ public:
   void fromPtree(const ptree& pt) { valueHolder_(str2any<T>(pt.data())); }
   void fromString(const string& s) { valueHolder_(str2any<T>(s)); }
 };
+#pragma GCC diagnostic pop
 
 template<typename T, template<typename> class ValueHolder>
 class ReadonlyProperty : public Property<T, ValueHolder> {


### PR DESCRIPTION
Fixing a warning of dangling reference. The reference ic created by a Singleton: I trust it to persist, so I disable the warning locally
Ignoring a temp file created by the xml exporter