### PR TITLE
feature: compiles on mac osx with clang, modern gcc, root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 #----------------------------------------------------------------------------
 # CMAKE compatibility issues
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 #----------------------------------------------------------------------------
 # Project name and version
@@ -20,8 +20,8 @@ OPTION(INSTALL_DOC "Set to ON to build/install Documentation" OFF )
 
 
 # using cache lets users override with " cmake -DCMAKE_CXX_STANDARD=14 .. "
-SET(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-add_compile_options(-Wall -Werror -fmax-errors=2 -g)
+SET(CMAKE_CXX_STANDARD 20 CACHE STRING "")
+add_compile_options(-Wall -Werror -Wno-undefined-var-template -g)
 
 
 
@@ -70,8 +70,13 @@ FILE( GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh
 # Exlude files with main function defined
 SET ( sources "" )
 FOREACH( file ${all_sources} )
- IF ( ${file} MATCHES "MaterialSection.cc" OR ${file} MATCHES "HoughTrack.cc" OR
-      ${file} MATCHES "TrackShooter.cc" OR ${file} MATCHES "tunePtParam.cc" OR ${file} MATCHES "diskPlace.cc")
+ IF ( ${file} MATCHES "MaterialSection.cc" OR
+      ${file} MATCHES "HoughTrack.cc" OR
+      ${file} MATCHES "TrackShooter.cc" OR
+      ${file} MATCHES "tunePtParam.cc" OR
+      ${file} MATCHES "diskPlace.cc" OR
+      ${file} MATCHES "ringPlace.cc" OR
+      ${file} MATCHES "ringName.cc" )
    SET ( APPEND source_other ${file} )
    MESSAGE( STATUS "Omitting the following ?buggy? file: ${file} !!!" ) 
  ELSEIF( ${file} MATCHES "tklayout.cc" OR ${file} MATCHES "setup.cc" OR ${file} MATCHES "delphize.cc" )

--- a/include/AnalyzerVisitors/TriggerProcessorBandwidth.hh
+++ b/include/AnalyzerVisitors/TriggerProcessorBandwidth.hh
@@ -58,7 +58,6 @@ class TriggerProcessorBandwidthVisitor : public ConstGeometryVisitor {
   const Tracker* tracker_;
   const SimParms* simParms_;
 
-  int accumulatedLayerOffset_ = 0;
 public:
   SummaryTable processorConnectionSummary, processorInboundBandwidthSummary, processorInboundStubPerEventSummary;
   SummaryTable processorCommonConnectionSummary;

--- a/include/ConversionStation.hh
+++ b/include/ConversionStation.hh
@@ -49,7 +49,6 @@ namespace material {
     std::string subdetectorName_;
     static const std::map<std::string, Type> typeString;
     Type stationType_;
-    bool valid_;
     PropertyNodeUnique<std::string> conversionsNode_;
     PropertyNodeUnique<std::string> nonConvertedMaterialsNode_;
 

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -246,7 +246,7 @@ public:
 
   virtual void setup();
   void check() override;
-  virtual void build();
+  virtual void build() override;
   // Geometric module interface
   const Polygon3d<4>& basePoly() const { return decorated().basePoly(); }
 
@@ -514,19 +514,19 @@ class BarrelModule : public DetectorModule, public Clonable<BarrelModule> {
 public:
   Property<int16_t, AutoDefault> layer;
   int16_t ring() const { return (int16_t)myid(); }
-  int16_t moduleRing() const { return ring(); }
+  int16_t moduleRing() const override { return ring(); }
   Property<int16_t, AutoDefault> rod;
 
   BarrelModule(Decorated* decorated, const std::string subdetectorName) :
     DetectorModule(decorated, subdetectorName)
   { setup(); }
 
-  void accept(GeometryVisitor& v) {
+  void accept(GeometryVisitor& v) override {
     v.visit(*this);
     v.visit(*(DetectorModule*)this);
     decorated().accept(v);
   }
-  void accept(ConstGeometryVisitor& v) const {
+  void accept(ConstGeometryVisitor& v) const override {
     v.visit(*this);
     v.visit(*(const DetectorModule*)this);
     decorated().accept(v);
@@ -603,7 +603,7 @@ public:
       });
   }
 
-  void build();
+  void build() override;
 
 
   //double maxZ() const { return MAX(basePoly().getVertex(0).Z(), basePoly().getVertex(2).Z()); } 
@@ -611,11 +611,11 @@ public:
   //double maxR() const { return MAX(basePoly().getVertex(0).Rho(), basePoly().getVertex(2).Rho()); }
   //double minR() const { return center().Rho(); }//MIN(basePoly().getVertex(0).Rho(), basePoly().getVertex(2).Rho()); }
 
-  virtual ModuleSubdetector subdet() const { return BARREL; }
+  virtual ModuleSubdetector subdet() const override { return BARREL; }
 
-  PosRef posRef() const { return (PosRef){ subdetectorId(), (side() > 0 ? ring() : -ring()), layer(), rod() }; }
-  TableRef tableRef() const { return (TableRef){ subdetectorName(), layer(), ring() }; }
-  UniRef uniRef() const { return UniRef{ subdetectorName(), layer(), ring(), rod(), side() }; }
+  PosRef posRef() const override { return (PosRef){ subdetectorId(), (side() > 0 ? ring() : -ring()), layer(), rod() }; }
+  TableRef tableRef() const override { return (TableRef){ subdetectorName(), layer(), ring() }; }
+  UniRef uniRef() const override { return UniRef{ subdetectorName(), layer(), ring(), rod(), side() }; }
 };
 
 
@@ -624,7 +624,7 @@ class EndcapModule : public DetectorModule, public Clonable<EndcapModule> {
 public:
   Property<int16_t, AutoDefault> disk;
   Property<int16_t, AutoDefault> ring;
-  int16_t moduleRing() const { return ring(); };
+  int16_t moduleRing() const override { return ring(); };
   int16_t blade() const { return (int16_t)myid(); } // CUIDADO Think of a better name!
   int16_t side() const { return (int16_t)signum(center().Z()); }
   Property<int, AutoDefault> endcapDiskSurface;
@@ -703,15 +703,15 @@ public:
       });
   }
 
-  void build();
+  void build() override;
 
-  void accept(GeometryVisitor& v) {
-    v.visit(*this); 
+  void accept(GeometryVisitor& v) override {
+    v.visit(*this);
     v.visit(*(DetectorModule*)this);
     decorated().accept(v); 
   }
-  void accept(ConstGeometryVisitor& v) const {
-    v.visit(*this); 
+  void accept(ConstGeometryVisitor& v) const override {
+    v.visit(*this);
     v.visit(*(const DetectorModule*)this);
     decorated().accept(v); 
   }
@@ -729,11 +729,11 @@ public:
   //                      return ((side[0]+side[1])/2).Rho(); }
 
 
-  virtual ModuleSubdetector subdet() const { return ENDCAP; }
+  virtual ModuleSubdetector subdet() const override { return ENDCAP; }
 
-  PosRef posRef() const { return (PosRef){ subdetectorId(), (side() > 0 ? disk() : -disk()), ring(), blade() }; }
-  TableRef tableRef() const { return (TableRef){ subdetectorName(), disk(), ring() }; }
-  UniRef uniRef() const { return UniRef{ subdetectorName(), disk(), ring(), blade(), side() }; }
+  PosRef posRef() const override { return (PosRef){ subdetectorId(), (side() > 0 ? disk() : -disk()), ring(), blade() }; }
+  TableRef tableRef() const override { return (TableRef){ subdetectorName(), disk(), ring() }; }
+  UniRef uniRef() const override { return UniRef{ subdetectorName(), disk(), ring(), blade(), side() }; }
 
 private:
   bool isSmallerAbsZModuleInRing_;

--- a/include/Disk.hh
+++ b/include/Disk.hh
@@ -147,11 +147,11 @@ public:
   void computeActualCoverage();
   void computeActualZCoverage();
 
-  void accept(GeometryVisitor& v) {
-    v.visit(*this); 
+  void accept(GeometryVisitor& v) override {
+    v.visit(*this);
     for (auto& r : rings_) { r.accept(v); }
   }
-  void accept(ConstGeometryVisitor& v) const { 
+  void accept(ConstGeometryVisitor& v) const override {
     v.visit(*this); 
     for (const auto& r : rings_) { r.accept(v); }
   }

--- a/include/Extractor.hh
+++ b/include/Extractor.hh
@@ -313,7 +313,6 @@ namespace insur {
       };
 
 
-      ModuleCap&           modulecap;
       Module&              module;
       std::vector<Volume*> volumes;
       std::string          moduleId;
@@ -334,7 +333,6 @@ namespace insur {
       const double         centralDeadAreaLength;
       const double         chipNegativeXExtraWidth;
       const double         chipPositiveXExtraWidth;
-            double         hybridTotalMass;
             double         hybridTotalVolume_mm3;
             double         hybridFrontAndBackVolume_mm3;
             double         hybridLeftAndRightVolume_mm3;

--- a/include/GeometricModule.hh
+++ b/include/GeometricModule.hh
@@ -114,7 +114,7 @@ public:
       waferDiameter("waferDiameter", parsedAndChecked(), 131.)
   {}
 
-  virtual RectangularModule* clone() const { return Clonable<RectangularModule>::clone(); }
+  virtual RectangularModule* clone() const override { return Clonable<RectangularModule>::clone(); }
 
   virtual double area() const override { return length()*width(); }
   virtual double length() const override { return length_(); }
@@ -124,12 +124,12 @@ public:
 
   void length(double l) { length_(l); }
 
-  virtual void accept(GeometryVisitor& v) { v.visit(*this); v.visit(*(GeometricModule*)this); }
-  virtual void accept(ConstGeometryVisitor& v) const { v.visit(*this); v.visit(*(const GeometricModule*)this); }
+  virtual void accept(GeometryVisitor& v) override { v.visit(*this); v.visit(*(GeometricModule*)this); }
+  virtual void accept(ConstGeometryVisitor& v) const override { v.visit(*this); v.visit(*(const GeometricModule*)this); }
   virtual void check() override;
   virtual void build() override;
 
-  virtual ModuleShape shape() const { return RECTANGULAR; }
+  virtual ModuleShape shape() const override { return RECTANGULAR; }
 };
 
 
@@ -152,7 +152,7 @@ public:
       waferDiameter("waferDiameter", parsedAndChecked(), 131.)
   {}
 
-  virtual WedgeModule* clone() const { return Clonable<WedgeModule>::clone(); }
+  virtual WedgeModule* clone() const override { return Clonable<WedgeModule>::clone(); }
 
   virtual double area() const override { return area_; }
   virtual double length() const override { return length_; }
@@ -160,12 +160,12 @@ public:
   virtual double maxWidth() const override { return maxWidth_; }
   virtual double meanWidth() const override { return (maxWidth_ + minWidth_)/2; }
 
-  virtual void accept(GeometryVisitor& v) { v.visit(*this); v.visit(*(GeometricModule*)this); }
-  virtual void accept(ConstGeometryVisitor& v) const { v.visit(*this); v.visit(*(const GeometricModule*)this); }
+  virtual void accept(GeometryVisitor& v) override { v.visit(*this); v.visit(*(GeometricModule*)this); }
+  virtual void accept(ConstGeometryVisitor& v) const override { v.visit(*this); v.visit(*(const GeometricModule*)this); }
 
   virtual void build() override;
 
-  virtual ModuleShape shape() const { return WEDGE; }
+  virtual ModuleShape shape() const override { return WEDGE; }
 };
 
 

--- a/include/Histo.hh
+++ b/include/Histo.hh
@@ -268,13 +268,13 @@ public:
     Histo<M, T, B>* folded = new Histo<M, T>();
     for (int i=0; i < M; i++) {
       int index = indices[i];
-      folded.setBinning(i, nbins_[index], lo_[index], hi_[index]);
+      folded->setBinning(i, nbins_[index], lo_[index], hi_[index]);
     }
 
     for (typename std::map<InternalBinKey, T>::const_iterator it = bins_.begin(); it != bins_.end(); ++it) {
       typename Histo<M, T>::InternalBinKey key;
       for (int i=0; i < M; i++) key.set(i, it->first.at(indices[i]));
-      folded.bins_[key] += it->second;
+      folded->bins_[key] += it->second;
     }
 
     return folded;

--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -10,9 +10,9 @@
 #include "InnerCabling/inner_cabling_functions.hh"
 
 
-namespace insur { class InnerBundle; }
-using insur::InnerBundle;
+namespace insur {
 
+class InnerBundle;
 
 /*
  * Low-Power Giga Bit Transceiver class.
@@ -88,6 +88,6 @@ private:
   int plotPowerChainColor_;
 };
 
-
+}
 
 #endif

--- a/include/InnerCabling/HvLine.hh
+++ b/include/InnerCabling/HvLine.hh
@@ -7,6 +7,7 @@
 #include "InnerCabling/PowerChain.hh"
 #include "Module.hh"
 
+namespace insur {
 
 /*
  * High Voltage line class.
@@ -43,6 +44,6 @@ private:
   PowerChain* powerChain_ = nullptr;
 };
 
-
+}
 
 #endif

--- a/include/InnerCabling/InnerBundle.hh
+++ b/include/InnerCabling/InnerBundle.hh
@@ -10,9 +10,9 @@
 #include "InnerCabling/inner_cabling_functions.hh"
 
 
-namespace insur { class InnerDTC; }
-using insur::InnerDTC;
+namespace insur {
 
+class InnerDTC;
 
 /*
  * Inner Tracker Fiber Bundle class.
@@ -67,6 +67,6 @@ private:
   int plotColor_;
 };
 
-
+}
 
 #endif

--- a/include/InnerCabling/InnerDTC.hh
+++ b/include/InnerCabling/InnerDTC.hh
@@ -9,6 +9,7 @@
 #include "InnerCabling/InnerBundle.hh"
 #include "InnerCabling/inner_cabling_functions.hh"
 
+namespace insur {
 
 /*
  * Inner Tracker DTC class.
@@ -46,6 +47,6 @@ private:
   int plotColor_;
 };
 
-
+}
 
 #endif

--- a/include/InnerCabling/PowerChain.hh
+++ b/include/InnerCabling/PowerChain.hh
@@ -9,9 +9,9 @@
 #include "InnerCabling/inner_cabling_functions.hh"
 
 
-namespace insur { class HvLine; }
-using insur::HvLine;
+namespace insur {
 
+class HvLine;
 
 /*
  * Power chain class.
@@ -95,6 +95,6 @@ private:
   int plotColor_;
 };
 
-
+}
 
 #endif

--- a/include/Layer.hh
+++ b/include/Layer.hh
@@ -186,11 +186,11 @@ public:
 
   bool isTiming() const { return rods_.front().isTiming(); }
 
-  void accept(GeometryVisitor& v) {
+  void accept(GeometryVisitor& v) override {
     v.visit(*this);
     for (auto& r : rods_) { r.accept(v); }
   }
-  void accept(ConstGeometryVisitor& v) const { 
+  void accept(ConstGeometryVisitor& v) const override {
     v.visit(*this);
     for (const auto& r : rods_) { r.accept(v); }
   }

--- a/include/OuterCabling/OuterBundle.hh
+++ b/include/OuterCabling/OuterBundle.hh
@@ -6,12 +6,12 @@
 
 #include "Property.hh"
 #include "Module.hh"
+#include "OuterCabling/OuterCable.hh"
 #include "OuterCabling/PhiPosition.hh"
 #include "OuterCabling/ServicesChannel.hh"
 
 
-namespace insur { class OuterCable; }
-using insur::OuterCable;
+namespace insur {
 
 
 class OuterBundle : public PropertyObject, public Buildable, public Identifiable<int> {
@@ -102,6 +102,6 @@ private:
   bool isPowerRoutedToBarrelLowerSemiNonant_;
 };
 
-
+}
 
 #endif

--- a/include/OuterCabling/OuterCable.hh
+++ b/include/OuterCabling/OuterCable.hh
@@ -5,12 +5,12 @@
 #include <string>
 
 #include "Property.hh"
-#include "OuterBundle.hh"
+#include "OuterCabling/ServicesChannel.hh"
 
+namespace insur {
 
-namespace insur { class DTC; }
-using insur::DTC;
-
+class OuterDTC;
+class OuterBundle;
 
 class OuterCable : public PropertyObject, public Buildable, public Identifiable<int> {
   typedef std::vector<OuterBundle*> Container;
@@ -61,6 +61,6 @@ private:
   std::unique_ptr<const ChannelSection> opticalChannelSection_; // opticalChannelSection is owned by OuterCable
 };
 
-
+}
 
 #endif

--- a/include/OuterCabling/OuterCablingMap.hh
+++ b/include/OuterCabling/OuterCablingMap.hh
@@ -8,6 +8,7 @@
 #include "OuterCabling/ModulesToBundlesConnector.hh"
 #include "OuterCabling/OuterDTC.hh"
 
+namespace insur {
 
 /* Build the cabling map.
    The cabling map contains all the necessary bundles, cables and DTCs for a given tracker.
@@ -62,5 +63,6 @@ private:
   // All bundles, cables, and DTC are owned by the Cabling map, and the Cabling map only!!
 };
 
+}
 
 #endif  // OUTERCABLINGMAP_HH

--- a/include/OuterCabling/OuterDTC.hh
+++ b/include/OuterCabling/OuterDTC.hh
@@ -5,8 +5,10 @@
 #include <string>
 
 #include "OuterCable.hh"
+#include "OuterBundle.hh"
 #include "Module.hh"
 
+namespace insur {
 
 class OuterDTC : public PropertyObject, public Buildable, public Identifiable<int> {
   typedef std::vector<OuterCable*> Container;
@@ -49,6 +51,6 @@ private:
   int plotColor_;
 };
 
-
+}
 
 #endif

--- a/include/OuterCabling/OuterGBT.hh
+++ b/include/OuterCabling/OuterGBT.hh
@@ -7,6 +7,8 @@
 #include "Property.hh"
 #include "Module.hh"
 
+namespace insur{
+
 class OuterGBT : public PropertyObject, public Buildable, public Identifiable<int> {
   typedef std::vector<Module*> Container; 
 
@@ -30,6 +32,7 @@ private:
 
 };
 
+}
 
 
 #endif

--- a/include/Ring.hh
+++ b/include/Ring.hh
@@ -34,8 +34,6 @@ class TiltedRing : public PropertyObject, public Buildable, public Identifiable<
 
   double thetaStart_, thetaEnd_;
 
-  double thetaStartInner_, thetaEndInner_;
-
   double numPhi_, phiOverlap_;
 
   double rStartOuter_REAL_, zStartOuter_REAL_, rEndOuter_REAL_, zEndOuter_REAL_;
@@ -71,12 +69,12 @@ class TiltedRing : public PropertyObject, public Buildable, public Identifiable<
   void buildLeftRight(double lastThetaEnd);
   void check() override;
 
-  void accept(GeometryVisitor& v) {
-    v.visit(*this); 
+  void accept(GeometryVisitor& v) override {
+    v.visit(*this);
     for (auto& m : modules_) { m.accept(v); }
   }
-  void accept(ConstGeometryVisitor& v) const {
-    v.visit(*this); 
+  void accept(ConstGeometryVisitor& v) const override {
+    v.visit(*this);
     for (const auto& m : modules_) { m.accept(v); }
     }
 
@@ -200,27 +198,7 @@ public:
 
   int nModules() const { return modules_.size(); }
  
-  Ring(const std::string subdetectorName) :
-    materialObject_(MaterialObject::ROD, subdetectorName),
-      moduleShape           ("moduleShape"           , parsedAndChecked()),
-      phiOverlap            ("phiOverlap"            , parsedOnly(), 1.),
-      requireOddModsPerSlice("requireOddModsPerSlice", parsedOnly(), false),
-      phiSegments           ("phiSegments"           , parsedOnly(), 4),
-      additionalModules     ("additionalModules"     , parsedOnly(), 0),
-      alignEdges            ("alignEdges"            , parsedOnly(), true),
-      ringGap               ("ringGap"               , parsedOnly(), 0.),
-      smallParity           ("smallParity"           , parsedOnly(), 1),
-      moduleNode            ("Module"                , parsedOnly()),
-      subdetectorName_      (subdetectorName),
-      smallDelta            ("smallDelta"            , parsedAndChecked()),
-      phiShift              ("phiShift"              , parsedOnly(),0.),
-      zError                ("zError"                , parsedAndChecked()),
-      rSafetyMargin         ("rSafetyMargin"         , parsedOnly(), 0.),
-      numModules            ("numModules"            , parsedOnly()),
-      zRotation             ("zRotation"             , parsedOnly(), 0.),
-      ringOuterRadius       ("ringOuterRadius"       , parsedOnly(), -1.),
-      ringInnerRadius       ("ringInnerRadius"       , parsedOnly(), -1.)
-  {}
+  Ring(const std::string subdetectorName);
 
   void setup() {
     minZ.setup([this]() { double min = std::numeric_limits<double>::max(); for (const auto& m : modules_) min = MIN(min, m.minZ()); return min; });
@@ -265,11 +243,11 @@ public:
 
   void computeActualPhiCoverage();
 
-  void accept(GeometryVisitor& v) { 
-    v.visit(*this); 
+  void accept(GeometryVisitor& v) override {
+    v.visit(*this);
     for (auto& m : modules_) { m.accept(v); }
   }
-  void accept(ConstGeometryVisitor& v) const { 
+  void accept(ConstGeometryVisitor& v) const override {
     v.visit(*this); 
     for (const auto& m : modules_) { m.accept(v); }
   }

--- a/include/Tracker.hh
+++ b/include/Tracker.hh
@@ -25,7 +25,7 @@
 
 using std::set;
 using material::SupportStructure;
-
+using insur::OuterCablingMap;
 
 
 class Tracker : public PropertyObject, public Buildable, public Identifiable<string>, Clonable<Tracker>, public Visitable {

--- a/include/global_funcs.hh
+++ b/include/global_funcs.hh
@@ -16,7 +16,6 @@ struct EnumTraits {
   static const std::vector<std::string> data;
 };
 
-
 #define define_enum_strings(E) template<> const std::vector<std::string> EnumTraits<E>::data
 #define _STRING_ENUM true
 #define _NOT_STRING_ENUM false
@@ -61,8 +60,8 @@ public:
     return EnumTraits<T>::data[static_cast<typename std::underlying_type<T>::type>(from)];
   }
   template<typename T> static T str2any(const std::string& from) {
-    static auto begin = std::begin(EnumTraits<T>::data);
-    static auto end = std::end(EnumTraits<T>::data); // + EnumTraits<T>::data_size;
+    auto begin = std::begin(EnumTraits<T>::data);
+    auto end = std::end(EnumTraits<T>::data); // + EnumTraits<T>::data_size;
     return static_cast<T>(std::distance(begin, std::find(begin, end, from)));
     // TODO : throw exception if string not found
   }

--- a/include/tk2CMSSW.hh
+++ b/include/tk2CMSSW.hh
@@ -47,9 +47,8 @@ namespace insur {
      * results for the new files are discarded.
      */
     class tk2CMSSW {
-        mainConfigHandler& mainConfiguration;
     public:
-        tk2CMSSW(mainConfigHandler& mch) : mainConfiguration(mch) {}
+        tk2CMSSW(mainConfigHandler& mch) {}
         virtual ~tk2CMSSW() {}
         void translate(MaterialTable& mt, MaterialBudget& mb, XmlTags& trackerXmlTags, std::string xmlDirectoryPath, std::string xmlOutputPath, std::string xmlOutputName = "", bool wt = false);
         struct ConfigFile { std::string name, content; };

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -849,7 +849,6 @@ void Analyzer::fillTriggerEfficiencyGraphs(const Tracker& tracker,
 
           myFractionProfile.Fill(eta, nExpectedTriggerPoints*100/double(nHits));
           double curAvgTrue=0;
-          double curAvgInteresting=0;
           double curAvgFake=0;
           double bgReductionFactor; // Reduction of the combinatorial background for ptPS modules by turning off the appropriate pixels
 
@@ -864,8 +863,6 @@ void Analyzer::fillTriggerEfficiencyGraphs(const Tracker& tracker,
               if (hitModule==nullptr) logERROR("Track::fillTriggerEfficiencyGraphs: This SHOULD NOT happen -> an active hit does not correspond to any module!");
 
               PtErrorAdapter pterr(*hitModule);
-              // Hits that we would like to have from tracks above this threshold
-              curAvgInteresting += pterr.getParticleFrequencyPerEventAbove(iMomentum);
               // ... out of which we only see these
               curAvgTrue += pterr.getTriggerFrequencyTruePerEventAbove(iMomentum);
 
@@ -1411,7 +1408,6 @@ RILength Analyzer::findModuleLayerRI(std::vector<ModuleCap>& layer,
   origin    = track.getOrigin();
   direction = track.getDirection();
   double distance, r;
-  int hits = 0;
   res.radiation = 0.0;
   res.interaction = 0.0;
   // set the track direction vector
@@ -1426,7 +1422,6 @@ RILength Analyzer::findModuleLayerRI(std::vector<ModuleCap>& layer,
         if (h.second != HitType::NONE) {
           distance = h.first.R();
           // module was hit
-          hits++;
           r = distance * sin(track.getTheta());
           tmp.radiation = iter->getRadiationLength();
           tmp.interaction = iter->getInteractionLength();
@@ -1446,8 +1441,6 @@ RILength Analyzer::findModuleLayerRI(std::vector<ModuleCap>& layer,
             tmp.interaction = tmp.interaction / cos(track.getTheta() + tiltAngle - M_PI/2);
           }
 
-          double tmpr = 0., tmpi = 0.;
-
 	  const double theta = track.getTheta();
 
 	  const std::map<LocalElement, RILength, ComponentNameCompare>& modulesComponentsRI = iter->getComponentsRI();
@@ -1460,9 +1453,6 @@ RILength Analyzer::findModuleLayerRI(std::vector<ModuleCap>& layer,
 	    sumComponentsRI[componentName].radiation += correctedMat.radiation;
 	    sumComponentsRI[componentName].interaction += correctedMat.interaction;
 
-	    // TO DO: what the hell is this duplicated work? also, the sum might not even be ok.
-            tmpr += sumComponentsRI.at(componentName).radiation; 
-            tmpi += sumComponentsRI.at(componentName).interaction;
           }
           // 2D plot and eta plot results
           if (!isPixel) fillCell(r, track.getEta(), track.getTheta(), tmp);
@@ -1568,7 +1558,6 @@ RILength Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, Track& t, 
   XYZVector origin, direction;
   origin    = t.getOrigin();
   direction = t.getDirection();
-  int hits = 0;
   res.radiation = 0.0;
   res.interaction = 0.0;
   // set the track direction vector
@@ -1576,7 +1565,6 @@ RILength Analyzer::findHitsModuleLayer(std::vector<ModuleCap>& layer, Track& t, 
         auto h = iter->getModule().checkTrackHits(origin, direction); 
         if (h.second != HitType::NONE) {
           // module was hit
-          hits++;
           tmp.radiation = iter->getRadiationLength();
           tmp.interaction = iter->getInteractionLength();
           // radiation and interaction length scaling for barrels
@@ -2541,7 +2529,7 @@ void Analyzer::prepareTriggerPerformanceHistograms(const int& nTracks, const dou
   //std::pair<double, TGraph> elemTotalGraph;
   std::pair<double, TProfile> elemTotalProfile;
   //TGraph totalGraph;
-  char dummyName[256]; sprintf(dummyName, "dummyName%d", bsCounter++);
+  char dummyName[256]; snprintf(dummyName, 256, "dummyName%d", bsCounter++);
   TProfile totalProfile(dummyName, dummyName, nbins, 0, myEtaMax);
   //elemTotalGraph.first = GraphBag::Triggerable;
   //elemTotalGraph.second = totalGraph;
@@ -3151,7 +3139,7 @@ void Analyzer::analyzeGeometry(Tracker& tracker, int nTracks /*=1000*/ ) {
 
   //TProfile* total = total2D.ProfileX("etaProfileTotal");
   char profileName_[256];
-  sprintf(profileName_, "etaProfileTotal%d", bsCounter++);
+  snprintf(profileName_, 256, "etaProfileTotal%d", bsCounter++);
   // totalEtaProfile = TProfile(*total2D.ProfileX(profileName_));
   savingGeometryV.push_back(totalEtaProfile);
   const double plotNumberOfHitModulesMaxY = (!tracker.isPixelTracker() ? plotNumberOfOuterTrackerHitModulesMaxY : plotNumberOfInnerTrackerHitModulesMaxY);

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -582,7 +582,7 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
       std::stringstream bundleInfo;
       bundleInfo << myBundle->myid() << ", ";
 
-      const OuterCable* myCable = myBundle->getCable();
+      const insur::OuterCable* myCable = myBundle->getCable();
       if (myCable != nullptr) {
 	std::stringstream cableInfo;
 	cableInfo << myCable->myid() << ", "
@@ -592,7 +592,7 @@ void ModulesToDTCsVisitor::visit(const Module& m) {
 		   << myBundle->powerChannelSection()->channelNumber() << " " 
 		   << any2str(myBundle->powerChannelSection()->channelSlot()) << ", ";
 	
-	const OuterDTC* myDTC = myCable->getDTC();
+	const insur::OuterDTC* myDTC = myCable->getDTC();
 	if (myDTC != nullptr) {
 	  std::stringstream DTCInfo;
 	  DTCInfo << myDTC->name() << ", "

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -764,7 +764,7 @@ const OuterDTC* DetectorModule::getDTC() const {
   const OuterDTC* myDTC = nullptr;
   const OuterBundle* myBundle = getBundle();
   if (myBundle) {
-    const OuterCable* myCable = myBundle->getCable();
+    const insur::OuterCable* myCable = myBundle->getCable();
     if (myCable) {
       myDTC = myCable->getDTC();
     }

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -4421,7 +4421,7 @@ namespace insur {
 
   ModuleComplex::ModuleComplex(std::string moduleName,
                                std::string parentName,
-                               ModuleCap&  modcap        ) : modulecap(modcap),
+                               ModuleCap&  modcap        ) :
 							     module(modcap.getModule()),
 							     moduleId(moduleName),
                                                              parentId(parentName),
@@ -4441,7 +4441,6 @@ namespace insur {
                                                              centralDeadAreaLength(module.centralDeadAreaLength()),
 							     chipNegativeXExtraWidth(module.chipNegativeXExtraWidth()),
 							     chipPositiveXExtraWidth(module.chipPositiveXExtraWidth()),
-                                                             hybridTotalMass(0.),
                                                              hybridTotalVolume_mm3(-1.),
                                                              hybridFrontAndBackVolume_mm3(-1.),
                                                              hybridLeftAndRightVolume_mm3(-1.),
@@ -4484,7 +4483,7 @@ namespace insur {
   }
 
   void ModuleComplex::buildSubVolumes() {
-    Volume* vol[nTypes];
+    std::vector<Volume*> vol(nTypes);
     if (!module.isPixelModule()) {
 
       if (!module.isTimingModule()) {

--- a/src/Layer.cc
+++ b/src/Layer.cc
@@ -327,7 +327,7 @@ RodTemplate Layer::makeRodTemplate(const double skewAngle) {
   RodTemplate rodTemplate(buildNumModules() > 0 ? buildNumModules() : (!ringNode.empty() ? ringNode.rbegin()->first + 1 : 1)); // + 1 to make room for a default constructed module to use when building rods in case the rodTemplate vector doesn't have enough elements
   const int numModules = rodTemplate.size();
   for (int i = 0; i < numModules; i++) {
-    rodTemplate[i] = std::move(unique_ptr<BarrelModule>(GeometryFactory::make<BarrelModule>(GeometryFactory::make<RectangularModule>(), subdetectorName())));
+    rodTemplate[i] = std::unique_ptr<BarrelModule>(GeometryFactory::make<BarrelModule>(GeometryFactory::make<RectangularModule>(), subdetectorName()));
     rodTemplate[i]->store(propertyTree());
     if (ringNode.count(i+1) > 0) rodTemplate[i]->store(ringNode.at(i+1));
     if (isSkewedForInstallation()) rodTemplate[i]->skewAngle(skewAngle);

--- a/src/MaterialBudget.cc
+++ b/src/MaterialBudget.cc
@@ -332,7 +332,7 @@ namespace insur {
                 }
             }
         }
-        else throw std::out_of_range("Layer index is out of range: " + layer);
+        else throw std::out_of_range(std::string("Layer index is out of range: ") + layer);
         return index;
     }
 

--- a/src/MaterialObject.cc
+++ b/src/MaterialObject.cc
@@ -16,6 +16,7 @@
 #include "MessageLogger.hh"
 #include <stdexcept>
 
+define_enum_strings(material::Location) = { "all", "dee", "external" };
 
 namespace material {
   const std::map<MaterialObject::Type, const std::string> MaterialObject::typeString = {
@@ -24,7 +25,6 @@ namespace material {
       {LAYER, "layer"}
   };
 
-  define_enum_strings(Location) = { "all", "dee", "external" };
 
   MaterialObject::MaterialObject(Type materialType, const std::string subdetectorName) :
     subdetectorName_(subdetectorName),

--- a/src/MaterialProperties.cc
+++ b/src/MaterialProperties.cc
@@ -19,13 +19,11 @@ const RILength RILength::operator+(const RILength &other) const {
   return result;              // All done!
 }
 
+define_enum_strings(insur::MechanicalCategory) = { "Unknown", "Module", "Cabling", "Supports & Cooling" };
 
+define_enum_strings(insur::MaterialProperties::Category) = { "Nocat", "Bmod", "Emod", "Bser", "Eser", "Bsup", "Esup", "Osup", "Tsup", "Usup" };
 
 namespace insur {
-
-  define_enum_strings(MechanicalCategory) = { "Unknown", "Module", "Cabling", "Supports & Cooling" };
-
-
 
     /*-----public functions-----*/
     /**
@@ -390,8 +388,5 @@ namespace insur {
         return split.first;
     }
 
-
-
-  define_enum_strings(MaterialProperties::Category) = { "Nocat", "Bmod", "Emod", "Bser", "Eser", "Bsup", "Esup", "Osup", "Tsup", "Usup" };
 }
 

--- a/src/Materialway.cc
+++ b/src/Materialway.cc
@@ -1863,11 +1863,8 @@ namespace material {
 
     //modules
     class ModuleVisitor : public GeometryVisitor {
-    private:
-      WeightDistributionGrid& weightDistribution_;
     public:
-      ModuleVisitor(WeightDistributionGrid& weightDistribution) :
-        weightDistribution_(weightDistribution) {}
+      ModuleVisitor(WeightDistributionGrid& weightDistribution) {}
       virtual ~ModuleVisitor() {}
 
       void visit(DetectorModule& module) {

--- a/src/OuterCabling/OuterCable.cc
+++ b/src/OuterCabling/OuterCable.cc
@@ -1,6 +1,7 @@
 #include "OuterCabling/OuterCable.hh"
 #include "OuterCabling/OuterDTC.hh"
 
+using namespace insur;
 
 OuterCable::OuterCable(const int id, const double phiSectorWidth, const int phiSectorRef, const Category& type, const int slot, const bool isPositiveCablingSide) : 
   phiSectorWidth_(phiSectorWidth),

--- a/src/PlotDrawer.cc
+++ b/src/PlotDrawer.cc
@@ -128,7 +128,7 @@ template<class CoordType> void SummaryFrameStyle<CoordType>::drawEtaTicks(double
       if (textX > (endL + textDistanceL)) textX = endL + textDistanceL;
       if (textY > (endR + textDistanceR)) textY = endR + textDistanceR;
 
-      sprintf(labelChar, "%.01f", eta);
+      snprintf(labelChar, 10, "%.01f", eta);
       aLabel = new TText(textX, textY, labelChar);
       aLabel->SetTextAlign(21);
       aLabel->SetTextSize(labelSize);

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -1,6 +1,28 @@
 #include "Ring.hh"
 #include "MessageLogger.hh"
 
+Ring::Ring(const std::string subdetectorName) :
+  materialObject_(MaterialObject::ROD, subdetectorName),
+    moduleShape           ("moduleShape"           , parsedAndChecked()),
+    phiOverlap            ("phiOverlap"            , parsedOnly(), 1.),
+    requireOddModsPerSlice("requireOddModsPerSlice", parsedOnly(), false),
+    phiSegments           ("phiSegments"           , parsedOnly(), 4),
+    additionalModules     ("additionalModules"     , parsedOnly(), 0),
+    alignEdges            ("alignEdges"            , parsedOnly(), true),
+    ringGap               ("ringGap"               , parsedOnly(), 0.),
+    smallParity           ("smallParity"           , parsedOnly(), 1),
+    moduleNode            ("Module"                , parsedOnly()),
+    subdetectorName_      (subdetectorName),
+    smallDelta            ("smallDelta"            , parsedAndChecked()),
+    phiShift              ("phiShift"              , parsedOnly(),0.),
+    zError                ("zError"                , parsedAndChecked()),
+    rSafetyMargin         ("rSafetyMargin"         , parsedOnly(), 0.),
+    numModules            ("numModules"            , parsedOnly()),
+    zRotation             ("zRotation"             , parsedOnly(), 0.),
+    ringOuterRadius       ("ringOuterRadius"       , parsedOnly(), -1.),
+    ringInnerRadius       ("ringInnerRadius"       , parsedOnly(), -1.)
+{}
+
 inline void Ring::check() {
   PropertyObject::check();
   if (moduleShape() == ModuleShape::WEDGE && buildDirection() == TOPDOWN) throw PathfulException("Wedge-module rings cannot be built top down");

--- a/src/SupportStructure.cc
+++ b/src/SupportStructure.cc
@@ -131,7 +131,9 @@ namespace material {
         layerRadii.erase(std::prev(layerRadii.end()));
 
         //build inactiveElements inside spaces
-        for(std::set<double>::iterator minIter = layerRadii.begin(), maxIter = ++ layerRadii.begin(); minIter != layerRadii.end(); std::advance(minIter,2), std::advance(maxIter,2)) {
+        for(std::set<double>::iterator minIter = layerRadii.begin(), maxIter = std::next(layerRadii.begin());
+            std::distance(minIter, layerRadii.end()) > 0;
+            std::advance(minIter,2), std::advance(maxIter,std::min(2, (int)std::distance(maxIter, layerRadii.end())))) {
           buildInactiveElementPair(direction_, autoPosition(), *minIter, *maxIter - *minIter);
         }
         logINFO("Building barrel support structure vertically oriented, positioned at Z: "+any2str(autoPosition()));

--- a/src/Usher.cc
+++ b/src/Usher.cc
@@ -1456,7 +1456,6 @@ namespace insur {
           std::vector<int> layer_counters_;
           std::vector<bool>& barrel_has_services_;
           
-          double prevZ = -1.;
           int index = 0;
         public:
           BarrelVisitor(std::vector<std::pair<double, double> >& radius_list_io, 
@@ -1537,7 +1536,6 @@ namespace insur {
           std::vector<int> layer_counters_;
           std::vector<bool>& endcap_has_services_;
 
-          double prevR = -1.;
           int index = 0;
         public:
           EndcapVisitor(std::vector<std::pair<double, double> >& radius_list_io, 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -625,7 +625,7 @@ namespace insur {
 	  myLegend->SetTextSize(0.025);
 
 	  myTable = new RootWTable();
-	  sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+	  snprintf(titleString, 256, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
 	  myTable->setContent(0, 0, titleString);
 	  myTable->setContent(0, 1, "Radiation length");
 	  myTable->setContent(0, 2, "Interaction length");
@@ -732,7 +732,7 @@ namespace insur {
 	allSubdetectorsLegend->SetTextSize(0.025);
 
 	RootWTable* allSubdetectorsTable = new RootWTable();
-	sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+	snprintf(titleString, 256, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
 	allSubdetectorsTable->setContent(0, 0, titleString);
 	allSubdetectorsTable->setContent(0, 1, "Radiation length");
 	allSubdetectorsTable->setContent(0, 2, "Interaction length");
@@ -836,7 +836,7 @@ namespace insur {
 	myLegend->SetTextSize(0.025);
 
 	myTable = new RootWTable();
-	sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+	snprintf(titleString, 256, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
 	myTable->setContent(0, 0, titleString);
 	myTable->setContent(0, 1, "Radiation length");
 	myTable->setContent(0, 2, "Interaction length");
@@ -928,7 +928,7 @@ namespace insur {
       myPad->SetFillColor(color_pad_background);
 
       myTable = new RootWTable();
-      sprintf(titleString, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
+      snprintf(titleString, 256, "Average (eta = [0, %.1f])", a.getEtaMaxMaterial());
       myTable->setContent(0, 0, titleString);
       myTable->setContent(0, 1, "Radiation length");
       myTable->setContent(0, 2, "Interaction length");
@@ -3439,7 +3439,7 @@ namespace insur {
     // COLLECT DETAILED INFO (FULL TRACKER MATERIALS, TRACKING VOLUME)
     RootWTable* myTable = new RootWTable();
     char titleString[256];
-    sprintf(titleString, "Average (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
+    snprintf(titleString, 256, "Average (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
     myTable->setContent(0, 0, titleString);
     myTable->setContent(0, 1, "Radiation length");
     myTable->setContent(0, 2, "Interaction length");
@@ -3476,7 +3476,7 @@ namespace insur {
 
     // TOTAL PER LOCATION (FULL TRACKER MATERIALS, TRACKING VOLUME)
     myTable = new RootWTable();
-    sprintf(titleString, "Average (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
+    snprintf(titleString, 256, "Average (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
     myTable->setContent(0, 0, titleString);
     myTable->setContent(0, 1, "Radiation length");
     myTable->setContent(0, 2, "Interaction length");
@@ -3567,9 +3567,9 @@ namespace insur {
     myImage->setComment("Material in total tracking volume");
     myImage->setName("fullLayoutMatOverviewTrackingVolume");
     myTable = new RootWTable();
-    sprintf(titleString, "Average radiation length in tracking volume (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
+    snprintf(titleString, 256, "Average radiation length in tracking volume (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
     myTable->setContent(1, 1, titleString);
-    sprintf(titleString, "Average interaction length in tracking volume (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
+    snprintf(titleString, 256, "Average interaction length in tracking volume (eta = [0, %.1f])", analyzer.getEtaMaxMaterial());
     myTable->setContent(2, 1, titleString);
     if (fullTrackerTrackingVolumeTotalR) myTable->setContent(1, 2, averageHistogramValues(*fullTrackerTrackingVolumeTotalR, analyzer.getEtaMaxMaterial()), 5);
     if (fullTrackerTrackingVolumeTotalI) myTable->setContent(2, 2, averageHistogramValues(*fullTrackerTrackingVolumeTotalI, analyzer.getEtaMaxMaterial()), 5);
@@ -7090,7 +7090,7 @@ namespace insur {
         pw[1]=endTick.Y();
         pw[2]=endTick.Z();
         myView->WCtoNDC(pw, pn);
-        sprintf(labelChar, "%.01f", eta);
+        snprintf(labelChar, 10, "%.01f", eta);
         aLabel = new TText(pn[0], pn[1], labelChar);
         aLabel->SetTextSize(aLabel->GetTextSize()*.6);
         aLabel->SetTextAlign(21);
@@ -7117,7 +7117,7 @@ namespace insur {
       pw[1]=endTick.Y();
       pw[2]=endTick.Z();
       myView->WCtoNDC(pw, pn);
-      sprintf(labelChar, "%.01f", analyzer.getEtaMaxGeometry());
+      snprintf(labelChar, 10, "%.01f", analyzer.getEtaMaxGeometry());
       aLabel = new TText(pn[0], pn[1], labelChar);
       aLabel->SetTextSize(aLabel->GetTextSize()*.8);
       aLabel->SetTextAlign(21);
@@ -7139,7 +7139,7 @@ namespace insur {
         pw[1]=-tickLength;
         pw[2]=endTick.Z();
         myView->WCtoNDC(pw, pn);
-        sprintf(labelChar, "%.0f", z);
+        snprintf(labelChar, 10, "%.0f", z);
         aLabel = new TText(pn[0], pn[1], labelChar);
         aLabel->SetTextSize(aLabel->GetTextSize()*.6);
         aLabel->SetTextAlign(23);
@@ -7160,7 +7160,7 @@ namespace insur {
         pw[1]=endTick.Y();
         pw[2]=-tickLength;
         myView->WCtoNDC(pw, pn);
-        sprintf(labelChar, "%.0f", y);
+        snprintf(labelChar, 10, "%.0f", y);
         aLabel = new TText(pn[0], pn[1], labelChar);
         aLabel->SetTextSize(aLabel->GetTextSize()*.6);
         aLabel->SetTextAlign(32);

--- a/src/delphize.cc
+++ b/src/delphize.cc
@@ -211,7 +211,7 @@ int main(int argc, char* argv[]) {
   
   if (itPtProfiles==ptProfiles.end()) {
     std::cerr << "Error: the collection of profiles is empty" << std::endl;
-    return false;
+    return 1;
   }
   
   // First profile -> get eta, rescale bins, ...
@@ -287,5 +287,5 @@ int main(int argc, char* argv[]) {
   outFile->close();
   delete outFile;
 
-  return true;
+  return 0;
 }


### PR DESCRIPTION
Please merge at your discretion, I largely did this for my own convenience.
I understand how delicate codes like that can be across compiler versions, so if you want to keep things stable or take time to validate (which I am happy to help with given some directions) there is no rush.

With these changes the code base is C++20 compliant to function with modern ROOT versions available through conda.

Clang is a bit more pedantic than gcc in its standards compliance and is very strict about unused variables. I checked manually and indeed the variables were not being used when the compiler was complaining. Code now emits no warnings or errors for modern compilers.

Through cmake route, can compile to a few different OS targets. Notably arm64 and amd64 mac laptops.
It's a bit more convenient to run from my laptop than running from lxplus or a headnode otherwise.
