### PR TITLE
IT cabling map fixes and e-links update

### DIFF
--- a/include/InnerCabling/GBT.hh
+++ b/include/InnerCabling/GBT.hh
@@ -24,13 +24,18 @@ class GBT : public PropertyObject, public Buildable, public Identifiable<int> {
   typedef std::vector<Module*> Container; 
 
 public:
-  GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndexColor, const int numELinksPerModule);
+  GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndexColor);
 
   // MODULES CONNECTED TO THE GBT
   const Container& modules() const { return modules_; }
-  const int numModules() const { return modules_.size(); }
-  void addModule(Module* m);
-  const int numELinks() const { return numELinksPerModule_ * numModules(); } 
+  int numModules() const { return modules_.size(); }
+  void addModule(Module* m, const int numELinks);
+  int numELinks() const {
+    int numELinks = 0;
+    for (const auto& m : modules_)
+      numELinks += m->numELinks();
+    return numELinks;
+  }
 
   // BUNDLE TO WHICH THE GBT IS CONECTED
   void setBundle(InnerBundle* bundle) { myBundle_ = bundle; }
@@ -52,7 +57,6 @@ public:
   const int getCMSSWId() const { return myGBTCMSSWId_; }
   const int GBTIndexInPowerChain() const { return myGBTIndexInPowerChain_; } // GBT location index in power chain
   const int plotStyleGBTIndexInPowerChain() const { return plotStyleGBTIndexInPowerChain_; } // GBT plotting style
-  const int numELinksPerModule() const { return numELinksPerModule_; }
   
   const bool isPositiveZEnd() const { return myPowerChain_->isPositiveZEnd(); }
   const bool isPositiveXSide() const { return myPowerChain_->isPositiveXSide(); }
@@ -83,7 +87,6 @@ private:
   int myGBTCMSSWId_;
   int myGBTIndexInPowerChain_;
   int plotStyleGBTIndexInPowerChain_;
-  int numELinksPerModule_;
 
   int plotPowerChainColor_;
 };

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -35,22 +35,21 @@ private:
 
   // CONNECT MODULES TO GBTS
   const std::pair<int, double> computeNumGBTsInPowerChain(const int numELinksPerModule, const int numModulesInPowerChain, const bool isBarrel);
-  const int computeGBTIndexInPowerChain(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
-  const int computeGBTIndexInSpecialPowerChain(const int ringRef, const int numELinks, const int phiRefInPowerChain, const int phiRef) const;
-  const std::string computeGBTId(const int powerChainId, const int myGBTIndex) const;
+  int computeGBTIndexInPowerChain(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
+  int computeGBTIndexInSpecialPowerChain(const int ringRef, const int numELinks, const int phiRefInPowerChain, const int phiRef) const;
   void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
   void connectOneModuleToOneGBT(Module* m, GBT* GBT) const;
   void checkModulesToGBTsCabling(const std::map<std::string, std::unique_ptr<GBT> >& GBTs) const;
 
   // CONNECT GBTs TO BUNDLES
-  const int computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const;
-  const int computeBundleId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex) const;
+  int computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const;
+  int computeBundleId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex) const;
   void createAndStoreBundles(GBT* myGBT, std::map<int, std::unique_ptr<InnerBundle> >& bundles, const int bundleId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex);
   void connectOneGBTToOneBundle(GBT* myGBT, InnerBundle* myBundle) const;
   void checkGBTsToBundlesCabling(const std::map<int, std::unique_ptr<InnerBundle> >& bundles) const;
 
   // CONNECT BUNDLES TO DTCS
-  const int computeDTCId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber) const;
+  int computeDTCId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber) const;
   void createAndStoreDTCs(InnerBundle* myBundle, std::map<int, std::unique_ptr<InnerDTC> >& DTCs, const int DTCId, const bool isPositiveZEnd, const bool isPositiveXSide);
   void connectOneBundleToOneDTC(InnerBundle* myBundle, InnerDTC* myDTC) const;
   void computeCMSSWIds(std::map<int, std::unique_ptr<InnerDTC> >& DTCs);

--- a/include/InnerCabling/InnerCablingMap.hh
+++ b/include/InnerCabling/InnerCablingMap.hh
@@ -37,21 +37,18 @@ private:
   const std::pair<int, double> computeNumGBTsInPowerChain(const int numELinksPerModule, const int numModulesInPowerChain, const bool isBarrel);
   int computeGBTIndexInPowerChain(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double maxNumModulesPerGBTInPowerChain, const int numGBTsInPowerChain) const;
   int computeGBTIndexInSpecialPowerChain(const int ringRef, const int numELinks, const int phiRefInPowerChain, const int phiRef) const;
-  void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
-  void connectOneModuleToOneGBT(Module* m, GBT* GBT) const;
+  void createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndex, const int numELinks, std::map<std::string, std::unique_ptr<GBT> >& GBTs);
   void checkModulesToGBTsCabling(const std::map<std::string, std::unique_ptr<GBT> >& GBTs) const;
 
   // CONNECT GBTs TO BUNDLES
   int computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const;
   int computeBundleId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex) const;
   void createAndStoreBundles(GBT* myGBT, std::map<int, std::unique_ptr<InnerBundle> >& bundles, const int bundleId, const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex);
-  void connectOneGBTToOneBundle(GBT* myGBT, InnerBundle* myBundle) const;
   void checkGBTsToBundlesCabling(const std::map<int, std::unique_ptr<InnerBundle> >& bundles) const;
 
   // CONNECT BUNDLES TO DTCS
   int computeDTCId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber) const;
   void createAndStoreDTCs(InnerBundle* myBundle, std::map<int, std::unique_ptr<InnerDTC> >& DTCs, const int DTCId, const bool isPositiveZEnd, const bool isPositiveXSide);
-  void connectOneBundleToOneDTC(InnerBundle* myBundle, InnerDTC* myDTC) const;
   void computeCMSSWIds(std::map<int, std::unique_ptr<InnerDTC> >& DTCs);
   void checkBundlesToDTCsCabling(const std::map<int, std::unique_ptr<InnerDTC> >& DTCs) const;
 

--- a/include/InnerCabling/inner_cabling_constants.hh
+++ b/include/InnerCabling/inner_cabling_constants.hh
@@ -3,6 +3,9 @@
 
 #include <math.h>
 #include <string>
