### PR TITLE
Refactor DetectorModule::couldHit for performance

### DIFF
--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -362,9 +362,6 @@ public:
   double maxEta() const { return MAX(basePoly().getVertex(0).Eta(), basePoly().getVertex(2).Eta()); }
   double minEta() const { return MIN(basePoly().getVertex(0).Eta(), basePoly().getVertex(2).Eta()); }
   double etaAperture() const { return maxEta() - minEta(); }
-  double maxEtaWithError(double zError) const { return minMaxEtaWithError(zError).second; }
-  double minEtaWithError(double zError) const { return minMaxEtaWithError(zError).first; }
-  std::pair<double, double> minMaxEtaWithError(double zError) const;
 
   double maxTheta() const { return MAX(basePoly().getVertex(0).Theta(), basePoly().getVertex(2).Theta()); }
   double minTheta() const { return MIN(basePoly().getVertex(0).Theta(), basePoly().getVertex(2).Theta()); }
@@ -424,7 +421,7 @@ int numSegmentsEstimate() const { return sensors().front().numSegmentsEstimate()
   inline bool is3DPixelModule() const { return (isPixelModule() && moduleType().find(insur::type_3D) != std::string::npos); }
   inline bool isTimingModule() const { return (moduleType().find(insur::type_timing) != std::string::npos); }
 
-  bool couldHit(const XYZVector& direction, double zError) const;
+  bool couldHit(double trackPhi, double trackSlope, double zError) const;
   double trackCross(const XYZVector& PL, const XYZVector& PU) { return decorated().trackCross(PL, PU); }
   std::pair<XYZVector, HitType> checkTrackHits(const XYZVector& trackOrig, const XYZVector& trackDir);
   int numHits() const { return numHits_; }
@@ -479,8 +476,6 @@ protected:
   Sensors sensors_;
   std::string subdetectorName_;
   int16_t subdetectorId_;
-  mutable double cachedZError_ = -1.;
-  mutable std::pair<double,double> cachedMinMaxEtaWithError_;
   XYZVector rAxis_;
   double tiltAngle_ = 0.;
   double yawAngle_ = 0.;

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3347,10 +3347,14 @@ void Analyzer::createGeometryLite(Tracker& tracker) {
       static const double BoundaryEtaSafetyMargin = 5. ; // track origin shift in units of zError to compute boundaries
 
       //static std::ofstream ofs("hits.txt");
-      for (auto& m : moduleV) {
+      const double track_phi = direction.Phi();
+      const double track_slope = direction.Z() / direction.R();
+      const double zError = SimParms::getInstance().lumiRegZError() * BoundaryEtaSafetyMargin;
+
+      for (const auto& m : moduleV) {
         // A module can be hit if it fits the phi (precise) contraints
         // and the eta constaints (taken assuming origin within 5 sigma)
-        if (m->couldHit(direction, SimParms::getInstance().lumiRegZError()*BoundaryEtaSafetyMargin)) {
+        if (m->couldHit(track_phi, track_slope, zError)) {
           auto h = m->checkTrackHits(origin, direction); 
           if (h.second != HitType::NONE) {
             result.push_back(std::make_pair(m,h.second));

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "DetectorModule.hh"
 #include "ModuleCap.hh"
 #include "OuterCabling/OuterBundle.hh"
@@ -340,53 +342,35 @@ std::map<std::string, double> DetectorModule::extremaWithHybrids() const {
   }
 
 
-std::pair<double, double> DetectorModule::minMaxEtaWithError(double zError) const {
-  if (cachedZError_ != zError) {
-    cachedZError_ = zError;
-    double eta1 = (XYZVector(0., maxR(), maxZ() + zError)).Eta();
-    double eta2 = (XYZVector(0., minR(), minZ() - zError)).Eta();
-    double eta3 = (XYZVector(0., minR(), maxZ() + zError)).Eta();
-    double eta4 = (XYZVector(0., maxR(), minZ() - zError)).Eta();
-    cachedMinMaxEtaWithError_ = std::minmax({eta1, eta2, eta3, eta4});
-    //cachedMinMaxEtaWithError_ = std::make_pair(MIN(eta1, eta2), MAX(eta1, eta2));
-  }
-  return cachedMinMaxEtaWithError_;
-}
-
-
-bool DetectorModule::couldHit(const XYZVector& direction, double zError) const {
-
-  double eta       = direction.Eta();
-  double phi       = direction.Phi();
-  double shiftPhi  = phi + 2*M_PI;
-  bool   withinEta = false;
-  bool   withinPhi = false;
-
-  // Eta region covered by module
-  if (eta > minEtaWithError(zError) && eta < maxEtaWithError(zError)) withinEta = true;
+bool DetectorModule::couldHit(double trackPhi, double trackSlope, double zError) const {
+  // Checking that hit within a module region works for barrel-type modules only!!!
+  // ATTENTION: For wedge shaped modules, min, max procedure will not work correctly 
+  // -> return true to avoid errors --> will be implemented in the future
+  if (shape() != ModuleShape::RECTANGULAR) return true;
 
   // Phi region is from <-pi;+3*pi> due to crossline at +pi -> need to check phi & phi+2*pi
-  if ( (phi     >=minPhi() && phi     <=maxPhi()) ||
-       (shiftPhi>=minPhi() && shiftPhi<=maxPhi()) ) withinPhi = true;
+  const double modMinPhi = minPhi();
+  const double modMaxPhi = maxPhi();
 
-  // Checking that hit within a module region works for barrel-type modules only!!!
-  if (this->shape()==ModuleShape::RECTANGULAR) return (withinEta && withinPhi);
-  // ATTENTION: For wedge shaped modules, min, max procedure will not work correctly -> return true to avoid errors --> will be implemented in the future
-  else return true;
+  bool validPhi = (trackPhi >= modMinPhi && trackPhi <= modMaxPhi);
+  if (!validPhi) {
+    const double shiftPhi = trackPhi + 2.0 * M_PI;
+    validPhi = (shiftPhi >= modMinPhi && shiftPhi <= modMaxPhi);
+  }
+  if (!validPhi) return false;
+
+  // Eta covered by module
+  const double zMinErr = minZ() - zError;
+  const double zMaxErr = maxZ() + zError;
+  const double rMin = minR();
+  const double rMax = maxR();
+
+  // Calculate the 4 corner slopes and the track's
+  const auto [minSlope, maxSlope] = std::minmax({ zMinErr / rMin, zMinErr / rMax, 
+                                                  zMaxErr / rMin, zMaxErr / rMax });
+
+  return (trackSlope >= minSlope || trackSlope <= maxSlope);
 }
-
-//bool DetectorModule::couldHit(const XYZVector& direction, double zError) const {
-//  double eta = direction.Eta(), phi = direction.Phi();
-//  bool withinEta = eta > minEtaWithError(zError) && eta < maxEtaWithError(zError);
-//  bool withinPhi;
-//  if (minPhi() < 0. && maxPhi() > 0. && maxPhi()-minPhi() > M_PI) // across PI
-//    withinPhi = phi < minPhi() || phi > maxPhi();
-//  else 
-//    withinPhi = phi > minPhi() && phi < maxPhi();
-//  //bool withinPhiSub = phi-2*M_PI > minPhi() && phi-2*M_PI < maxPhi();
-//  //bool withinPhiAdd = phi+2*M_PI > minPhi() && phi+2*M_PI < maxPhi();
-//  return withinEta && (withinPhi /*|| withinPhiSub || withinPhiAdd*/);
-//}
 
 
 /*


### PR DESCRIPTION
`Analyzer::createGeometryLite` has to make multiple calls to`DetectorModule::couldHit` when simulating a large number of tracks, creating a CPU intensive region.

# TLDR

Evaluated the performance of the program with

```
tklayout --performance -a -N 3000 -n 50000 -T -R -w geometries/CMS_Phase2/OT807_IT744.cfg
```

Summary of Refactor Results:

- **Geometry Analysis Time:** Dropped from **87.7s to 39.5s (-54.9%)**
- **Total CPU Instructions:** Reduced from **1.398 trillion to 1.170 trillion (-16.3%)**
- **Total Branches:** Reduced from **260.3 billion to 212.8 billion (-18.2%)**
- **L1 Loads:** Dropped from **364.6 billion to 316.8 billion (-13.1%)**
- **LLC Loads:** Reduced from **8.74 billion to 8.52 billion (-2.5%)**
- **LLC Miss Rate:** Improved from **39.8% to 29.9% (-9.9%)**

# Current `main` branch

- The hit calculation currently uses 3 different functions for something that can be done in 1. 
- `DetectorModule::minMaxEtaWithError` instantiates 4 rvalue objects per call just for calculating `eta`.
- `DetectorModule::minMaxEtaWithError` is redundantly called twice (implicitly) in [DetectorModule.cc:366](https://github.com/tkLayout/tkLayout/blob/main/src/DetectorModule.cc#L366).

## Metrics

### Execution log highlights

``` bash
...

Analyzing geometry ... done [in 87.7363 s]

...
```

### `perf stat` highlights

``` bash
 Performance counter stats for 'tklayout --performance -a -N 3000 -n 50000 -T -R -w geometries/CMS_Phase2/OT807_IT744.cfg':

        232,720.85 msec task-clock:HGu                   #    0.994 CPUs utilized             

...

 1,079,846,078,508      cycles:HGu                       #    4.640 GHz                         (81.82%)
 1,398,150,749,360      instructions:HGu                 #    1.29  insn per cycle              (90.91%)
   260,178,210,150      branches:HGu                     #    1.118 G/sec                       (90.91%)
     1,214,262,151      branch-misses:HGu                #    0.47% of all branches             (81.82%)

...

   364,628,021,700      L1-dcache-loads:HGu              #    1.567 G/sec                       (90.91%)
    18,236,579,029      L1-dcache-load-misses:HGu        #    5.00% of all L1-dcache accesses   (90.91%)
     8,735,841,292      LLC-loads:HGu                    #   37.538 M/sec                       (90.91%)
     3,477,960,686      LLC-load-misses:HGu              #   39.81% of all LL-cache accesses    (90.91%)

     234.151008320 seconds time elapsed

     228.928908000 seconds user
       1.920128000 seconds sys
```

# After refactoring

- Changed the phi/eta evaluation order in `DetectorModule::couldHit` for improved branching logic.
- `DetectorModule::couldHit` now evaluates the RZ slope of the track against the slope of the corners of the modules. This allows for indirectly evaluating the`eta` hit, improving cache locality and avoiding expensive computations.
- `DetectorModule::couldHit` now uses scalar values that are calculated once outside the `Analyzer::createGeometryLite` loop.

## Metrics

### Execution log highlights

``` bash
...

Analyzing geometry ... done [in 39.4802 s]

...
```

### `perf stat` highlights

``` bash
 Performance counter stats for 'tklayout --performance -a -N 3000 -n 50000 -T -R -w geometries/CMS_Phase2/OT807_IT744.cfg':

        180,002.99 msec task-clock:HGu                   #    0.993 CPUs utilized             

...

   836,737,176,319      cycles:HGu                       #    4.648 GHz                         (81.82%)
 1,170,381,861,708      instructions:HGu                 #    1.40  insn per cycle              (90.91%)
   212,840,213,760      branches:HGu                     #    1.182 G/sec                       (90.91%)
     1,107,057,740      branch-misses:HGu                #    0.52% of all branches             (81.82%)

...

   316,808,162,079      L1-dcache-loads:HGu              #    1.760 G/sec                       (90.92%)
    17,269,398,049      L1-dcache-load-misses:HGu        #    5.45% of all L1-dcache accesses   (90.91%)
     8,519,953,535      LLC-loads:HGu                    #   47.332 M/sec                       (90.91%)
     2,551,207,570      LLC-load-misses:HGu              #   29.94% of all LL-cache accesses    (90.91%)

     181.348170405 seconds time elapsed

     176.503683000 seconds user
       1.970605000 seconds sys
```