### PR TITLE
Pixel Detid mismatches

### DIFF
--- a/include/Barrel.hh
+++ b/include/Barrel.hh
@@ -12,10 +12,7 @@
 #include "Property.hh"
 #include "Layer.hh"
 #include "Visitable.hh"
-
-namespace material {
-  class SupportStructure;
-}
+#include "SupportStructure.hh"
 
 class Barrel : public PropertyObject, public Buildable, public Identifiable<string>, Clonable<Barrel>, public Visitable {
 

--- a/include/DetIdBuilder.hh
+++ b/include/DetIdBuilder.hh
@@ -1,9 +1,25 @@
 #ifndef _DETIDBUILDER_HH
 #define	_DETIDBUILDER_HH
 
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <vector>
+#include <string>
+#include <tuple>
+
 #include "global_constants.hh"
 #include "global_funcs.hh"
-#include <Tracker.hh>
+#include "Visitor.hh"
+
+class Endcap;
+class Disk;
+class Ring;
+class Layer;
+class RodPair;
+class BarrelModule;
+class EndcapModule;
+class Sensor;
 
 /** See https://github.com/tkLayout/tkLayout/wiki/DetIds-in-tkLayout-for-the-entire-Tracker .
  * All geometry hierarchy levels (for example OT Barrel, or Ring) are assigned a size (number of bits) and an Id.
@@ -42,7 +58,6 @@ private:
 
   std::map<int, uint32_t> geometryHierarchyIds_;  // WHAT IS CALCULATED HERE !! Id associated to each level in the geometry hierarchy.
 
-  bool isTiltedLayer_;
   int numRods_;
   int numFlatRings_;
   int numRings_;

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -735,7 +735,11 @@ public:
   TableRef tableRef() const { return (TableRef){ subdetectorName(), disk(), ring() }; }
   UniRef uniRef() const { return UniRef{ subdetectorName(), disk(), ring(), blade(), side() }; }
 
+  std::size_t getPhiIdentifier() const { return phiIdentifier; }
+  void setPhiIdentifier(std::size_t id) { phiIdentifier = id; }
+
 private:
+  std::size_t phiIdentifier; /// DetId phi identifier
   bool isSmallerAbsZModuleInRing_;
 };
 

--- a/include/Endcap.hh
+++ b/include/Endcap.hh
@@ -12,11 +12,7 @@
 #include "Property.hh"
 #include "Disk.hh"
 #include "Visitable.hh"
-
-namespace material {
-  class SupportStructure;
-}
-
+#include "SupportStructure.hh"
 
 class Endcap : public PropertyObject, public Buildable, public Identifiable<std::string>, public Visitable {
  private:

--- a/include/Sensor.hh
+++ b/include/Sensor.hh
@@ -12,7 +12,15 @@
 
 
 enum ModuleSubdetector { BARREL = 1, ENDCAP = 2 };
-enum SensorPosition { NO, LOWER, UPPER };
+
+/// Sensor position in the module's local system of reference
+enum SensorPosition {
+  /// Default value, or modules with 1 sensor only
+  NO,
+  /// Z-axis for stacked sensors, Y-axis for planar
+  LOWER, UPPER 
+};
+
 enum class SensorType { Pixel, Largepix, Strip, None };
 
 class DetectorModule;

--- a/src/DetIdBuilder.cc
+++ b/src/DetIdBuilder.cc
@@ -1,5 +1,86 @@
-#include <DetIdBuilder.hh>
+#include <cmath>
+#include <cstdint>
+#include <map>
 
+#include "DetIdBuilder.hh"
+#include "Layer.hh"
+#include "RodPair.hh"
+#include "DetectorModule.hh"
+#include "Sensor.hh"
+#include "Endcap.hh"
+#include "Disk.hh"
+#include "Ring.hh"
+#include "global_funcs.hh"
+
+namespace {
+  constexpr size_t DETECTOR_LEVEL = 0;
+  constexpr size_t SUBDETECTOR_LEVEL = 1;
+
+  // Barrel geometry hierarchy
+
+  namespace Barrels { // Pixel and Outer common levels
+    constexpr size_t UNUSED_LEVEL = 2;
+    constexpr size_t LAYER_LEVEL = 3;
+  }
+
+  namespace PixelBarrel {
+    constexpr size_t LADDER_LEVEL = 4;
+    constexpr size_t MODULE_LEVEL = 5;
+    constexpr size_t SENSOR_LEVEL = 6;
+  }
+
+  namespace TOB {
+    constexpr size_t RING_LEVEL = 4;
+    constexpr size_t LADDER_LEVEL = 5;
+    constexpr size_t MODULE_LEVEL = 6;
+    constexpr size_t SENSOR_LEVEL = 7;
+  }
+
+  // Endcap geometry hierarchy
+
+  namespace Endcaps { // Pixel and Outer common levels
+    constexpr size_t SIDE_LEVEL = 2;
+    constexpr size_t RING_LEVEL = 5;
+    constexpr size_t PANEL_LEVEL = 6;
+    constexpr size_t SENSOR_LEVEL = 8;
+  }
+
+  namespace PixelEndcap {
+    constexpr size_t DISK_LEVEL = 3;
+    constexpr size_t SUBDISK_LEVEL = 4;
+    constexpr size_t MODULE_LEVEL = 7;
+  }
+
+  namespace TID {
+    constexpr size_t UNUSED_LEVEL = 3;
+    constexpr size_t DISK_LEVEL = 4;
+    constexpr size_t MODULE_LEVEL = 7;
+  }
+
+  // CMSSW DetId scheme bit values for the Tracker and subdetectors DetIds
+  namespace DetId {
+    constexpr uint32_t Fixed_0 = 0;
+    constexpr uint32_t Fixed_1 = 1;
+    constexpr uint32_t Tracker = 1;
+    constexpr uint32_t PixelBarrel = 1;
+    constexpr uint32_t PixelEndcap = 2;
+    constexpr uint32_t OuterEndcap = 4;
+    constexpr uint32_t OuterTracker = 5;
+
+    // Outer Tracker ring level bits based on tiltedness
+    namespace OTRing {
+      constexpr uint32_t NegativeZ = 1;
+      constexpr uint32_t PositiveZ = 2;
+      constexpr uint32_t Flat = 3;
+    }
+
+    // Endcap disk level bits based on the Z-coordinate of the disk
+    namespace EndcapDisk {
+      constexpr uint32_t NegativeZ = 1;
+      constexpr uint32_t PositiveZ = 2;
+    }
+  }
+}
 
     //************************************//
     //*               Visitor             //
@@ -13,29 +94,19 @@ BarrelDetIdBuilder::BarrelDetIdBuilder(bool isPixelTracker, std::vector<int> geo
 {}
 
 void BarrelDetIdBuilder::visit(Barrel& b) {
-
-  // !!! Tracker level
-  geometryHierarchyIds_[0] = 1;   // always 1.
-
-  // !!! Barrel level
-  if (!isPixelTracker_) { geometryHierarchyIds_[1] = 205 % 100; }  // Outer Tracker : always 5. 
-                                                        // In CMSSW, Phase 2 Outer Tracker Barrel is identified by 205, and its id is 205 % 100.
-  else { geometryHierarchyIds_[1] = 201 % 100; }                   // Inner Tracker : always 1.
-                                                        // In CMSSW, Phase 2 Inner Tracker Barrel is identified by 201, and its id is 201 % 100.
-
-  // !!! Unused hierarchy level			   
-  geometryHierarchyIds_[2] = 0;  // always 0.
+  geometryHierarchyIds_[DETECTOR_LEVEL] = DetId::Tracker;
+  geometryHierarchyIds_[SUBDETECTOR_LEVEL] = isPixelTracker_ ? DetId::PixelBarrel : DetId::OuterTracker;
+  geometryHierarchyIds_[Barrels::UNUSED_LEVEL] = DetId::Fixed_0;
 }
 
 void BarrelDetIdBuilder::visit(Layer& l) {
-  // !!! Layer level
-  geometryHierarchyIds_[3] = l.layerNumber();
+  // Increasing in radius
+  geometryHierarchyIds_[Barrels::LAYER_LEVEL] = l.layerNumber();
 
-  isTiltedLayer_ = l.isTilted();
+  // Store information for visit(RodPair&) and visit(BarrelModule&)
   numRods_ = l.numRods();
   numFlatRings_ = l.buildNumModulesFlat();
-  numRings_ = l.buildNumModules();
-  if (!isTiltedLayer_) numRings_ = numFlatRings_;
+  numRings_ = l.isTilted() ? l.buildNumModules() : numFlatRings_;
 }
 
 void BarrelDetIdBuilder::visit(RodPair& r) {
@@ -52,74 +123,55 @@ void BarrelDetIdBuilder::visit(RodPair& r) {
 }
 
 void BarrelDetIdBuilder::visit(BarrelModule& m) {
-  int side = m.uniRef().side;
-  uint32_t ringRef;
+  const bool isPositiveZ = m.side() > 0;
 
-  // Flat layer, or flat part of a tilted layer
-  if (!m.isTilted()) {
-    if (!isPixelTracker_) {
-      // !!! Category level
-      geometryHierarchyIds_[4] = 3;  // flat part : always 3.
+  // Z+ modules are copied to the Z- side, reversing their order in |Z|
+  uint32_t flatRingRef = isPositiveZ ? m.ring() + numFlatRings_ : 1 + numFlatRings_ - m.ring();
+  // Remove the offset
+  flatRingRef = isCentered_ && isPositiveZ ? flatRingRef - 1 : flatRingRef;
 
-      // !!! Rod level
-      geometryHierarchyIds_[5] = phiRef_;
+  if (isPixelTracker_) { // Pixel Barrel
+    if (m.isTilted()) {
+      logWARNING("No CMSSW DetId scheme exists for Pixel Barrel with tilted modules.");
     }
-    // !!! Inner Tracker : Rod level
-    else { geometryHierarchyIds_[4] = phiRef_; }
+    else {
+      // Increasing in phi
+      geometryHierarchyIds_[PixelBarrel::LADDER_LEVEL] = phiRef_;
+      // Increasing in |z|
+      geometryHierarchyIds_[PixelBarrel::MODULE_LEVEL] = flatRingRef;
+    }
+  }
+  else { // Outer Tracker Barrel
+    if (m.isTilted()) {
+      uint32_t tiltedRingRef = isPositiveZ ? m.ring() - numFlatRings_ : 1 + numRings_ - m.ring();
 
-    // Calculated ring identifier. 
-    // Ring numbering starts from 1 from lowest Z, and increments with increasing Z.
-    if (isCentered_) ringRef = (side > 0 ? (m.uniRef().ring + numFlatRings_ - 1) : (1 + numFlatRings_ - m.uniRef().ring));
-    else ringRef = (side > 0 ? (m.uniRef().ring + numFlatRings_) : (1 + numFlatRings_ - m.uniRef().ring));
-
-    // !!! Module level
-    if (!isPixelTracker_) { geometryHierarchyIds_[6] = ringRef; }
-
-    // !!! Inner Tracker : Ring level
-    else { geometryHierarchyIds_[5] = ringRef; }
+      geometryHierarchyIds_[TOB::RING_LEVEL] = isPositiveZ ? DetId::OTRing::PositiveZ : DetId::OTRing::NegativeZ;
+      // Increasing in |z(rings)|
+      geometryHierarchyIds_[TOB::LADDER_LEVEL] = tiltedRingRef;
+      // Increasing in phi(barrel)
+      geometryHierarchyIds_[TOB::MODULE_LEVEL] = phiRef_;
+    }
+    else {
+      geometryHierarchyIds_[TOB::RING_LEVEL] = DetId::OTRing::Flat;
+      // Increasing in phi(barrel)
+      geometryHierarchyIds_[TOB::LADDER_LEVEL] = phiRef_;
+      // Increasing in |z(rings)|
+      geometryHierarchyIds_[TOB::MODULE_LEVEL] = flatRingRef;
+    }
   }
 
-  // Tilted part
-  else {
-    if (!isPixelTracker_) {
-      // !!! Category level
-      uint32_t category = (side > 0 ? 2 : 1); // tilted part : 2 on +Z side, 1 on -Z side.
-      geometryHierarchyIds_[4] = category;
+  // Sensor level is irrelevant at module level, assign a fixed value
+  geometryHierarchyIds_[isPixelTracker_ ? PixelBarrel::SENSOR_LEVEL : TOB::SENSOR_LEVEL] = DetId::Fixed_0;
 
-      // !!! Ring level
-      ringRef = (side > 0 ? (m.uniRef().ring - numFlatRings_) : (1 + numRings_ - m.uniRef().ring));
-      geometryHierarchyIds_[5] = ringRef;
-
-      // !!! Module level
-      geometryHierarchyIds_[6] = phiRef_;
-    }
-    // No scheme for tilted Inner Tracker exists in CMSSW.
-    else { logWARNING("Tilted Pixel DetIds not supported yet."); }
-  }
-
-  // !!! Assign a null ref to sensor level.
-  uint32_t sensorRef = 0;
-  if (!isPixelTracker_) { geometryHierarchyIds_[7] = sensorRef; }
-  else { geometryHierarchyIds_[6] = sensorRef; };
-
-  // NOW THAT ALL NECESSARY REFS ARE COMPUTED, BUILD MODULE DETID !!
   m.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
 }
 
 void BarrelDetIdBuilder::visit(Sensor& s) {
-  if (s.subdet() == ModuleSubdetector::BARREL) {
+  if (s.subdet() != ModuleSubdetector::BARREL) return;
 
-    // !!! Sensor level
-    if (!isPixelTracker_) {
-      uint32_t sensorRef = (s.innerOuter() == SensorPosition::LOWER ? 1 : 2); // Lower sensor 1, upper sensor 2.
-      geometryHierarchyIds_[7] = sensorRef;
-    }
-    // !!! Inner tracker : Sensor level
-    else { geometryHierarchyIds_[6] = 0; }
+  geometryHierarchyIds_[isPixelTracker_ ? PixelBarrel::SENSOR_LEVEL : TOB::SENSOR_LEVEL] = isPixelTracker_ ? DetId::Fixed_0 : s.innerOuter();
 
-    // NOW THAT ALL NECESSARY REFS ARE COMPUTED, BUILD SENSOR DETID !!
-    s.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
-  }  
+  s.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
 }
 
 
@@ -137,45 +189,25 @@ EndcapDetIdBuilder::EndcapDetIdBuilder(bool isPixelTracker, bool hasSubDisks, st
 {}
 
 void EndcapDetIdBuilder::visit(Endcap& e) {
-  // !!! Tracker level
-  geometryHierarchyIds_[0] = 1;   // always 1.
-
-  // !!! Endcap level
-  if (!isPixelTracker_) { geometryHierarchyIds_[1] = 204 % 100; } // Outer Tracker : always 4. 
-                                                       // In CMSSW, Phase 2 Outer Tracker Endcap is identified by 204, and its id is 204 % 100.
-  else { geometryHierarchyIds_[1] = 202 % 100; }                  // Inner Tracker : always 2. 
-                                                       // In CMSSW, Phase 2 Inner Tracker Endcap is identified by 202, and its id is 202 % 100.
+  geometryHierarchyIds_[DETECTOR_LEVEL] = DetId::Tracker;
+  geometryHierarchyIds_[SUBDETECTOR_LEVEL] = isPixelTracker_ ? DetId::PixelEndcap : DetId::OuterEndcap;
 }
 
 void EndcapDetIdBuilder::visit(Disk& d) {
-  bool side = d.side();
+  geometryHierarchyIds_[Endcaps::SIDE_LEVEL] = d.side() ? DetId::EndcapDisk::PositiveZ : DetId::EndcapDisk::NegativeZ;
+  // Increasing in |z|
+  geometryHierarchyIds_[isPixelTracker_ ? PixelEndcap::DISK_LEVEL : TID::DISK_LEVEL] = d.diskNumber();
 
-  // !!! Z side level
-  uint32_t sideRef = (side ? 2 : 1);  // 2 for Z+ side, 1 for -Z side
-  geometryHierarchyIds_[2] = sideRef;
-
-  // !!! Unused hierarchy level	
-  geometryHierarchyIds_[3] = 0;   // always 0
-
-  // !!! Disk level
-  uint32_t diskRef = d.diskNumber();
-  if(!hasSubDisks_){
-    geometryHierarchyIds_[4] = diskRef;
-  } else {
-    geometryHierarchyIds_[3] = diskRef;
-  }
-
+  // Store information for visit(Ring&)
   numEmptyRings_ = d.numEmptyRings();
 }
    
 void EndcapDetIdBuilder::visit(Ring& r) {
-  // !!! Ring level
-  uint32_t ringRef = r.myid() - numEmptyRings_;
-  geometryHierarchyIds_[5] = ringRef;
+  geometryHierarchyIds_[Endcaps::PANEL_LEVEL] = DetId::Fixed_1;
+  // Increasing in radius
+  geometryHierarchyIds_[Endcaps::RING_LEVEL] = r.myid() - numEmptyRings_;
 
-  // !!! Unused hierarchy level	
-  geometryHierarchyIds_[6] = 1;   // always 1
-
+  // Store information for visit(EndcapModule&)
   numModules_ = r.numModules();
 }
  
@@ -183,55 +215,48 @@ void EndcapDetIdBuilder::visit(EndcapModule& m) {
   double phiSegment = 2 * M_PI / numModules_;                // Phi interval between 2 consecutive modules.
   double startAngle = femod( m.center().Phi(), phiSegment);  // Calculates the smallest positive Phi in the Ring.
 
-  // Calculates Phi identifier.
+  // Calculates 1-based Phi identifier (range: 1 to numModules_)
   uint32_t phiRef_ = 1 + round(femod(m.center().Phi() - startAngle, 2*M_PI) / phiSegment);
-  geometryHierarchyIds_[7] = phiRef_;
-  if(hasSubDisks_){
-    if(phiRef_%2 == 1){
-      uint32_t phiSD1Ref_ = 1 + round(femod(m.center().Phi() - startAngle, 2*M_PI) / (2*phiSegment)); //Identifier for the first SD
-      geometryHierarchyIds_[4] = 0; 
-      geometryHierarchyIds_[7] = phiSD1Ref_;
-    } else {
-      uint32_t phiSD2Ref_ = 1 + round(femod(m.center().Phi() - (startAngle+phiSegment), 2*M_PI) / (2*phiSegment)); //Identifier for the second SD
-      geometryHierarchyIds_[4] = 1;
-      geometryHierarchyIds_[7] = phiSD2Ref_;
+
+  if (isPixelTracker_) { // Pixel Endcap
+    if (hasSubDisks_) {
+      const bool isOddModule = (phiRef_ % 2 == 1);
+      // Increasing in |z|
+      geometryHierarchyIds_[PixelEndcap::SUBDISK_LEVEL] = isOddModule ? DetId::Fixed_0 : DetId::Fixed_1;
+      // Increasing in phi
+      geometryHierarchyIds_[PixelEndcap::MODULE_LEVEL] = isOddModule ? ((phiRef_ + 1) / 2) : (phiRef_ / 2);
+    }
+    else {
+      logWARNING("No CMSSW DetId scheme exists for Pixel Endcap with Single Disk.");
     }
   }
+  else { // Outer Tracker Endcap
+    if (hasSubDisks_) {
+      logWARNING("No CMSSW DetId scheme exists for Outer Endcap with SubDisks.");
+    }
+    else {
+      geometryHierarchyIds_[TID::UNUSED_LEVEL] = DetId::Fixed_0;
+      // Increasing in phi
+      geometryHierarchyIds_[TID::MODULE_LEVEL] = phiRef_;
+    }
+  }
+
   // First module with Phi > 0 has phiRef 1. 
   // Next module (with bigger Phi) has phiRef 2. 
   // phiRef increments with increasing Phi.
   // If we have subdisks, apply the same logic but to 
   // modules in individual subdisks
 
-  // !!! Assign a null ref to sensor level.
-  uint32_t sensorRef = 0;
-  geometryHierarchyIds_[8] = sensorRef;
+  // Sensor level is irrelevant at module level, assign a fixed value
+  geometryHierarchyIds_[Endcaps::SENSOR_LEVEL] = DetId::Fixed_0;
 
-  // NOW THAT ALL NECESSARY REFS ARE COMPUTED, BUILD MODULE DETID !!
   m.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
 }
 
 void EndcapDetIdBuilder::visit(Sensor& s) {  
-  if (s.subdet() == ModuleSubdetector::ENDCAP) {
+  if (s.subdet() != ModuleSubdetector::ENDCAP) return;
 
-    // !!! Sensor level
-    if (!isPixelTracker_) {
-      uint32_t sensorRef = (s.innerOuter() == SensorPosition::LOWER ? 1 : 2);  // Lower sensor 1, upper sensor 2.
-      geometryHierarchyIds_[8] = sensorRef;
-    }
-    // !!! Inner tracker : Sensor level
-    else { geometryHierarchyIds_[8] = 0; }
+  geometryHierarchyIds_[Endcaps::SENSOR_LEVEL] = isPixelTracker_ ? DetId::Fixed_0 : s.innerOuter();
 
-    // NOW THAT ALL NECESSARY REFS ARE COMPUTED, BUILD SENSOR DETID !!
-    s.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
-
-    /*for (int a = 0; a < geometryHierarchyIds_.size(); a++) {
-      std::cout << "values = " << std::endl;
-      std::cout << geometryHierarchyIds_.at(a) << std::endl;
-      std::cout << "scheme = " << std::endl;
-      std::cout << geometryHierarchySizes_.at(a) << std::endl;
-      }*/
-    //std::bitset<32> test(s.myDetId());
-    //std::cout << s.myDetId() << " " << test << " " << "rho = " <<  s.hitPoly().getCenter().Rho() << " z = " <<  s.hitPoly().getCenter().Z() << " phi = " <<  (s.hitPoly().getCenter().Phi() * 180. / M_PI) << std::endl;
-  }
+  s.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
 }

--- a/src/DetIdBuilder.cc
+++ b/src/DetIdBuilder.cc
@@ -212,19 +212,19 @@ void EndcapDetIdBuilder::visit(Ring& r) {
 }
  
 void EndcapDetIdBuilder::visit(EndcapModule& m) {
-  double phiSegment = 2 * M_PI / numModules_;                // Phi interval between 2 consecutive modules.
-  double startAngle = femod( m.center().Phi(), phiSegment);  // Calculates the smallest positive Phi in the Ring.
+  // Phi identifier (range: 1 to numModules_)
+  uint32_t phiRef_ = m.myid();
 
-  // Calculates 1-based Phi identifier (range: 1 to numModules_)
-  uint32_t phiRef_ = 1 + round(femod(m.center().Phi() - startAngle, 2*M_PI) / phiSegment);
+  // Z+ modules are copied to the Z- side with a +180° shift, Phi ∈ [-pi, pi]
+  if (m.side() < 0)
+    phiRef_ = 1 + ((3 * numModules_ / 2 - phiRef_) % numModules_);
 
   if (isPixelTracker_) { // Pixel Endcap
     if (hasSubDisks_) {
-      const bool isOddModule = (phiRef_ % 2 == 1);
       // Increasing in |z|
-      geometryHierarchyIds_[PixelEndcap::SUBDISK_LEVEL] = isOddModule ? DetId::Fixed_0 : DetId::Fixed_1;
+      geometryHierarchyIds_[PixelEndcap::SUBDISK_LEVEL] = m.isSmallerAbsZModuleInRing() ? DetId::Fixed_0 : DetId::Fixed_1;
       // Increasing in phi
-      geometryHierarchyIds_[PixelEndcap::MODULE_LEVEL] = isOddModule ? ((phiRef_ + 1) / 2) : (phiRef_ / 2);
+      geometryHierarchyIds_[PixelEndcap::MODULE_LEVEL] = (phiRef_ % 2 == 1) ? ((phiRef_ + 1) / 2) : (phiRef_ / 2);
     }
     else {
       logWARNING("No CMSSW DetId scheme exists for Pixel Endcap with Single Disk.");
@@ -240,12 +240,6 @@ void EndcapDetIdBuilder::visit(EndcapModule& m) {
       geometryHierarchyIds_[TID::MODULE_LEVEL] = phiRef_;
     }
   }
-
-  // First module with Phi > 0 has phiRef 1. 
-  // Next module (with bigger Phi) has phiRef 2. 
-  // phiRef increments with increasing Phi.
-  // If we have subdisks, apply the same logic but to 
-  // modules in individual subdisks
 
   // Sensor level is irrelevant at module level, assign a fixed value
   geometryHierarchyIds_[Endcaps::SENSOR_LEVEL] = DetId::Fixed_0;

--- a/src/DetIdBuilder.cc
+++ b/src/DetIdBuilder.cc
@@ -169,7 +169,7 @@ void BarrelDetIdBuilder::visit(BarrelModule& m) {
 void BarrelDetIdBuilder::visit(Sensor& s) {
   if (s.subdet() != ModuleSubdetector::BARREL) return;
 
-  geometryHierarchyIds_[isPixelTracker_ ? PixelBarrel::SENSOR_LEVEL : TOB::SENSOR_LEVEL] = isPixelTracker_ ? DetId::Fixed_0 : s.innerOuter();
+  geometryHierarchyIds_[isPixelTracker_ ? PixelBarrel::SENSOR_LEVEL : TOB::SENSOR_LEVEL] = s.innerOuter();
 
   s.buildDetId(geometryHierarchyIds_, geometryHierarchySizes_);
 }

--- a/src/DetIdBuilder.cc
+++ b/src/DetIdBuilder.cc
@@ -212,8 +212,8 @@ void EndcapDetIdBuilder::visit(Ring& r) {
 }
  
 void EndcapDetIdBuilder::visit(EndcapModule& m) {
-  // Phi identifier (range: 1 to numModules_)
-  uint32_t phiRef_ = m.myid();
+  // Range : 1 to numModules_
+  uint32_t phiRef_ = m.getPhiIdentifier();
 
   // Z+ modules are copied to the Z- side with a +180° shift, Phi ∈ [-pi, pi]
   if (m.side() < 0)

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -87,21 +87,19 @@ void DetectorModule::build() {
   }
   if (numSensors() > 0) {
     for (int i = 0; i < numSensors(); i++) {
+      // Build the sensor
       Sensor* s = GeometryFactory::make<Sensor>();
       s->parent(this);
       s->myid(i+1);
       s->store(propertyTree());
       if (sensorNode.count(i+1) > 0) s->store(sensorNode.at(i+1));
-      if (numSensors() == 1) s->innerOuter(SensorPosition::NO);
-      else if (sensorLayout() == SensorLayout::MONO) s->innerOuter(SensorPosition::NO);
-      else {
-	if (i == 0) s->innerOuter(SensorPosition::LOWER);
-	else if (i == 1) s->innerOuter(SensorPosition::UPPER);
-	else s->innerOuter(SensorPosition::NO);
-      }
+      if (numSensors() == 1 || i >= 2) s->innerOuter(SensorPosition::NO);
+      else s->innerOuter(i == 0 ? SensorPosition::LOWER : SensorPosition::UPPER);
       s->build();
+
+      // Add it to the module's list of sensors
       sensors_.push_back(s);
-      materialObject_.sensorChannels[i+1]=s->numChannels();
+      materialObject_.sensorChannels[i+1] = s->numChannels();
     }
   } else {
     Sensor* s = GeometryFactory::make<Sensor>();  // fake sensor to avoid defensive programming when iterating over the sensors and the module is empty

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -85,16 +85,27 @@ void DetectorModule::build() {
     decorated().store(propertyTree());
     decorated().build();
   }
+
   if (numSensors() > 0) {
-    for (int i = 0; i < numSensors(); i++) {
+    int nSensors = numSensors();
+    if (nSensors > 2) {
+      logERROR("More than 2 sensors found. Only the first 2 will be used.");
+      nSensors = 2;
+      numSensors.scaleByUnit(2.0001 / static_cast<double>(numSensors())); // cheating the read-only property
+    }
+
+    for (int i = 0; i < nSensors; i++) {
       // Build the sensor
       Sensor* s = GeometryFactory::make<Sensor>();
       s->parent(this);
       s->myid(i+1);
       s->store(propertyTree());
-      if (sensorNode.count(i+1) > 0) s->store(sensorNode.at(i+1));
-      if (numSensors() == 1 || i >= 2) s->innerOuter(SensorPosition::NO);
-      else s->innerOuter(i == 0 ? SensorPosition::LOWER : SensorPosition::UPPER);
+      if (sensorNode.count(i+1) > 0)
+        s->store(sensorNode.at(i+1));
+      if (nSensors == 1)
+        s->innerOuter(SensorPosition::NO);
+      else
+        s->innerOuter(i == 0 ? SensorPosition::LOWER : SensorPosition::UPPER);
       s->build();
 
       // Add it to the module's list of sensors

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -102,6 +102,7 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
     EndcapModule* mod = GeometryFactory::clone(*templ);
     mod->build();
     mod->translate(XYZVector(modTranslateX, 0, 0));
+    mod->myid(i+1);
 
     double yawAngle = 0;
     bool doYaw = false;
@@ -110,7 +111,7 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
       mod->notInRegularRing();
       yawAngle = mod->yawAngleFromConfig();
     }
-    else if (mod->yawFlip()) {
+    if (mod->yawFlip()) {
       doYaw = true;
       yawAngle += M_PI;
     }
@@ -156,19 +157,23 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
     mod->translateZ(parity * smallDelta);
     mod->setIsSmallerAbsZModuleInRing(parity < 0);
 
-    const bool isFlipped = (!isRingOn4Dees() ? (parity < 0) : isSmallerAbsZRingInDisk());
+    const bool isFlipped = (!isRingOn4Dees() 
+                            ? (parity < 0)                // Two-sided Dees: modules on small |Z| side are flipped
+                            : isSmallerAbsZRingInDisk()); // Four Dees: all modules in the inner ring are flipped
+
     mod->flipped(isFlipped);
     modules_.push_back(mod);
   }
 
-  // Sort the modules in increasing phi and assign their IDs
+  // Sort the modules in increasing phi and set their IDs
   modules_.sort([](const EndcapModule& mod_a, const EndcapModule& mod_b) {
-    // Use femod to properly handle small numerical differences in phi that can arise from the module placement
+    // femod handles small differences in phi in module placement
     double a = femod(mod_a.center().Phi(), 2.0 * M_PI);
     double b = femod(mod_b.center().Phi(), 2.0 * M_PI);
     return a < b;
   });
-  for (size_t id = 0; id < modules_.size(); id++) { modules_[id].myid(id + 1); }
+  for (size_t id = 0; id < modules_.size(); id++)
+    modules_[id].setPhiIdentifier(id + 1);
 }
 
 

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -1,5 +1,6 @@
 #include "Ring.hh"
 #include "MessageLogger.hh"
+#include "global_funcs.hh"
 
 inline void Ring::check() {
   PropertyObject::check();
@@ -83,18 +84,25 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
   double alignmentRotation = alignEdges() ? 0.5 : 0.;
   double deltaPhiNom = 2.*M_PI/numMods;
   double deltaPhiLarge = deltaPhiNom+2*phiShift; //This is the spacing in phi between modules around +/- 90 deg
-  double nominalZRot = 0.;
-  if (deltaPhiLarge!=deltaPhiNom){ deltaPhiNom = deltaPhiNom-(4*phiShift/(numMods-2));} //Adjust nominal module spacing if the spacing between modules around +/- 90 deg is more than the nominal
+  
+  if (deltaPhiLarge != deltaPhiNom) {
+    // Adjust nominal module spacing to keep the same average spacing between modules
+    deltaPhiNom -= 4 * phiShift / (numMods - 2);
+  }
+
   templ->store(propertyTree());
 
   for (int i = 0, parity = smallParity(); i < numMods; i++, parity *= -1) {
-    if (moduleNode.count(i) > 0) {
-     templ->store(moduleNode.at(i)); // Store module config in the template module so we have access to it later
-    } 
+    auto nodeIt = moduleNode.find(i);
+    if (nodeIt != moduleNode.end()) {
+      // Store module config in the template module
+      templ->store(nodeIt->second);
+    }
+
     EndcapModule* mod = GeometryFactory::clone(*templ);
     mod->build();
     mod->translate(XYZVector(modTranslateX, 0, 0));
-    mod->myid(i+1);
+
     double yawAngle = 0;
     bool doYaw = false;
     if (mod->yawAngleFromConfig.state()) {
@@ -102,53 +110,65 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
       mod->notInRegularRing();
       yawAngle = mod->yawAngleFromConfig();
     }
-    if (mod->yawFlip()) {
+    else if (mod->yawFlip()) {
       doYaw = true;
       yawAngle += M_PI;
     }
+
     if (doYaw) {
-      double tmp_r = mod->center().Rho();
-      mod->translateR(-tmp_r); //perform yaw angle rotation with the module at the centre
+      double rho_center = mod->center().Rho();
+
+      mod->translateR(-rho_center);
       mod->yaw(yawAngle);
-      if(mod->manualRhoCentre() > 0 ){// For irregular rings (with yawed modules) that need to stay tangent to the same inner/outer radius, the module centre is shifted
-        mod->translateR(mod->manualRhoCentre()-mod->center().Rho());
-      } else {
-        mod->translateR(tmp_r-mod->center().Rho());
-      }
+
+      if (mod->manualRhoCentre() > 0)
+        mod->translateR(mod->manualRhoCentre());
+      else
+        mod->translateR(rho_center);
     }
-    if (deltaPhiLarge == deltaPhiNom) { //In this case we have uniform phi spacing between the modules
-      nominalZRot = (i + alignmentRotation)*deltaPhiNom;
-    } else { 
-      mod->notInRegularRing();
-      //Ensure larger spacing is used between modules around +/- 90 deg - use pi and not pi/2 to switch between the two calculations as there is a range
-      //translation later and this gives the correct spacing in the end. 
-      if (((i + alignmentRotation)*deltaPhiNom + alignmentRotation*(deltaPhiLarge-deltaPhiNom)) < M_PI ){
-        nominalZRot = (i + alignmentRotation)*deltaPhiNom + alignmentRotation*(deltaPhiLarge-deltaPhiNom);
-      } else {
-        nominalZRot = (i + alignmentRotation)*deltaPhiNom + (1+alignmentRotation)*(deltaPhiLarge-deltaPhiNom);
-      } 
-    }
-    if (mod->manualPhiCenter.state() && mod->manualPhiCenterDeg.state()) {
-        logWARNING("A module was set both manualPhiCenter and manualPhiCenterDeg. Only the former will be considered");
-    }
+
+    if (mod->manualPhiCenter.state() && mod->manualPhiCenterDeg.state())
+      logWARNING("A module was set both manualPhiCenter and manualPhiCenterDeg. Only the former will be considered");
+
+    double nominalZRot = 0.;
     if (mod->manualPhiCenter.state()) {
       nominalZRot = mod->manualPhiCenter();
-    } else if (mod->manualPhiCenterDeg.state()) {
-      nominalZRot = mod->manualPhiCenterDeg() / 180 * M_PI;
     }
-    mod->rotateZ(nominalZRot);
-    mod->rotateZ(zRotation());
-    mod->translateZ(parity*smallDelta);
+    else if (mod->manualPhiCenterDeg.state()) {
+      nominalZRot = mod->manualPhiCenterDeg() * (M_PI / 180.0);
+    }
+    else if (deltaPhiLarge == deltaPhiNom) {
+      // Uniform phi spacing between the modules
+      nominalZRot = (i + alignmentRotation) * deltaPhiNom;
+    }
+    else {
+      // Modules around +/- 90° have a larger spacing 
+      mod->notInRegularRing();
+
+      // Increase rotation for modules in the 1st half of the ring, decrease for those in the 2nd half
+      double diffPhi = deltaPhiLarge - deltaPhiNom;
+      nominalZRot = (i + alignmentRotation) * deltaPhiNom + alignmentRotation * diffPhi;
+      if (nominalZRot >= M_PI)
+        nominalZRot += diffPhi;
+    }
+
+    mod->rotateZ(nominalZRot + zRotation());
+    mod->translateZ(parity * smallDelta);
     mod->setIsSmallerAbsZModuleInRing(parity < 0);
-    const bool isFlipped = (!isRingOn4Dees() ? (parity < 0) // Case where ring modules are placed on both sides of a same dee.
-			                                    // Half of the ring modules are flipped: 
-			                                    // the ones placed with parity < 0, hence on the small |Z| side.
-			    : isSmallerAbsZRingInDisk()); // Case where ring modules are placed on 4 dees.
-                                                          // If the ring is on the small |Z| side with respect to the disk:
-                                                          // all ring modules are flipped.
+
+    const bool isFlipped = (!isRingOn4Dees() ? (parity < 0) : isSmallerAbsZRingInDisk());
     mod->flipped(isFlipped);
-    modules_.push_back(mod);  
+    modules_.push_back(mod);
   }
+
+  // Sort the modules in increasing phi and assign their IDs
+  modules_.sort([](const EndcapModule& mod_a, const EndcapModule& mod_b) {
+    // Use femod to properly handle small numerical differences in phi that can arise from the module placement
+    double a = femod(mod_a.center().Phi(), 2.0 * M_PI);
+    double b = femod(mod_b.center().Phi(), 2.0 * M_PI);
+    return a < b;
+  });
+  for (size_t id = 0; id < modules_.size(); id++) { modules_[id].myid(id + 1); }
 }
 
 

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -36,15 +36,20 @@ const Polygon3d<4>& Sensor::hitPoly() const {
   double offset = sensorNormalOffset();
   hitPoly_ = CoordinateOperations::computeTranslatedPolygon(parent_->basePoly(), offset);
   // Special case for split-sensor modules: sensor's polygon is reduced and shifted along local Y
-  if (parent_->numSensors() > 1 && parent_->sensorLayout() == SensorLayout::MONO) {
+  if (parent_->numSensors() == 2 && parent_->sensorLayout() == SensorLayout::MONO) {
     const XYZVector unitY(parent_->getLocalY());
+
     // Resizing the sensor polygon wrt the module polygon, accounting for the dead space between sensors
     double moduleLength = parent_->length();
     double deadLength = parent_->centralDeadAreaLength();
     double sensorLength = moduleLength / parent_->numSensors() - deadLength / 2.;
     Polygon3d<4> *poly = CoordinateOperations::computeResizedPolygon(*hitPoly_, unitY, sensorLength/moduleLength);
-    // Shifting the sensor
-    double offsetY = -moduleLength/2. + (myid() - 1) * (sensorLength + deadLength) + sensorLength / 2.;
+
+    // UPPER sensor is shifted up in the *local* Y direction
+    double offsetY = (moduleLength - sensorLength) * 0.5;
+    offsetY = innerOuter() == SensorPosition::UPPER ? offsetY : -offsetY;
+
+    // Apply the shift along the local Y direction and update the polygon
     poly->translate(unitY*offsetY);
     delete hitPoly_;
     hitPoly_ = poly;

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -47,7 +47,7 @@ const Polygon3d<4>& Sensor::hitPoly() const {
 
     // UPPER sensor is shifted up in the *local* Y direction
     double offsetY = (moduleLength - sensorLength) * 0.5;
-    offsetY = innerOuter() == SensorPosition::UPPER ? offsetY : -offsetY;
+    offsetY = (innerOuter() == SensorPosition::UPPER) ? offsetY : -offsetY;
 
     // Apply the shift along the local Y direction and update the polygon
     poly->translate(unitY*offsetY);

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -36,7 +36,7 @@ const Polygon3d<4>& Sensor::hitPoly() const {
   double offset = sensorNormalOffset();
   hitPoly_ = CoordinateOperations::computeTranslatedPolygon(parent_->basePoly(), offset);
   // Special case for split-sensor modules: sensor's polygon is reduced and shifted along local Y
-  if (parent_->numSensors() > 1 && innerOuter() == SensorPosition::NO) {
+  if (parent_->numSensors() > 1 && parent_->sensorLayout() == SensorLayout::MONO) {
     const XYZVector unitY(parent_->getLocalY());
     // Resizing the sensor polygon wrt the module polygon, accounting for the dead space between sensors
     double moduleLength = parent_->length();
@@ -46,6 +46,7 @@ const Polygon3d<4>& Sensor::hitPoly() const {
     // Shifting the sensor
     double offsetY = -moduleLength/2. + (myid() - 1) * (sensorLength + deadLength) + sensorLength / 2.;
     poly->translate(unitY*offsetY);
+    delete hitPoly_;
     hitPoly_ = poly;
   }
   return *hitPoly_;


### PR DESCRIPTION
## Add headers

- `boost::ptr_vector` requires a complete `material::SupportStructure` type rather than forward declarations.

## Refactored `DetIdBuilder`

- Replaced magic numbers with variables.
- Added comments.
- Logic cleanup, dead code, deleted unused members, etc.

`tklayout -T -R -w geometries/CMS_Phase2/OT806_IT742.cfg --xml` output matches `upstream/main`.

## DetId mismatch for the L1 split-sensors

CMSSW modified its DetId schema to account for the [reordering of the pixel + L1 split-sensors](https://github.com/cms-sw/cmssw/tree/e957f137deedc9bbf6d6c9af98012970af9e9b37/Geometry/TrackerNumberingBuilder#phase-2-upgrade-detector-detid-schema-modified-to-account-for-the-re-ordering-of-the-pixel--l1-split-sensor), causing tkLayout's pixel sensor DetId list to be 108 entries shorter than CMSSW's.

- Reused the 3D sensors logic for the L1 split-sensors DetId assignment (I'll add some documentation regarding this before marking this PR as "ready for review").
- Also fixed a memory leak in `const Polygon3d<4>& Sensor::hitPoly() const`.

## Coordinate mismatch

tkLayout's pixel sensor lists had non-negligible differences in **Z** ($\delta$ > 0.2 cm) and $\boldsymbol{\varphi}$ ($\delta$ > 1°) placement relative to the CMSSW's pixel sensors list.

<p align="center">
<img width="630" height="470" alt="image" src="https://github.com/user-attachments/assets/29ef3414-7c36-46d8-9923-fa2f6b332129" />
</p>

<table border="1" class="dataframe" align="center">
  <thead>
    <tr>
      <th></th>
      <th></th>
      <th colspan="3" halign="left">Z Difference [cm]</th>
      <th colspan="3" halign="left">R Difference [cm]</th>
      <th colspan="3" halign="left">ϕ Difference [°]</th>
    </tr>
    <tr>
      <th>section</th>
      <th>count</th>
      <th>min</th>
      <th>mean</th>
      <th>max</th>
      <th>min</th>
      <th>mean</th>
      <th>max</th>
      <th>min</th>
      <th>mean</th>
      <th>max</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>TBPX</th>
      <td>108</td>
      <td>-2.205</td>
      <td>0.0</td>
      <td>2.205</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
    </tr>
    <tr>
      <th>TEPX</th>
      <td>704</td>
      <td>-0.8</td>
      <td>0.0</td>
      <td>0.8</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0001</td>
      <td>-18.0</td>
      <td>0.0001</td>
      <td>18.0</td>
    </tr>
    <tr>
      <th>TFPX</th>
      <td>864</td>
      <td>-1.8</td>
      <td>0.0</td>
      <td>1.8</td>
      <td>-0.032</td>
      <td>0.0</td>
      <td>0.032</td>
      <td>-18.1</td>
      <td>0.0</td>
      <td>18.1</td>
    </tr>
  </tbody>
</table>

Further analysis showed that for each CMSSW sensor, a corresponding tkLayout sensor existed in approximately the same position, indicating  that the sensors were mislabeled rather than misplaced.

<p align="center">
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0ffc4201-db20-4156-9a3d-0842c633e68e" />
</p>

### TBPX

L1 upper and lower sensors were inverted, causing a coordinate mismatch along the Z-axis.

- The logic in `Sensor.cc` now correctly applies the offset to split-sensors.

### TEPX and TFPX

`phiRef_` logic in `EndcapDetIdBuilder::visit(EndcapModule& m)` would inverte the location of the odd and even subdisks for some rings/layers.

  - Refactored `Ring.cc`: modules are guaranteed to be assigned IDs with monotonically increasing $\varphi$.
  - `EndcapDetIdBuilder::visit(EndcapModule&)` now uses pre-computed information for the DetId assignment.

Spanning over the entire list after the fix:

<table border="1" class="dataframe", align="center">
  <thead>
    <tr>
      <th></th>
      <th></th>
      <th colspan="3" halign="left">Z Difference [cm]</th>
      <th colspan="3" halign="left">R Difference [cm]</th>
      <th colspan="3" halign="left">ϕ Difference [°]</th>
    </tr>
    <tr>
      <th>section</th>
      <th>count</th>
      <th>min</th>
      <th>mean</th>
      <th>max</th>
      <th>min</th>
      <th>mean</th>
      <th>max</th>
      <th>min</th>
      <th>mean</th>
      <th>max</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>TBPX</th>
      <td>864</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>-0.0001</td>
      <td>0.0</td>
      <td>0.0001</td>
    </tr>
    <tr>
      <th>TEPX</th>
      <td>1408</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0001</td>
      <td>-0.0004</td>
      <td>0.0</td>
      <td>0.0004</td>
    </tr>
    <tr>
      <th>TFPX</th>
      <td>1728</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>-0.0005</td>
      <td>0.0</td>
      <td>0.0005</td>
    </tr>
  </tbody>
</table>