+#include <string_view>
+#include <vector>
+#include <unordered_map>
 #include "global_funcs.hh"
 #include "OuterCabling/outer_cabling_constants.hh"
 
@@ -19,32 +22,25 @@ static const int inner_cabling_maxNumGBTsPerBundle = 12;
 // Maximum number of bundles per cable
 static const int inner_cabling_maxNumBundlesPerCable = 6;
 
+// GEOMETRY NAMES
+// The cabling map is geometry-dependent, hence the subdetector names are placed here.
+static const std::string inner_cabling_tbpx = "TBPX";
+static const std::string inner_cabling_tfpx = "TFPX";
+static const std::string inner_cabling_tepx = "TEPX";
 
 // READOUT 1.28 GB/s E-LINKS
-static const int inner_cabling_numELinksPerModuleBarrelLayer1 = 6;
-static const int inner_cabling_numELinksPerModuleBarrelLayer2 = 2;
-static const int inner_cabling_numELinksPerModuleBarrelLayer3 = 2;
-static const int inner_cabling_numELinksPerModuleBarrelLayer4 = 1;
-
-static const int inner_cabling_numELinksPerModuleForwardRing1 = 3;
-static const int inner_cabling_numELinksPerModuleForwardRing2 = 3;
-static const int inner_cabling_numELinksPerModuleForwardRing3 = 2;
-static const int inner_cabling_numELinksPerModuleForwardRing4 = 2;
-
-static const int inner_cabling_numELinksPerModuleEndcapRing1 = 4;
-static const int inner_cabling_numELinksPerModuleEndcapRing2 = 3;
-static const int inner_cabling_numELinksPerModuleEndcapRing3 = 2;
-static const int inner_cabling_numELinksPerModuleEndcapRing4 = 2;
-static const int inner_cabling_numELinksPerModuleEndcapRing5 = 1;
-
+// Each value's index corresponds to the specific layer (TBPX) or disk (TFPX/TEPX) number.
+static const std::unordered_map<std::string_view, std::unordered_map<int, int>> inner_cabling_numELinksPerModule = {
+  {inner_cabling_tbpx, {{1, 6}, {2, 2}, {3, 2}, {4, 1}}},
+  {inner_cabling_tfpx, {{1, 3}, {2, 3}, {3, 2}, {4, 2}}},
+  {inner_cabling_tepx, {{1, 4}, {2, 3}, {3, 2}, {4, 2}, {5, 1}}}
+};
 
 // MAX NUMBER OF POWER CHAINS PER FIBER BUNDLE, in TBPX
-// This would be uselessly complicated to make this automatic.
-static const int maxNumPowerChainsPerBundleBarrelLayer1 = 1;
-static const int maxNumPowerChainsPerBundleBarrelLayer2 = 3;
-static const int maxNumPowerChainsPerBundleBarrelLayer3 = 3;
-static const int maxNumPowerChainsPerBundleBarrelLayer4 = 4;
-
+// Each key corresponds to the specific layer number.
+static const std::unordered_map<int, int> maxPowerChainsPerBundleTBPX = {
+  {1, 1}, {2, 3}, {3, 3}, {4, 4}
+};
 
 // POWER CHAIN TYPE
 // 4 ampere or 8 ampere.
@@ -53,14 +49,6 @@ enum PowerChainType { IUNDEFINED, I4A, I8A };
 
 // ROUNDING
 static const double inner_cabling_roundingTolerance = outer_cabling_roundingTolerance;
-
-
-// GEOMETRY NAMES
-// The cabling map is geometry-dependent, hence the subdetector names are placed here.
-static const std::string inner_cabling_tbpx = "TBPX";
-static const std::string inner_cabling_tfpx = "TFPX";
-static const std::string inner_cabling_tepx = "TEPX";
-
 
 // CMSSW IDS
 // Total number of DTCs in OT

--- a/include/InnerCabling/inner_cabling_functions.hh
+++ b/include/InnerCabling/inner_cabling_functions.hh
@@ -6,6 +6,7 @@
 #include "InnerCabling/inner_cabling_constants.hh"
 #include "MessageLogger.hh"
 
+#include <cstddef>
 
 namespace inner_cabling_functions {
 
@@ -25,7 +26,7 @@ namespace inner_cabling_functions {
   const bool isSmallerAbsZHalfRing(const int halfRingIndex);
 
   // compute number of ELinks per module
-  const int computeNumELinksPerModule(const std::string subDetectorName, const int layerOrRingNumber);
+  std::size_t computeNumELinksPerModule(const std::string& subDetectorName, const std::size_t layerOrRingNumber);
 }
 
 

--- a/include/InnerCabling/inner_cabling_functions.hh
+++ b/include/InnerCabling/inner_cabling_functions.hh
@@ -26,7 +26,7 @@ namespace inner_cabling_functions {
   const bool isSmallerAbsZHalfRing(const int halfRingIndex);
 
   // compute number of ELinks per module
-  std::size_t computeNumELinksPerModule(const std::string& subDetectorName, const std::size_t layerOrRingNumber);
+  std::size_t computeNumELinksModule(const std::string& subDetectorName, std::size_t layerOrRingNumber, int phiRefInPowerChain);
 }
 
 

--- a/src/AnalyzerVisitors/GeometricInfo.cc
+++ b/src/AnalyzerVisitors/GeometricInfo.cc
@@ -650,7 +650,7 @@ void InnerTrackerModulesToDTCsVisitor::preVisit() {
              "Module_Layer/I,Module_Ring/I,Module_phi_deg/D," \
              "N_Chips_Per_Module/I,N_Channels_Per_Module/I," \
              "Is_LongBarrel/O,Power_Chain/I,Power_Chain_Type/C," \
-             "N_ELinks_Per_Module/I,LpGBT_Id/C,LpGBT_CMSSW_IdPerDTC/U," \
+             "N_ELinks/I,LpGBT_Id/C,LpGBT_CMSSW_IdPerDTC/U," \
              "MFB/I,DTC_Id/I,DTC_CMSSW_Id/U," \
              "IsPlusZEnd/O,IsPlusXSide/O\n"
           << std::fixed << std::setprecision(6);
@@ -703,11 +703,11 @@ void InnerTrackerModulesToDTCsVisitor::visit(const Module& m) {
 
     // GBT info
     if (myGBT) {
-      // Separate logic for the L1 TBPX (can we please add an enum for the module subtype?)
-      const int numElinks = (m.moduleSubType() == 1) ? myGBT->numELinksPerModule() / 2
-                                                     : myGBT->numELinksPerModule();
+      // Generalization logic for the TBPX-L1
+      const int numElinksPerModule = m.numELinks();
+      const int numElinksPerDetId = numElinksPerModule / m.numSensors();
 
-      output_ << numElinks << ","
+      output_ << numElinksPerDetId << ","
               << any2str(myGBT->GBTId()) << ","
               << myGBT->getCMSSWId()<< ",";
     }

--- a/src/InnerCabling/GBT.cc
+++ b/src/InnerCabling/GBT.cc
@@ -2,12 +2,11 @@
 #include "InnerCabling/InnerBundle.hh"
 
 
-GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndexInPowerChain, const int numELinksPerModule) :
+GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndexInPowerChain) :
   myGBTId_(GBTId),
   myGBTCMSSWId_(0), // Need to have consecutive integers, hence is done after full cabling map is created.
   myGBTIndexInPowerChain_(myGBTIndexInPowerChain),
-  plotStyleGBTIndexInPowerChain_(computePlotStyleGBTIndexInPowerChain(myGBTIndexInPowerChain, myPowerChain)),
-  numELinksPerModule_(numELinksPerModule)
+  plotStyleGBTIndexInPowerChain_(computePlotStyleGBTIndexInPowerChain(myGBTIndexInPowerChain, myPowerChain))
 {
   myPowerChain_ = myPowerChain;
   plotPowerChainColor_ = computePlotColor(myPowerChain);
@@ -17,7 +16,10 @@ GBT::GBT(PowerChain* myPowerChain, const std::string GBTId, const int myGBTIndex
 /*
  *  Assign a module to the GBT.
  */
-void GBT::addModule(Module* m) { 
+void GBT::addModule(Module* m, const int numELinks) {
+  if (m == nullptr) throw PathfulException("GBT::addModule Error: Module pointer is nullptr");
+  m->setGBT(this);
+  m->setNumELinks(numELinks);
   modules_.push_back(m);
 }
 

--- a/src/InnerCabling/InnerBundle.cc
+++ b/src/InnerCabling/InnerBundle.cc
@@ -19,7 +19,9 @@ InnerBundle::InnerBundle(const int bundleId, const bool isPositiveZEnd, const bo
 /*
  *  Connect a GBT to the Bundle.
  */
-void InnerBundle::addGBT(GBT* myGBT) { 
+void InnerBundle::addGBT(GBT* myGBT) {
+  if (myGBT == nullptr) throw PathfulException("InnerBundle::addGBT Error: GBT pointer is nullptr");
+  myGBT->setBundle(this);
   GBTs_.push_back(myGBT);
 }
 

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -84,9 +84,6 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
      } else {
         // Loops on all modules of the power chain
         for (auto& m : myPowerChain->modules()) {
-          // SET NUMBER OF ELINKS PER MODULE
-          m->setNumELinks(numELinksPerModule);
-
           // COLLECT MODULE INFORMATION NEEDED TO BUILD GBT
           const int ringRef = (myPowerChain->isLongBarrel() ? m->uniRef().ring - 1
                                                             : m->uniRef().ring - 2);
@@ -209,25 +206,16 @@ int InnerCablingMap::computeGBTIndexInSpecialPowerChain(const int ringRef, const
 /* Create a GBT, if does not exist yet.
  * Store it in the GBTs container.
  */
-void InnerCablingMap::createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndexInPowerChain, const int numELinksPerModule, std::map<std::string, std::unique_ptr<GBT> >& GBTs) {
-
+void InnerCablingMap::createAndStoreGBTs(PowerChain* myPowerChain, Module* m, const std::string myGBTId, const int myGBTIndexInPowerChain, const int numELinks, std::map<std::string, std::unique_ptr<GBT> >& GBTs) {
   auto found = GBTs.find(myGBTId);
   if (found == GBTs.end()) {
-    std::unique_ptr<GBT> myGBT(new GBT(myPowerChain, myGBTId, myGBTIndexInPowerChain, numELinksPerModule));
-    connectOneModuleToOneGBT(m, myGBT.get());
+    std::unique_ptr<GBT> myGBT(new GBT(myPowerChain, myGBTId, myGBTIndexInPowerChain));
+    myGBT->addModule(m, numELinks);
     GBTs.insert(std::make_pair(myGBTId, std::move(myGBT)));  
   }
   else {
-    connectOneModuleToOneGBT(m, found->second.get());
+    found->second->addModule(m, numELinks);
   }
-}
-
-
-/* Connect module to GBT and vice-versa.
- */
-void InnerCablingMap::connectOneModuleToOneGBT(Module* m, GBT* myGBT) const {
-  myGBT->addModule(m);
-  m->setGBT(myGBT);
 }
 
 
@@ -332,22 +320,13 @@ void InnerCablingMap::createAndStoreBundles(GBT* myGBT, std::map<int, std::uniqu
   auto found = bundles.find(bundleId);
   if (found == bundles.end()) {
     std::unique_ptr<InnerBundle> myBundle(new InnerBundle(bundleId, isPositiveZEnd, isPositiveXSide, subDetectorName, layerDiskNumber, myBundleIndex));
-    connectOneGBTToOneBundle(myGBT, myBundle.get());
+    myBundle->addGBT(myGBT);
     bundles.insert(std::make_pair(bundleId, std::move(myBundle)));  
   }
   else {
-    connectOneGBTToOneBundle(myGBT, found->second.get());
+    found->second->addGBT(myGBT);
   }
 }
-
-
-/* Connect GBT to Bundle and vice-versa.
- */
-void InnerCablingMap::connectOneGBTToOneBundle(GBT* myGBT, InnerBundle* myBundle) const {
-  myBundle->addGBT(myGBT);
-  myGBT->setBundle(myBundle);
-}
-
 
 /* Check GBTs-Bundle connections.
  */
@@ -439,20 +418,12 @@ void InnerCablingMap::createAndStoreDTCs(InnerBundle* myBundle, std::map<int, st
   auto found = DTCs.find(DTCId);
   if (found == DTCs.end()) {
     std::unique_ptr<InnerDTC> myDTC(new InnerDTC(DTCId, isPositiveZEnd, isPositiveXSide));
-    connectOneBundleToOneDTC(myBundle, myDTC.get());
+    myDTC->addBundle(myBundle);
     DTCs.insert(std::make_pair(DTCId, std::move(myDTC)));  
   }
   else {
-    connectOneBundleToOneDTC(myBundle, found->second.get());
+    found->second->addBundle(myBundle);
   }
-}
-
-
-/* Connect Bundle to DTC and vice-versa.
- */
-void InnerCablingMap::connectOneBundleToOneDTC(InnerBundle* myBundle, InnerDTC* myDTC) const {
-  myDTC->addBundle(myBundle);
-  myBundle->setDTC(myDTC);
 }
 
 

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -1,6 +1,8 @@
 #include "InnerCabling/InnerCablingMap.hh"
 #include <Tracker.hh>
 
+#include <string>
+
 
 /*
  * KEY POINT: CREATE THE INNER TRACKER CABLING MAP.
@@ -48,12 +50,13 @@ void InnerCablingMap::connectModulesToPowerChains(Tracker* tracker) {
  * As a result, one can just 'split' the modules of a given power chain and assign them to GBTs.
  */
 void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerChain> >& powerChains, std::map<std::string, std::unique_ptr<GBT> >& GBTs) {
+  auto computeGBTId = [](const int powerChainId, const int GBTIndexInPowerChain) -> std::string {
+    return std::to_string(powerChainId) + "_" + std::to_string(GBTIndexInPowerChain);
+  };
 
   // Loops on all power chains
-  for (auto& it : powerChains) {
-
-    // COLLECT GENERAL INFORMATION NEEDED TO BUILD GBTS   
-    PowerChain* myPowerChain = it.second.get();
+  for (const auto& [powerChainId, powerChainPtr] : powerChains) {
+    PowerChain* myPowerChain = powerChainPtr.get();
 
     const bool isBarrel = myPowerChain->isBarrel();
     const std::string subDetectorName = myPowerChain->subDetectorName();
@@ -64,22 +67,16 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
     const int layerOrRingNumber = (isBarrel ? layerNumber : ringNumber);
     const int numELinksPerModule = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, layerOrRingNumber);
 
-    std::pair<int, double> gbtsInPowerChain = computeNumGBTsInPowerChain(numELinksPerModule, numModulesInPowerChain, isBarrel);
-    const int numGBTsInPowerChain = gbtsInPowerChain.first;
-    const double numModulesPerGBTExact = gbtsInPowerChain.second;
+    auto [numGBTsInPowerChain, numModulesPerGBTExact] = computeNumGBTsInPowerChain(numELinksPerModule, numModulesInPowerChain, isBarrel);
     myPowerChain->setNumGBTsInPowerChain(numGBTsInPowerChain);
     const bool isSplitOverRings = myPowerChain->isSplitOverRings(); //If isSplitOverRings is true the power chain covers multiple rings; in that case we need a more hacky way to compute the correct lpGBT assignment
-   
-    const int powerChainId = myPowerChain->myid();
-    const bool isLongBarrel = myPowerChain->isLongBarrel();
-
 
     if (isSplitOverRings) {
         const int phiRef = myPowerChain->phiRef();
         for (auto& m: myPowerChain->modules()) {
             int ringRef = m->uniRef().ring;
             int phiRefInPowerChain = m->getPhiRefInPowerChain();
-            std::size_t numELinks = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, ringRef); 
+            int numELinks = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, ringRef); 
             int gbtIndex = computeGBTIndexInSpecialPowerChain(ringRef, numELinks, phiRefInPowerChain, phiRef);
             const std::string myGBTId = computeGBTId(powerChainId, gbtIndex);
             createAndStoreGBTs(myPowerChain, m, myGBTId, gbtIndex, numELinks, GBTs);
@@ -87,14 +84,13 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
      } else {
         // Loops on all modules of the power chain
         for (auto& m : myPowerChain->modules()) {
-
           // SET NUMBER OF ELINKS PER MODULE
           m->setNumELinks(numELinksPerModule);
 
           // COLLECT MODULE INFORMATION NEEDED TO BUILD GBT
-          const int ringRef = (isLongBarrel ? m->uniRef().ring - 1 : m->uniRef().ring - 2);
+          const int ringRef = (myPowerChain->isLongBarrel() ? m->uniRef().ring - 1
+                                                            : m->uniRef().ring - 2);
           const int phiRefInPowerChain = m->getPhiRefInPowerChain();
-      
           const int myGBTIndexInPowerChain = computeGBTIndexInPowerChain(isBarrel, numModulesInPowerChain, ringRef, phiRefInPowerChain, numModulesPerGBTExact, numGBTsInPowerChain);
           const std::string myGBTId = computeGBTId(powerChainId, myGBTIndexInPowerChain);
 
@@ -137,90 +133,76 @@ const std::pair<int, double> InnerCablingMap::computeNumGBTsInPowerChain(const i
   return std::make_pair(numGBTs, numModulesPerGBTExact);
 }
 
-
-
-/* Compute the index associated to each GBT in each power chain.
- */
-const int InnerCablingMap::computeGBTIndexInPowerChain(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double numModulesPerGBTExact, const int numGBTsInPowerChain) const {
+/* Compute the index associated to each GBT in each power chain. */
+int InnerCablingMap::computeGBTIndexInPowerChain(const bool isBarrel, const int numModulesInPowerChain, const int ringRef, const int phiRefInPowerChain, const double numModulesPerGBTExact, const int numGBTsInPowerChain) const {
+  if (std::abs(numModulesPerGBTExact) < inner_cabling_roundingTolerance) { 
+    logERROR(any2str("Found numModulesPerGBTExact ~ 0.")); 
+    return 0;
+  }
 
   // For one barrel ladder out of 2 (identified by phiRefInPowerChain), 
   // index modules from max |Z| to |Z| ~ 0, instead of from |Z| ~ 0 to max |Z|
-  const int barrelModuleRef = (phiRefInPowerChain == 0 ? ringRef : numModulesInPowerChain - ringRef - 1);
-  const int moduleRef = (isBarrel ? barrelModuleRef : phiRefInPowerChain);
+  const int barrelModuleRef = (phiRefInPowerChain == 0) ? ringRef : (numModulesInPowerChain - ringRef - 1);
+  const int moduleRef = isBarrel ? barrelModuleRef : phiRefInPowerChain;
+  const double exactIndex = moduleRef / numModulesPerGBTExact;
 
-  if (fabs(numModulesPerGBTExact) < inner_cabling_roundingTolerance) { logERROR(any2str("Found numModulesPerGBTExact ~ 0.")); }
+  int gbtIndex = (std::abs(exactIndex - std::round(exactIndex)) < inner_cabling_roundingTolerance) ? 
+        static_cast<int>(std::round(exactIndex)) : 
+        static_cast<int>(std::floor(exactIndex));
 
-  const double myGBTIndexInPowerChainExact = moduleRef / numModulesPerGBTExact;
-  int myGBTIndexInPowerChain = (fabs(myGBTIndexInPowerChainExact - round(myGBTIndexInPowerChainExact)) < inner_cabling_roundingTolerance ? 
-				round(myGBTIndexInPowerChainExact) 
-				: std::floor(myGBTIndexInPowerChainExact)
-				);
-
-  if (isBarrel && numGBTsInPowerChain >= 3 && (femod(numGBTsInPowerChain, 2) == 0) && barrelModuleRef == 2 && myGBTIndexInPowerChain == 0) {
-    myGBTIndexInPowerChain += 1;
+  if (isBarrel && (numGBTsInPowerChain >= 3) && (numGBTsInPowerChain % 2 == 0) && (barrelModuleRef == 2) && (gbtIndex == 0)) {
+    gbtIndex++;
   }
 
-  return myGBTIndexInPowerChain;
+  return gbtIndex;
 }
 
-const int InnerCablingMap::computeGBTIndexInSpecialPowerChain(const int ringRef, const int numELinks, const int phiRefInPowerChain, const int phiRef) const {
-  int numModulesPerGBT;
-  int myGBTIndexInPowerChain = 0;
-  if(ringRef == 3 ){  
-    if(phiRef==0){
-      numModulesPerGBT = inner_cabling_maxNumELinksPerGBT/numELinks;
-    } else {
-      numModulesPerGBT = inner_cabling_maxNumELinksPerGBT/numELinks-1;
+int InnerCablingMap::computeGBTIndexInSpecialPowerChain(const int ringRef, const int numELinks, const int phiRefInPowerChain, const int phiRef) const {
+  auto calculateIndex = [this](int numerator, int denominator) -> int {
+    if (denominator == 0) return 0; // Fallback
+
+    double exact = static_cast<double>(numerator) / denominator; 
+    return (std::abs(exact - std::round(exact)) < inner_cabling_roundingTolerance) ?
+          static_cast<int>(std::round(exact)) : 
+          static_cast<int>(std::floor(exact));
+  };
+
+  switch (ringRef) {
+  case 2: {
+    if (phiRef == 0) {
+      return (phiRefInPowerChain <= 1) ? 0 : (phiRefInPowerChain - 1);
     }
-    double myGBTIndexInPowerChainExact = phiRefInPowerChain/numModulesPerGBT;
-    myGBTIndexInPowerChain = (fabs(myGBTIndexInPowerChainExact - round(myGBTIndexInPowerChainExact)) < inner_cabling_roundingTolerance ?
-                                round(myGBTIndexInPowerChainExact) : std::floor(myGBTIndexInPowerChainExact));
-  } else if (ringRef == 5 ) {
-    numModulesPerGBT = inner_cabling_maxNumELinksPerGBT/numELinks;
-    double myGBTIndexInPowerChainExact = phiRefInPowerChain/numModulesPerGBT;
-    myGBTIndexInPowerChain = (fabs(myGBTIndexInPowerChainExact - round(myGBTIndexInPowerChainExact)) < inner_cabling_roundingTolerance ?
-                                2 + round(myGBTIndexInPowerChainExact) : 2 + std::floor(myGBTIndexInPowerChainExact)); //hack
-  } else {
-    if(ringRef==2){   
-        if(phiRef==0){
-            if(phiRefInPowerChain<=1){
-                myGBTIndexInPowerChain = 0;
-            } else {
-                myGBTIndexInPowerChain = phiRefInPowerChain-1; 
-            }
-        } else myGBTIndexInPowerChain = phiRefInPowerChain;
-    }    
-    if(ringRef==4){
-        if(phiRef==0){
-            if(phiRefInPowerChain==0){
-                myGBTIndexInPowerChain=0;
-            } else if (phiRefInPowerChain<=2){
-                myGBTIndexInPowerChain=1;
-            } else if (phiRefInPowerChain<=4){
-                myGBTIndexInPowerChain=2;
-            }
-        } else {
-            if(phiRefInPowerChain<=1){
-                myGBTIndexInPowerChain=0;
-            } else if (phiRefInPowerChain<=3){
-                myGBTIndexInPowerChain=1;
-            } else if (phiRefInPowerChain<=5){
-                myGBTIndexInPowerChain=2;
-            }
-        }
-    }
+    return phiRefInPowerChain;
   }
- return myGBTIndexInPowerChain;
-}
 
+  case 3: {
+    int numModulesPerGBT = (inner_cabling_maxNumELinksPerGBT / numELinks) - static_cast<int>(phiRef != 0);
+    return calculateIndex(phiRefInPowerChain, numModulesPerGBT);
+  }
 
-/* Compute the Id associated to each GBT.
- */
-const std::string InnerCablingMap::computeGBTId(const int powerChainId, const int myGBTIndexInPowerChain) const {
-  std::ostringstream GBTIdStream;
-  GBTIdStream << powerChainId << "_" << myGBTIndexInPowerChain;
-  const std::string GBTId = GBTIdStream.str();
-  return GBTId;
+  case 4: {
+    if (phiRef == 0) {
+      if (phiRefInPowerChain == 0) return 0;
+      if (phiRefInPowerChain <= 2) return 1;
+      if (phiRefInPowerChain <= 4) return 2;
+    }
+    else {
+      if (phiRefInPowerChain <= 1) return 0;
+      if (phiRefInPowerChain <= 3) return 1;
+      if (phiRefInPowerChain <= 5) return 2;
+    }
+    return 0; // Fallback
+  }
+
+  case 5: {
+    int numModulesPerGBT = inner_cabling_maxNumELinksPerGBT / numELinks;
+    return 2 + calculateIndex(phiRefInPowerChain, numModulesPerGBT);
+  }
+
+  default: { // Edge cases where ringRef doesn't match expected values
+    return 0;
+  }
+  }
 }
 
 
@@ -302,7 +284,7 @@ void InnerCablingMap::connectGBTsToBundles(std::map<std::string, std::unique_ptr
 /*
  * Compute the index used to identify uniquely a Fiber Bundle.
  */
-const int InnerCablingMap::computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const {
+int InnerCablingMap::computeBundleIndex(const std::string subDetectorName, const int layerNumber, const int powerChainPhiRef, const bool isAtSmallerAbsZDeeInDoubleDisk) const {
   int myBundleIndex = 0;
 
   if (subDetectorName == inner_cabling_tbpx) {
@@ -332,7 +314,7 @@ const int InnerCablingMap::computeBundleIndex(const std::string subDetectorName,
 
 /* Compute the Id associated to each bundle.
  */
-const int InnerCablingMap::computeBundleId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex) const {
+int InnerCablingMap::computeBundleId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber, const int myBundleIndex) const {
 
   const int innerTrackerQuarterIndex = inner_cabling_functions::computeInnerTrackerQuarterIndex(isPositiveZEnd, isPositiveXSide);
   const int subdetectorIndex = inner_cabling_functions::computeSubDetectorIndex(subDetectorName);
@@ -417,7 +399,7 @@ void InnerCablingMap::connectBundlesToDTCs(std::map<int, std::unique_ptr<InnerBu
 
 /* Compute the Id associated to each DTC.
  */
-const int InnerCablingMap::computeDTCId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber) const {
+int InnerCablingMap::computeDTCId(const bool isPositiveZEnd, const bool isPositiveXSide, const std::string subDetectorName, const int layerDiskNumber) const {
   int myDTCId = 0;
 
   if (subDetectorName == inner_cabling_tbpx) myDTCId = layerDiskNumber;

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -385,12 +385,12 @@ int InnerCablingMap::computeDTCId(const bool isPositiveZEnd, const bool isPositi
   else if (subDetectorName == inner_cabling_tfpx) {
     if (layerDiskNumber == 1) myDTCId = 2;
     else if (layerDiskNumber == 2) myDTCId = 3;
-    else if (layerDiskNumber == 3) myDTCId = 3;
-    else if (layerDiskNumber == 4) myDTCId = 4;
-    else if (layerDiskNumber == 5) myDTCId = 4;
-    else if (layerDiskNumber == 6) myDTCId = 5;
-    else if (layerDiskNumber == 7) myDTCId = 5;
-    else if (layerDiskNumber == 8) myDTCId = 5;
+    else if (layerDiskNumber == 3) myDTCId = 4;
+    else if (layerDiskNumber == 4) myDTCId = 5;
+    else if (layerDiskNumber == 5) myDTCId = 5;
+    else if (layerDiskNumber == 6) myDTCId = 6;
+    else if (layerDiskNumber == 7) myDTCId = 7;
+    else if (layerDiskNumber == 8) myDTCId = 8;
     else logERROR(any2str("Unexpected diskNumber in FPX : ") + any2str(layerDiskNumber));
   }
 

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -79,7 +79,7 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
         for (auto& m: myPowerChain->modules()) {
             int ringRef = m->uniRef().ring;
             int phiRefInPowerChain = m->getPhiRefInPowerChain();
-            int numELinks = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, ringRef); 
+            std::size_t numELinks = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, ringRef); 
             int gbtIndex = computeGBTIndexInSpecialPowerChain(ringRef, numELinks, phiRefInPowerChain, phiRef);
             const std::string myGBTId = computeGBTId(powerChainId, gbtIndex);
             createAndStoreGBTs(myPowerChain, m, myGBTId, gbtIndex, numELinks, GBTs);
@@ -307,13 +307,11 @@ const int InnerCablingMap::computeBundleIndex(const std::string subDetectorName,
 
   if (subDetectorName == inner_cabling_tbpx) {
     int maxNumPowerChainsPerBundleBarrelLayer = 0;
-    if (layerNumber == 1) maxNumPowerChainsPerBundleBarrelLayer = maxNumPowerChainsPerBundleBarrelLayer1;
-    else if (layerNumber == 2) maxNumPowerChainsPerBundleBarrelLayer = maxNumPowerChainsPerBundleBarrelLayer2;
-    else if (layerNumber == 3) maxNumPowerChainsPerBundleBarrelLayer = maxNumPowerChainsPerBundleBarrelLayer3;
-    else if (layerNumber == 4) maxNumPowerChainsPerBundleBarrelLayer = maxNumPowerChainsPerBundleBarrelLayer4;
-    else logERROR("Did not find supported layer number.");
-
-    if (maxNumPowerChainsPerBundleBarrelLayer == 0) logERROR(any2str("Found maxNumPowerChainsPerBundleBarrelLayer == 0."));
+    auto it = maxPowerChainsPerBundleTBPX.find(layerNumber);
+    if (it != maxPowerChainsPerBundleTBPX.end())
+      maxNumPowerChainsPerBundleBarrelLayer = it->second;
+    else
+      logERROR(any2str("Found maxNumPowerChainsPerBundleBarrelLayer == 0."));
 
     const double myBundleIndexExact = static_cast<double>(powerChainPhiRef) / maxNumPowerChainsPerBundleBarrelLayer;
     myBundleIndex = (fabs(myBundleIndexExact - round(myBundleIndexExact)) < inner_cabling_roundingTolerance ? 

--- a/src/InnerCabling/InnerCablingMap.cc
+++ b/src/InnerCabling/InnerCablingMap.cc
@@ -60,12 +60,11 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
 
     const bool isBarrel = myPowerChain->isBarrel();
     const std::string subDetectorName = myPowerChain->subDetectorName();
-    const int layerNumber = myPowerChain->layerDiskNumber();
-    const int ringNumber = myPowerChain->ringNumber();
     const int numModulesInPowerChain = myPowerChain->numModules();
 
-    const int layerOrRingNumber = (isBarrel ? layerNumber : ringNumber);
-    const int numELinksPerModule = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, layerOrRingNumber);
+    const int layerOrRingNumber = (isBarrel ? myPowerChain->layerDiskNumber()
+                                            : myPowerChain->ringNumber());
+    const int numELinksPerModule = inner_cabling_functions::computeNumELinksModule(subDetectorName, layerOrRingNumber, myPowerChain->phiRef());
 
     auto [numGBTsInPowerChain, numModulesPerGBTExact] = computeNumGBTsInPowerChain(numELinksPerModule, numModulesInPowerChain, isBarrel);
     myPowerChain->setNumGBTsInPowerChain(numGBTsInPowerChain);
@@ -76,7 +75,7 @@ void InnerCablingMap::connectModulesToGBTs(std::map<int, std::unique_ptr<PowerCh
         for (auto& m: myPowerChain->modules()) {
             int ringRef = m->uniRef().ring;
             int phiRefInPowerChain = m->getPhiRefInPowerChain();
-            int numELinks = inner_cabling_functions::computeNumELinksPerModule(subDetectorName, ringRef); 
+            int numELinks = inner_cabling_functions::computeNumELinksModule(subDetectorName, ringRef, phiRefInPowerChain);
             int gbtIndex = computeGBTIndexInSpecialPowerChain(ringRef, numELinks, phiRefInPowerChain, phiRef);
             const std::string myGBTId = computeGBTId(powerChainId, gbtIndex);
             createAndStoreGBTs(myPowerChain, m, myGBTId, gbtIndex, numELinks, GBTs);

--- a/src/InnerCabling/InnerDTC.cc
+++ b/src/InnerCabling/InnerDTC.cc
@@ -15,7 +15,9 @@ InnerDTC::InnerDTC(const int DTCId, const bool isPositiveZEnd, const bool isPosi
 /*
  *  Connect a Bundle to the DTC.
  */
-void InnerDTC::addBundle(InnerBundle* bundle) { 
+void InnerDTC::addBundle(InnerBundle* bundle) {
+  if (bundle == nullptr) throw PathfulException("InnerDTC::addBundle Error: Bundle pointer is nullptr");
+  bundle->setDTC(this);
   bundles_.push_back(bundle);
 }
 

--- a/src/InnerCabling/PowerChain.cc
+++ b/src/InnerCabling/PowerChain.cc
@@ -47,7 +47,10 @@ const PowerChainType PowerChain::powerChainType() const {
     return PowerChainType::IUNDEFINED;
   }
   else {
-    const int numROCsPerModule = modules().front()->outerSensor().totalROCs();
+    // Generalization when using split-sensors for TPBX-L1
+    const int numROCsPerSensor = modules().front()->outerSensor().totalROCs();
+    const int numROCsPerModule = numROCsPerSensor * modules().front()->numSensors();
+
     if (numROCsPerModule == 2) return PowerChainType::I4A;
     else if (numROCsPerModule == 4) return PowerChainType::I8A;
     else {

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -1,5 +1,8 @@
 #include "InnerCabling/inner_cabling_functions.hh"
 
+#include <string>
+#include <cstddef>
+
 
 namespace inner_cabling_functions {
 
@@ -149,56 +152,21 @@ namespace inner_cabling_functions {
   /*
    * Compute the number of ELinks per module, depending on the module location.
    */
-  const int computeNumELinksPerModule(const std::string subDetectorName, const int layerOrRingNumber) {   
-    int numELinksPerModule = 0;
-
-    // tbpx
-    if (subDetectorName == inner_cabling_tbpx) {
-      if (layerOrRingNumber == 1) numELinksPerModule = inner_cabling_numELinksPerModuleBarrelLayer1;
-      else if (layerOrRingNumber == 2) numELinksPerModule = inner_cabling_numELinksPerModuleBarrelLayer2;
-      else if (layerOrRingNumber == 3) numELinksPerModule = inner_cabling_numELinksPerModuleBarrelLayer3;
-      else if (layerOrRingNumber == 4) numELinksPerModule = inner_cabling_numELinksPerModuleBarrelLayer4;
-      else { 
-	logERROR(any2str("Found layer number ") + any2str(layerOrRingNumber)
-		 + any2str(" in ") + any2str(inner_cabling_tbpx)
-		 + any2str(". This is not supported.")
-		 );
-      }
-    }
-    // tfpx
-    else if (subDetectorName == inner_cabling_tfpx) {
-      if (layerOrRingNumber == 1) numELinksPerModule = inner_cabling_numELinksPerModuleForwardRing1;
-      else if (layerOrRingNumber == 2) numELinksPerModule = inner_cabling_numELinksPerModuleForwardRing2;
-      else if (layerOrRingNumber == 3) numELinksPerModule = inner_cabling_numELinksPerModuleForwardRing3;
-      else if (layerOrRingNumber == 4) numELinksPerModule = inner_cabling_numELinksPerModuleForwardRing4;
-      else { 
-	logERROR(any2str("Found ring number ") + any2str(layerOrRingNumber)
-		 + any2str(" in ") + any2str(inner_cabling_tfpx)
-		 + any2str(". This is not supported.")
-		 );
-      }
-    }
-    // tepx
-    else if (subDetectorName == inner_cabling_tepx) {
-      if (layerOrRingNumber == 1) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing1;
-      else if (layerOrRingNumber == 2) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing2;
-      else if (layerOrRingNumber == 3) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing3;
-      else if (layerOrRingNumber == 4) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing4;
-      else if (layerOrRingNumber == 5) numELinksPerModule = inner_cabling_numELinksPerModuleEndcapRing5;
-      else { 
-	logERROR(any2str("Found ring number ") + any2str(layerOrRingNumber)
-		 + any2str(" in ") + any2str(inner_cabling_tepx)
-		 + any2str(". This is not supported.")
-		 );
-      }
-    }
-    // other
-    else { 
-      logERROR(any2str("Unknown subDetector ") + any2str(subDetectorName)
-	       );
+std::size_t computeNumELinksPerModule(const std::string& subDetectorName, const std::size_t layerOrRingNumber) {
+    const auto it = inner_cabling_numELinksPerModule.find(subDetectorName);
+    if (it == inner_cabling_numELinksPerModule.end()) {
+      logERROR(any2str("Unknown subDetector name : ") + any2str(subDetectorName));
+      return 0; // Fallback
     }
 
-    return numELinksPerModule;
+    const auto it2 = it->second.find(layerOrRingNumber);
+    if (it2 == it->second.end()) {
+      logERROR(any2str("Found layer or ring number ") + any2str(layerOrRingNumber)
+          + any2str(" in ") + any2str(subDetectorName) + any2str(". This is not supported."));
+      return 0; // Fallback
+    }
+
+    return it2->second;
   }
 
 } // namespace

--- a/src/InnerCabling/inner_cabling_functions.cc
+++ b/src/InnerCabling/inner_cabling_functions.cc
@@ -152,7 +152,7 @@ namespace inner_cabling_functions {
   /*
    * Compute the number of ELinks per module, depending on the module location.
    */
-std::size_t computeNumELinksPerModule(const std::string& subDetectorName, const std::size_t layerOrRingNumber) {
+std::size_t computeNumELinksModule(const std::string& subDetectorName, std::size_t layerOrRingNumber, int phiRefInPowerChain) {
     const auto it = inner_cabling_numELinksPerModule.find(subDetectorName);
     if (it == inner_cabling_numELinksPerModule.end()) {
       logERROR(any2str("Unknown subDetector name : ") + any2str(subDetectorName));
@@ -166,7 +166,12 @@ std::size_t computeNumELinksPerModule(const std::string& subDetectorName, const 
       return 0; // Fallback
     }
 
-    return it2->second;
+    std::size_t numELinks = it2->second;
+    if (subDetectorName == inner_cabling_tepx && layerOrRingNumber == 2 && phiRefInPowerChain == 0) {
+      numELinks -= 1; // Special case for TEPX-R2
+    }
+
+    return numELinks;
   }
 
 } // namespace

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -9374,7 +9374,7 @@ std::string Vizard::createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* my
 
   // Header line
   dtcsToModulesCsv << "IsPlusZEnd/O,IsPlusXSide/O,DTC_Id/I,DTC_CMSSW_Id/U,MFB/I,"
-                      "LpGBT_Id/C,LpGBT_CMSSW_IdPerDTC/U,N_ELinks_Per_Module/I,"
+                      "LpGBT_Id/C,LpGBT_CMSSW_IdPerDTC/U,N_ELinks/I,"
                       "Power_Chain/I,Power_Chain_Type/C,Is_LongBarrel/O,"
                       "Module_DetId/i,Sensor_DetId/i,Module_Section/C,Module_Layer/I,Module_Ring/I,"
                       "Module_phi_deg/D,N_Chips_Per_Module/I,N_Channels_Per_Module/I\n"
@@ -9431,7 +9431,7 @@ std::string Vizard::createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* my
         const PowerChain* myPowerChain = myGBT->getPowerChain();
         if (!myPowerChain) {
           dtcsToModulesCsv << gbtStr 
-                           << myGBT->numELinksPerModule() << "," 
+                           << myGBT->numELinks() << "," 
                            << PAD_NO_POWERCHAIN;
           continue;
         }
@@ -9446,7 +9446,7 @@ std::string Vizard::createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* my
         const auto& myModules = myGBT->modules();
         if (myModules.empty()) {
           dtcsToModulesCsv << gbtStr 
-                           << myGBT->numELinksPerModule() << "," 
+                           << myGBT->numELinks() << "," 
                            << powerStr 
                            << PAD_NO_MODULES;
           continue;
@@ -9454,13 +9454,13 @@ std::string Vizard::createInnerTrackerDTCsToModulesCsv(const InnerCablingMap* my
 
         // Evaluate module type and format specific data
         for (const auto& m : myModules) {
-          // Separate logic for the L1 TBPX
-          const int numElinks = (m->moduleSubType() == 1) ? myGBT->numELinksPerModule() / 2 
-                                                          : myGBT->numELinksPerModule();
+          // Generalization logic for the TBPX-L1
+          const int numElinksPerModule = m->numELinks();
+          const int numElinksPerDetId = numElinksPerModule / m->numSensors();
 
           for (const auto& s : m->sensors()) {
             dtcsToModulesCsv << gbtStr 
-                             << numElinks << "," 
+                             << numElinksPerDetId << "," 
                              << powerStr
                              << m->myDetId() << ","
                              << s.myDetId() << ","


### PR DESCRIPTION
This PR refactors how the number of e-links of each module is handled in the IT cabling map bot. The main change is to move from hardcoded per-layer/per-ring constants to a LUT-based approach.

This PR also fixes several overloaded connection errors and DTC ID assignment mismatches.

**TODO:** Implement module-type-dependent e-link assignment. 

## IT cabling map fixes

* Added `numROCsPerModule` generalization in `PowerChain::powerChainType()` when using split-sensors for TBPX-L1 (`PowerChain.cc`).
* Added an exception for TEPX-R2 in `computeNumELinksModule` (`inner_cabling_functions.cc`).
* Rearranged the TFPX DTC IDs in`InnerCablingMap::computeDTCId` (`InnerCablingMap.cc`).

## Refactoring of e-link assignment and GBT interfaces:

* Replaced hardcoded e-link constants with a LUT (`inner_cabling_numELinksPerModule` in `inner_cabling_constants.hh`). Updated `computeNumELinksPerModule` to `computeNumELinksModule` to implement lookups via this map (`inner_cabling_functions.hh`).
* Changed the `GBT` class to no longer store a single `numELinksPerModule` value. Instead, ELink counts are now tracked in the module itself. The `GBT` constructor and `addModule` method signatures were updated accordingly. (`GBT.hh`; `GBT.cc`).
* Updated `GBT::numELinks` to return the sum of e-links of all connected modules.
* Modified the logic in `InnerCablingMap::connectModulesToGBTs` to use the new ELink-per-module map and updated function signatures so that each module's ELink count is set individually (`InnerCablingMap.cc`).
* Updated the GBT creation and module-to-GBT assignment logic to pass and use per-module e-link counts, both for regular and special power chains. (`InnerCablingMap.cc`).

## CSV output:

* Updated output field names and logic in `GeometricInfo.cc` to reflect the per-module e-link assignment.

## General code cleanup:

* Removed unnecessary `const` qualifiers from return types in various function signatures (`GBT.hh`; `InnerCablingMap.hh`).
* Replaced `InnerCablingMap::computeGBTId` with a local lambda.
* Removed redundant helpers (`connectOne*ToOne*` functions in `InnerCablingMap.cc`) and localized the connection logic in the parent classes' `add*` methods (`GBT.cc`; `InnerBundle.cc`; `PowerChain.cc`; `InnerDTC.cc`). Additionally, added `nullptr` checks to these methods.
* Refactored `computeGBTIndexInSpecialPowerChain` with a switch statement and a lambda to reduce nested conditionals and code duplication.