### PR TITLE
Align Module Orientation and Improve XML Export Descriptions

### DIFF
--- a/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V807.cfg
+++ b/geometries/CMS_Phase2/OuterTracker/Tilted/TBPS_V807.cfg
@@ -12,12 +12,23 @@ Barrel TBPS {
   /// FLAT PART GEOMETRY ///
   //////////////////////////
   bigDelta 11.9 // as in 3.6.5 
-  Layer 1 { smallDelta 3.5475 }
-  Layer 2 { smallDelta 3.0475 }
-  Layer 3 { smallDelta 3.5844 }
+  Layer 1 {
+    Ring 1-4 {
+      yawFlipRods 3,4,7,8,11,12,17,18 
+    }
+  }
+  Layer 2 {
+    Ring 1-6 {
+      yawFlipRods 3,4,7,8,11,12,15,16,19,20,21,22,25,26
+    }
+  }
+  Layer 3 {
+    Ring 1-8 {
+      yawFlipRods 3,4,7,8,11,12,15,16,19,20,23,24,27,28,31,32,35,36
+    }
+  }
   radiusMode fixed
   innerRadius 233 // as in 3.6.5 
-  Layer 2 { placeRadiusHint 361.7 } // as in 3.6.5 
   outerRadius 514 // as in 3.6.5
   // NB : for the z placement of modules within the flat part, the most stringent of zError and zOverlap is used
 
@@ -65,7 +76,6 @@ Barrel TBPS {
     Ring 15 { ringInnerZ 1004.2048784789 }
     Ring 16 { ringInnerZ 1182.332 }
 
-    yawFlipRods 3,4,7,8,11,12,17,18 
     Ring 5-16 { yawFlip true }
   }
 
@@ -73,6 +83,7 @@ Barrel TBPS {
   /// FULL LAYER ///
   //////////////////
   Layer 1 {
+    smallDelta 3.5475
     Ring 1-6 { triggerWindow 5 }
     Ring 7   { triggerWindow 4 }
     Ring 8-9 { triggerWindow 5 }
@@ -142,7 +153,6 @@ Barrel TBPS {
     Ring 17 { ringInnerZ 1048.1339581709 }
     Ring 18 { ringInnerZ 1181.542 }
 	
-    yawFlipRods 3,4,7,8,11,12,15,16,19,20,21,22,25,26
     Ring 7-18 { yawFlip true }
   }
 
@@ -150,6 +160,8 @@ Barrel TBPS {
   /// FULL LAYER ///
   //////////////////
   Layer 2 {
+    smallDelta 3.0475
+    placeRadiusHint 361.7
     Ring 1-11 { triggerWindow 5 }
     Ring 12-13 { triggerWindow 4 }
     Ring 14-18 { triggerWindow 7 }
@@ -209,7 +221,6 @@ Barrel TBPS {
     Ring 19 { ringInnerZ 1075.16863741588 }
     Ring 20 { ringInnerZ 1179.356 }
 	
-    yawFlipRods 3,4,7,8,11,12,15,16,19,20,23,24,27,28,31,32,35,36
     Ring 9-20 { yawFlip true }
   }
 
@@ -217,6 +228,7 @@ Barrel TBPS {
   /// FULL LAYER ///
   //////////////////
   Layer 3 {
+    smallDelta 3.5844
     Ring 1-8 { triggerWindow 7 }
     Ring 9-10 { triggerWindow 8 }
     Ring 11-13 { triggerWindow 7 }

--- a/include/CoordinateOperations.hh
+++ b/include/CoordinateOperations.hh
@@ -73,22 +73,6 @@ namespace CoordinateOperations {
     return maxget(polygon.begin(), polygon.end(), [](const XYZVector& v) { return v.Rho(); });
   }
 
-  template<class Polygon> Polygon* computeTranslatedPolygon(const Polygon& basePolygon, double normalOffset) {
-    Polygon* p = new Polygon(basePolygon);
-    p->translate(p->getNormal() * normalOffset);
-    return p;
-  }
-
-  template<class Polygon> Polygon* computeResizedPolygon(const Polygon& basePolygon, const XYZVector& axis, double scale) {
-    Polygon* p = new Polygon();
-    const XYZVector& center = basePolygon.getCenter();
-    for (const XYZVector* vtx = basePolygon.begin(); vtx != basePolygon.end(); ++vtx) {
-      XYZVector shift = ROOT::Math::VectorUtil::ProjVector(center - *vtx, axis) * (1. - scale);
-      *p << (*vtx + shift);
-    }
-    return p;
-  }
-
   /**
    * Compute the polygon whose vertices are all the middles of the edges of the polygon sepcified as a parameter.
    */

--- a/include/CoordinateOperations.hh
+++ b/include/CoordinateOperations.hh
@@ -9,6 +9,9 @@
 #define CORDINATEOPERATIONS_H
 
 #include <vector>
+#include <array>
+#include <cstddef>
+#include <Math/Vector3D.h>
 #include <Math/Vector3Dfwd.h>
 #include <Math/VectorUtil.h>
 #include <TVector3.h>
@@ -19,6 +22,35 @@ using ROOT::Math::XYZVector;
 
 
 namespace CoordinateOperations {
+
+  /*
+   * Given a box center and its three half-axis vectors (already scaled to half-extent),
+   * returns the 16 bounding-box candidate points: top & bottom corners plus the top &
+   * bottom midpoints of each edge. Used for module-with-hybrids extrema computation.
+   * Corner ordering (in the xy plane): 0=(+x,+y), 1=(-x,+y), 2=(-x,-y), 3=(+x,-y).
+   */
+  inline std::array<XYZVector, 16> boundingBoxCandidates(const XYZVector& center,
+                                                         const XYZVector& halfX,
+                                                         const XYZVector& halfY,
+                                                         const XYZVector& halfZ) {
+    std::array<XYZVector, 4> xyCorners;
+    for (std::size_t i = 0; i < 4; ++i) {
+      double signX = (i == 0 || i == 3) ? 1. : -1.;
+      double signY = (i == 0 || i == 1) ? 1. : -1.;
+      xyCorners[i] = center + signX * halfX + signY * halfY;
+    }
+    std::array<XYZVector, 16> pts;
+    for (std::size_t i = 0; i < 4; ++i) {
+      std::size_t next = (i + 1) % 4;
+      XYZVector top = xyCorners[i] + halfZ;
+      XYZVector bot = xyCorners[i] - halfZ;
+      pts[i*4]     = top;
+      pts[i*4 + 1] = bot;
+      pts[i*4 + 2] = (top + (xyCorners[next] + halfZ)) * 0.5;
+      pts[i*4 + 3] = (bot + (xyCorners[next] - halfZ)) * 0.5;
+    }
+    return pts;
+  }
 
   /*
    * Convert XYZVector or Polar3DVector into a TVector. 

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -332,11 +332,11 @@ public:
 
   bool flipped() const { return decorated().flipped(); } 
   bool flipped(bool newFlip) {
-    if (newFlip && numSensors() > 1) {
-      sensors_.front().innerOuter(SensorPosition::UPPER);
-      sensors_.back().innerOuter(SensorPosition::LOWER);
-    }
-    return decorated().flipped(newFlip);
+    bool ret = decorated().flipped(newFlip);
+
+    clearSensorPolys();
+
+    return ret;
   } 
   ModuleShape shape() const { return decorated().shape(); }
   ////////

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -368,19 +368,12 @@ public:
   double thetaAperture() const { return maxTheta() - minTheta(); }
 
   // Get local X orientation on sensor plane. Ie, for barrel modules, the Lorentz drift orientation!!
-  // NB: This is not garanteed at all to match CMSSW frame of reference orientation, which is independent.
   const TVector3 getLocalX() const {
-    XYZVector localX = basePoly().getVertex(3) - basePoly().getVertex(0);
-    if (flipped()) { localX *= -1; } // a flip operation does not move the polygon vertexes, hence desserves special treatment.
-    if ( fabs(tiltAngle() - M_PI/2.) < insur::geom_zero || !isPixelModule() ) { localX *= -1; }
-    return CoordinateOperations::convertCoordVectorToTVector3(localX).Unit();
+    return CoordinateOperations::convertCoordVectorToTVector3(basePoly().getVertex(0) - basePoly().getVertex(1)).Unit();
   }
   // Get local Y orientation on sensor plane.
-  // NB: This is not garanteed at all to match CMSSW frame of reference orientation, which is independent.
   const TVector3 getLocalY() const { 
-    XYZVector localY = basePoly().getVertex(0) - basePoly().getVertex(1);
-    if ( fabs(tiltAngle() - M_PI/2.) < insur::geom_zero || !isPixelModule() ) { localY *= -1; }
-    return CoordinateOperations::convertCoordVectorToTVector3(localY).Unit();
+    return CoordinateOperations::convertCoordVectorToTVector3(basePoly().getVertex(0) - basePoly().getVertex(3)).Unit();
   }
 
   const Sensors& sensors() const { return sensors_; }

--- a/include/DetectorModule.hh
+++ b/include/DetectorModule.hh
@@ -346,6 +346,33 @@ public:
   double maxR() const { return maxget2(sensors_.begin(), sensors_.end(), &Sensor::maxR); }
   double minR() const { return minget2(sensors_.begin(), sensors_.end(), &Sensor::minR); }
 
+  // Hybrid-expanded module dimensions. Shared by extremaWithHybrids() and ModuleComplex
+  // (Extractor) so the two stay in sync. Args are explicit so callers can pass variants
+  // (e.g. the double-sensor pixel length).
+  static double computeExpandedModWidth(double moduleWidth, double serviceHybridWidth,
+                                        double deadAreaExtraWidth, double chipNegativeXExtraWidth,
+                                        double chipPositiveXExtraWidth) {
+    const double totalServiceHybridWidth = 2. * serviceHybridWidth;                              // OT case
+    const double totalDeadAreaExtraWidth = 2. * deadAreaExtraWidth;                              // IT case: around sensor
+    const double totalChipExtraWidth = 2. * MAX(chipNegativeXExtraWidth, chipPositiveXExtraWidth); // IT case: around chip
+    return moduleWidth + totalServiceHybridWidth + MAX(totalDeadAreaExtraWidth, totalChipExtraWidth);
+  }
+  static double computeExpandedModLength(double moduleLength, double frontEndHybridWidth,
+                                         double deadAreaExtraLength) {
+    return moduleLength + 2. * frontEndHybridWidth + 2. * deadAreaExtraLength;
+  }
+  static double computeExpandedModThickness(bool isPixel, bool isTiming, double dsDistance,
+                                            double sensorThickness, double supportPlateThickness,
+                                            double chipThickness, double hybridThickness) {
+    if (!isPixel) {
+      // if (!isTiming)
+      return dsDistance + sensorThickness + supportPlateThickness;
+      // else  // Legacy formula, likely incorrect
+      //   return sensorThickness + 2.0 * MAX(supportPlateThickness, hybridThickness);
+    }
+    return sensorThickness + chipThickness + hybridThickness;
+  }
+
   std::map<std::string, double> extremaWithHybrids() const;
   double minZwithHybrids() const { return extremaWithHybrids()["minZ"]; }
   double maxZwithHybrids() const { return extremaWithHybrids()["maxZ"]; }

--- a/include/Extractor.hh
+++ b/include/Extractor.hh
@@ -117,17 +117,6 @@ namespace insur {
     void addRotationAroundZAxis(std::map<std::string,Rotation>& storedRotations, 
 				const std::string rotationName,
 				const double rotationAngleInRad) const;
-    void createAndStoreDDTrackerAngularAlgorithmBlock(std::vector<AlgoInfo>& storedAlgorithmBlocks,
-						      const std::string nameSpace, 
-						      const std::string parentName,
-						      const std::string childName,
-						      const double startAngleInRad,
-						      const double rangeAngleInRad,
-						      const double radius,
-						      const XYZVector& center,
-						      const int numCopies,
-						      const int startCopyNumber,
-						      const int copyNumberIncrement);
     Composite createComposite(std::string name, double density, MaterialProperties& mp, bool nosensors = false);
     std::vector<ModuleCap>::iterator findPartnerModule(std::vector<ModuleCap>::iterator i,
                                                        std::vector<ModuleCap>::iterator g, int ponrod, bool find_first = false);

--- a/include/Extractor.hh
+++ b/include/Extractor.hh
@@ -144,18 +144,6 @@ namespace insur {
 #endif
  
 
-  namespace ModuleComplexHelpers {
-    const double computeExpandedModWidth(const double moduleWidth, 
-					 const double serviceHybridWidth, 
-					 const double deadAreaExtraWidth,
-					 const double chipNegativeXExtraWidth,
-					 const double chipPositiveXExtraWidth);
-    const double computeExpandedModLength(const double moduleLength, 
-					  const double frontEndHybridWidth, 
-					  const double deadAreaExtraLength);
-  };
-
-
   class ModuleComplex {
     public :
      ModuleComplex(std::string moduleName, std::string parentName, ModuleCap& modcap);

--- a/include/Extractor.hh
+++ b/include/Extractor.hh
@@ -139,6 +139,7 @@ namespace insur {
     std::string numericParam(std::string name, std::string value);
     std::string vectorParam(double x, double y, double z);
     std::string arbitraryLengthVector(std::string name, std::vector<double> invec);
+    std::string arbitraryLengthStringVector(std::string name, std::vector<std::string> invec);
     double compositeDensity(ModuleCap& mc, bool nosensors = false);
     double compositeDensity(InactiveElement& ie);
     double fromRim(double r, double w);

--- a/include/GeometricModule.hh
+++ b/include/GeometricModule.hh
@@ -38,7 +38,8 @@ class GeometricModule : public ModuleDecorable {
 protected:
   int numHits_ = 0;
   bool flipped_ = false;
-  int tiltAngle_ = 0., skewAngle_ = 0.;
+  double tiltAngle_ = 0.;
+  double skewAngle_ = 0.;
   double zrotAngle_ = 0.;
   Polygon3d<4> basePoly_;
   std::vector<XYZVector> contour_;

--- a/include/GeometricModule.hh
+++ b/include/GeometricModule.hh
@@ -76,7 +76,20 @@ public:
   double skewAngle() const { return skewAngle_; }
   double zrotAngle() const { return zrotAngle_; }
   bool flipped() const { return flipped_; }
-  bool flipped(bool newFlip) { flipped_=newFlip; return flipped_; }
+  bool flipped(bool shouldFlip) {
+    if (flipped_ != shouldFlip) {
+      // 180° rotation around the local Y axis
+      Polygon3d<4> flippedPoly;
+      flippedPoly << basePoly_.getVertex(1)
+                  << basePoly_.getVertex(0)
+                  << basePoly_.getVertex(3)
+                  << basePoly_.getVertex(2);
+      basePoly_ = flippedPoly;
+
+      flipped_ = shouldFlip;
+    }
+    return flipped_;
+  }
 
   void translate(const XYZVector& vector) { basePoly_.translate(vector); }
   void mirror(const XYZVector& vector) { basePoly_.mirror(vector); }

--- a/include/Polygon3d.hh
+++ b/include/Polygon3d.hh
@@ -211,7 +211,6 @@ bool Polygon3d<NumSides>::isLineIntersecting(const XYZVector& orig, const XYZVec
   double normOrig = this->getNormal().Dot(orig);
   double normDir = this->getNormal().Dot(dir);
   double d = this->getCenter().Dot(this->getNormal());
-  if (normDir < 1e-3) return false; // no fabs because if normDir < 0 we want to return false, as we're matching with the module in the opposite direction
   intersection = orig + (((d - normOrig)/normDir) * dir); // TODO: slightly inefficient here: we do not need to go 3D and then 2D again...
   return isPointInside(intersection);
 }

--- a/include/Polygon3d.hh
+++ b/include/Polygon3d.hh
@@ -9,6 +9,8 @@
 
 #include <TRandom.h>
 #include <Math/Vector3Dfwd.h>
+#include <Math/GenVector/RotationX.h>
+#include <Math/GenVector/RotationY.h>
 #include <Math/GenVector/RotationZ.h>
 #include <Math/GenVector/Rotation3D.h>
 #include <Math/GenVector/Transform3D.h>
@@ -22,44 +24,8 @@ struct PolygonLess {
   }
 };
 
-template<class Coords, class FloatType>
-struct RotateX {};
-
-template<class FloatType>
-struct RotateX<XYZVector, FloatType> {
-  XYZVector operator()(const XYZVector& vector, FloatType angle) const {
-    return XYZVector(vector.X(),
-                     vector.Y()*cos(angle) - vector.Z()*sin(angle),
-                     vector.Y()*sin(angle) + vector.Z()*cos(angle));
-  }
-};
-
-template<class Coords, class FloatType>
-struct RotateY {};
-
-template<class FloatType>
-struct RotateY<XYZVector, FloatType> {
-  XYZVector operator()(const XYZVector& vector, FloatType angle) const {
-    return XYZVector(vector.Z()*sin(angle) + vector.X()*cos(angle),
-                     vector.Y(),
-                     vector.Z()*cos(angle) - vector.X()*sin(angle));
-  }
-};
-
-template<class Coords, class FloatType>
-struct RotateZ {};
-
-template<class FloatType>
-struct RotateZ<XYZVector, FloatType> {
-  XYZVector operator()(const XYZVector& vector, FloatType angle) const {
-    return XYZVector(vector.X()*cos(angle) - vector.Y()*sin(angle),
-                     vector.X()*sin(angle) + vector.Y()*cos(angle),
-                     vector.Z());
-  }
-};
-
+// Primary templates (required before specialization)
 template<class Coords> Coords crossProduct(const Coords& v1, const Coords& v2);
-
 template<class Coords> Coords unitVector(const Coords& vector);
 
 template<int NumSides, class Coords, class Random, class FloatType = double>
@@ -68,17 +34,22 @@ protected:
   FloatType area_;
   Coords v_[NumSides]; // vertices of the polygon
   size_t allocated_;
+  ROOT::Math::Rotation3D rotation_; // Underlying rotation state
+  
   virtual void computeProperties() = 0;
   mutable Coords center_, normal_;
   mutable bool centerDirty_, normalDirty_;
   void setGeomDirty(bool dirty) { centerDirty_ = normalDirty_ = dirty; }
+
 public:
-  AbstractPolygon() : allocated_(0), centerDirty_(true), normalDirty_(true) {}
-  AbstractPolygon(const Coords& vertex): allocated_(0), centerDirty_(true), normalDirty_(true) { *this << vertex; }
+  AbstractPolygon() : allocated_(0), rotation_(), centerDirty_(true), normalDirty_(true) {}
+  AbstractPolygon(const Coords& vertex): allocated_(0), rotation_(), centerDirty_(true), normalDirty_(true) { *this << vertex; }
   virtual ~AbstractPolygon() {};
+  
   virtual AbstractPolygon<NumSides, Coords, Random, FloatType>& operator<<(const Coords& vertex);
   virtual AbstractPolygon<NumSides, Coords, Random, FloatType>& operator<<(const std::vector<Coords>& vertices);
   virtual AbstractPolygon<NumSides, Coords, Random, FloatType>& operator()(const Coords& vertex) { *this << vertex; return *this; }
+  
   const Coords* getVertices() const;
   const Coords* begin() const { return v_; }
   const Coords* end() const { return (v_+NumSides); }
@@ -91,8 +62,11 @@ public:
 
   const Coords& getCenter() const;
   const Coords& getNormal() const; 
+  const ROOT::Math::Rotation3D& getRotation() const { return rotation_; } // Access the accumulated rotation
+  
   AbstractPolygon<NumSides, Coords, Random, FloatType>& translate(const Coords& vector); 
   AbstractPolygon<NumSides, Coords, Random, FloatType>& mirror(const Coords& vector); 
+  AbstractPolygon<NumSides, Coords, Random, FloatType>& rotate(const ROOT::Math::Rotation3D& rot);
   AbstractPolygon<NumSides, Coords, Random, FloatType>& rotateX(FloatType angle);
   AbstractPolygon<NumSides, Coords, Random, FloatType>& rotateY(FloatType angle);
   AbstractPolygon<NumSides, Coords, Random, FloatType>& rotateZ(FloatType angle);
@@ -118,7 +92,6 @@ double AbstractPolygon<NumSides, Coords, Random, FloatType>::getDoubleArea() con
   return area_;
 }
 
-
 template<int NumSides, class Coords, class Random, class FloatType> 
 const Coords& AbstractPolygon<NumSides, Coords, Random, FloatType>::getCenter() const {
   if (centerDirty_) {
@@ -128,7 +101,6 @@ const Coords& AbstractPolygon<NumSides, Coords, Random, FloatType>::getCenter() 
   return center_;
 }
 
-
 template<int NumSides, class Coords, class Random, class FloatType> 
 const Coords& AbstractPolygon<NumSides, Coords, Random, FloatType>::getNormal() const {
   if (normalDirty_) {
@@ -137,8 +109,6 @@ const Coords& AbstractPolygon<NumSides, Coords, Random, FloatType>::getNormal() 
   }
   return normal_;
 }
-
-
 
 template<int NumSides, class Coords, class Random, class FloatType>
 AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::translate(const Coords& vector) {
@@ -157,24 +127,26 @@ AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, 
 }
 
 template<int NumSides, class Coords, class Random, class FloatType>
-AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateX(FloatType angle) {
-  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return RotateX<Coords, FloatType>()(coord, angle); });
+AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotate(const ROOT::Math::Rotation3D& rot) {
+  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return rot(coord); });
+  rotation_ = rot * rotation_; // Track total accumulation
   setGeomDirty(true);
   return *this;
+}
+
+template<int NumSides, class Coords, class Random, class FloatType>
+AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateX(FloatType angle) {
+  return rotate(ROOT::Math::Rotation3D(ROOT::Math::RotationX(angle)));
 }
 
 template<int NumSides, class Coords, class Random, class FloatType>
 AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateY(FloatType angle) {
-  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return RotateY<Coords, FloatType>()(coord, angle); });
-  setGeomDirty(true);
-  return *this;
+  return rotate(ROOT::Math::Rotation3D(ROOT::Math::RotationY(angle)));
 }
 
 template<int NumSides, class Coords, class Random, class FloatType>
 AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateZ(FloatType angle) {
-  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return RotateZ<Coords, FloatType>()(coord, angle); });
-  setGeomDirty(true);
-  return *this;
+  return rotate(ROOT::Math::Rotation3D(ROOT::Math::RotationZ(angle)));
 }
 
 template<int NumSides, class Coords, class Random, class FloatType> 
@@ -191,8 +163,6 @@ AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, 
   }
   return *this;
 }
-
-
 
 template<int NumSides>
 class Polygon3d : public AbstractPolygon<NumSides, ROOT::Math::XYZVector, TRandom> { // no checks are made on the convexity, but the algorithms in the class only work for convex polygons, so beware!
@@ -222,8 +192,6 @@ public:
 };
 
 typedef Polygon3d<3> Triangle3d;
-
-
 
 template<int NumSides>
 bool Polygon3d<NumSides>::isPointInside(const XYZVector& p) const {
@@ -272,12 +240,10 @@ XYZVector Polygon3d<NumSides>::generateRandomPoint(TRandom* die) const {
   return it->generateRandomPoint(die);
 }
 
-
 template<int NumSides>
 inline const std::multiset<Triangle3d, PolygonLess<Triangle3d> >& Polygon3d<NumSides>::getTriangulation() const {
   return trianglesByArea_;
 }
-
 
 inline void Triangle3d::computeProperties() {
    this->area_ = sqrt((this->v_[1] - this->v_[0]).Cross(this->v_[2] - this->v_[0]).Mag2());
@@ -301,9 +267,4 @@ inline XYZVector Triangle3d::generateRandomPoint(TRandom* die) const {
   return this->v_[0] + a*(this->v_[1]-this->v_[0]) + b*(this->v_[2]-this->v_[0]); // seriously C++??? you've been around for a while now, time to fix this horrid syntax??
 }
 
-
-
 #endif
-
-
-

--- a/include/Polygon3d.hh
+++ b/include/Polygon3d.hh
@@ -173,7 +173,6 @@ public:
   Polygon3d(const ROOT::Math::XYZVector& vertex) : AbstractPolygon<NumSides, ROOT::Math::XYZVector, TRandom>(vertex) {}
   const TriangleSet& getTriangulation() const;
   bool isPointInside(const ROOT::Math::XYZVector& p) const;
-  bool isLineIntersecting(const XYZVector& orig, const XYZVector& dir) const;
   bool isLineIntersecting(const XYZVector& orig, const XYZVector& dir, XYZVector& intersection) const;
   ROOT::Math::XYZVector generateRandomPoint(TRandom* die) const;
 };
@@ -205,10 +204,22 @@ bool Polygon3d<NumSides>::isPointInside(const XYZVector& p) const {
 
 template<int NumSides>
 bool Polygon3d<NumSides>::isLineIntersecting(const XYZVector& orig, const XYZVector& dir, XYZVector& intersection) const {
-  double normOrig = this->getNormal().Dot(orig);
-  double normDir = this->getNormal().Dot(dir);
-  double d = this->getCenter().Dot(this->getNormal());
-  intersection = orig + (((d - normOrig)/normDir) * dir); // TODO: slightly inefficient here: we do not need to go 3D and then 2D again...
+  const auto normal = this->getNormal();
+  const auto center = this->getCenter();
+
+  // If normDir ~= 0, the polygon is parallel to the line, so no intersection
+  const double normDir = normal.Dot(dir);
+  if (std::fabs(normDir) < 1e-3) return false;
+
+  const double normOrig = normal.Dot(orig);
+  const double d = center.Dot(normal);
+
+  // If t < 0, the line is pointing away from the plane, so no intersection
+  const double t = (d - normOrig) / normDir;
+  if (t < 0.) return false;
+
+  intersection = orig + t * dir;
+
   return isPointInside(intersection);
 }
 

--- a/include/Polygon3d.hh
+++ b/include/Polygon3d.hh
@@ -12,8 +12,6 @@
 #include <Math/GenVector/RotationX.h>
 #include <Math/GenVector/RotationY.h>
 #include <Math/GenVector/RotationZ.h>
-#include <Math/GenVector/Rotation3D.h>
-#include <Math/GenVector/Transform3D.h>
 
 using namespace ROOT::Math;
 
@@ -34,7 +32,6 @@ protected:
   FloatType area_;
   Coords v_[NumSides]; // vertices of the polygon
   size_t allocated_;
-  ROOT::Math::Rotation3D rotation_; // Underlying rotation state
   
   virtual void computeProperties() = 0;
   mutable Coords center_, normal_;
@@ -42,8 +39,8 @@ protected:
   void setGeomDirty(bool dirty) { centerDirty_ = normalDirty_ = dirty; }
 
 public:
-  AbstractPolygon() : allocated_(0), rotation_(), centerDirty_(true), normalDirty_(true) {}
-  AbstractPolygon(const Coords& vertex): allocated_(0), rotation_(), centerDirty_(true), normalDirty_(true) { *this << vertex; }
+  AbstractPolygon() : allocated_(0), centerDirty_(true), normalDirty_(true) {}
+  AbstractPolygon(const Coords& vertex): allocated_(0), centerDirty_(true), normalDirty_(true) { *this << vertex; }
   virtual ~AbstractPolygon() {};
   
   virtual AbstractPolygon<NumSides, Coords, Random, FloatType>& operator<<(const Coords& vertex);
@@ -62,7 +59,6 @@ public:
 
   const Coords& getCenter() const;
   const Coords& getNormal() const; 
-  const ROOT::Math::Rotation3D& getRotation() const { return rotation_; } // Access the accumulated rotation
   
   AbstractPolygon<NumSides, Coords, Random, FloatType>& translate(const Coords& vector); 
   AbstractPolygon<NumSides, Coords, Random, FloatType>& mirror(const Coords& vector); 
@@ -127,26 +123,27 @@ AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, 
 }
 
 template<int NumSides, class Coords, class Random, class FloatType>
-AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotate(const ROOT::Math::Rotation3D& rot) {
-  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return rot(coord); });
-  rotation_ = rot * rotation_; // Track total accumulation
+AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateX(FloatType angle) {
+  ROOT::Math::RotationX rotX(angle);
+  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return rotX(coord); });
   setGeomDirty(true);
   return *this;
 }
 
 template<int NumSides, class Coords, class Random, class FloatType>
-AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateX(FloatType angle) {
-  return rotate(ROOT::Math::Rotation3D(ROOT::Math::RotationX(angle)));
-}
-
-template<int NumSides, class Coords, class Random, class FloatType>
 AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateY(FloatType angle) {
-  return rotate(ROOT::Math::Rotation3D(ROOT::Math::RotationY(angle)));
+  ROOT::Math::RotationY rotY(angle);
+  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return rotY(coord); });
+  setGeomDirty(true);
+  return *this;
 }
 
 template<int NumSides, class Coords, class Random, class FloatType>
 AbstractPolygon<NumSides, Coords, Random, FloatType>& AbstractPolygon<NumSides, Coords, Random, FloatType>::rotateZ(FloatType angle) {
-  return rotate(ROOT::Math::Rotation3D(ROOT::Math::RotationZ(angle)));
+  ROOT::Math::RotationZ rotZ(angle);
+  std::transform(&v_[0], &v_[NumSides], &v_[0], [&](const Coords& coord) { return rotZ(coord); });
+  setGeomDirty(true);
+  return *this;
 }
 
 template<int NumSides, class Coords, class Random, class FloatType> 

--- a/include/Ring.hh
+++ b/include/Ring.hh
@@ -149,6 +149,8 @@ class Ring : public PropertyObject, public Buildable, public Identifiable<int>, 
   void buildBottomUp();
   void buildTopDown();
 
+  void sortModulesByIncreasingPhi();
+
   Property<ModuleShape, NoDefault> moduleShape;
   Property<double, Default> phiOverlap;
   Property<bool  , Default> requireOddModsPerSlice;

--- a/include/Sensor.hh
+++ b/include/Sensor.hh
@@ -98,8 +98,6 @@ public:
   double alveolaWidth() const;
   double alveolaLength() const;
 
-  double sensorNormalOffset() const;             // normal offset of the sensor center, in the frame of reference of the module
-  double sensorXOffset() const;
   const XYZVector& center() const { return hitPoly().getCenter(); }  // center of the sensor
   const Polygon3d<4>& hitPoly() const;           // sensor rectangle (in plane containing the sensor center)
   const Polygon3d<4>& hitMidPoly() const;        // losange formed by the mid-points of hitPoly

--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -247,12 +247,7 @@ namespace insur {
     static const std::string xml_tracker = "Tracker";
     static const std::string xml_tob = "TOB";
     static const std::string xml_tid = "TID";
-    static const std::string xml_phialt_algo = "track:DDTrackerPhiAltAlgo";
-    static const std::string xml_angular_algo = "track:DDTrackerAngular";
     static const std::string xml_xyzpos_algo = "track:DDTrackerXYZPosAlgo";
-    static const std::string xml_trackerring_algo = "track:DDTrackerRingAlgo";
-    static const std::string xml_trackerring_irregular_algo = "track:DDTrackerIrregularRingAlgo";
-    static const std::string xml_angularv1_algo = "track:DDTrackerAngularV1";
     static const std::string xml_param_string = "String";
     static const std::string xml_param_numeric = "Numeric";
     static const std::string xml_childparam = "ChildName";

--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -249,6 +249,7 @@ namespace insur {
     static const std::string xml_tid = "TID";
     static const std::string xml_phialt_algo = "track:DDTrackerPhiAltAlgo";
     static const std::string xml_angular_algo = "track:DDTrackerAngular";
+    static const std::string xml_xyzpos_algo = "track:DDTrackerXYZPosAlgo";
     static const std::string xml_trackerring_algo = "track:DDTrackerRingAlgo";
     static const std::string xml_trackerring_irregular_algo = "track:DDTrackerIrregularRingAlgo";
     static const std::string xml_angularv1_algo = "track:DDTrackerAngularV1";

--- a/src/DetIdBuilder.cc
+++ b/src/DetIdBuilder.cc
@@ -215,10 +215,6 @@ void EndcapDetIdBuilder::visit(EndcapModule& m) {
   // Range : 1 to numModules_
   uint32_t phiRef_ = m.getPhiIdentifier();
 
-  // Z+ modules are copied to the Z- side with a +180° shift, Phi ∈ [-pi, pi]
-  if (m.side() < 0)
-    phiRef_ = 1 + ((3 * numModules_ / 2 - phiRef_) % numModules_);
-
   if (isPixelTracker_) { // Pixel Endcap
     if (hasSubDisks_) {
       // Increasing in |z|

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -786,9 +786,6 @@ void BarrelModule::build() {
 
     rAxis_ = XYZVector(1., 0., 0.);
 
-    // Initial global orientation with skew
-    rotateY(M_PI_2 - skewAngle());
-
     // tilt
     tiltAngle_ = 0.;
 
@@ -804,10 +801,7 @@ void EndcapModule::build() {
   try {
     DetectorModule::build();
 
-    // Initial global position
-    rotateZ(M_PI_2);
-
-    rAxis_ = XYZVector(1., 0., 0.);
+    rAxis_ = XYZVector(0., -1., 0.);
 
     // tilt
     tiltAngle_ = M_PI_2;

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -874,16 +874,15 @@ const int DetectorModule::innerDTCPlotColor() const {
 void BarrelModule::build() {
   try {
     DetectorModule::build();
-    //myModuleCap_->setCategory(MaterialProperties::b_mod);
-    decorated().rotateY(M_PI/2);
 
-    rAxis_ = normal();
+    rAxis_ = XYZVector(1., 0., 0.);
 
-    // skew
-    decorated().rotateZ(skewAngle());    
-    
+    // Initial global orientation with skew
+    rotateY(M_PI_2 - skewAngle());
+
     // tilt
     tiltAngle_ = 0.;
+
     for (auto& s : sensors_) { s.subdet(ModuleSubdetector::BARREL); }
   }
   catch (PathfulException& pe) { pe.pushPath(*this, myid()); throw; }
@@ -895,11 +894,15 @@ void BarrelModule::build() {
 void EndcapModule::build() {
   try {
     DetectorModule::build();
-    //myModuleCap_->setCategory(MaterialProperties::e_mod);
-    rAxis_ = (basePoly().getVertex(0) + basePoly().getVertex(3)).Unit();
+
+    // Initial global position
+    rotateZ(M_PI_2);
+
+    rAxis_ = XYZVector(1., 0., 0.);
 
     // tilt
-    tiltAngle_ = M_PI/2.;
+    tiltAngle_ = M_PI_2;
+
     for (auto& s : sensors_) { s.subdet(ModuleSubdetector::ENDCAP); }
   }
   catch (PathfulException& pe) { pe.pushPath(*this, myid()); throw; }

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -1,4 +1,10 @@
 #include <algorithm>
+#include <cmath>
+#include <vector>
+#include <array>
+#include <map>
+
+#include <Math/Vector3D.h>
 
 #include "DetectorModule.hh"
 #include "ModuleCap.hh"
@@ -129,9 +135,6 @@ void DetectorModule::build() {
 
 
 std::map<std::string, double> DetectorModule::extremaWithHybrids() const {
-
-    std::map<std::string, double> extrema;
-
     //                                                   OUTER TRACKER MODULE
     //
     //  Top View
@@ -157,7 +160,6 @@ std::map<std::string, double> DetectorModule::extremaWithHybrids() const {
     //
     //  SupportPlate(8) thickness is of course null for 2S modules.
 
-
     //                                                      PIXEL MODULE
     //
     //  Top View 
@@ -175,15 +177,13 @@ std::map<std::string, double> DetectorModule::extremaWithHybrids() const {
     //
     // Chip(3) volume can contain Bumps and any other material for simplification.
 
-
-
     // =========================================================================================================
     // Finding Xmin/Xmax/Ymin/Ymax/Zmin/Zmax/Rmin/Rmax/RminatZmin/RmaxatZmax, taking hybrid volumes into account
     // =========================================================================================================
     //
     // Module polygon
     //   top view
-    //   v1                v2
+    //   v1                v0
     //    *---------------*
     //    |       ^ my    |
     //    |       |   mx  |
@@ -191,156 +191,65 @@ std::map<std::string, double> DetectorModule::extremaWithHybrids() const {
     //    |     center    |
     //    |               |
     //    *---------------*
-    //   v0                v3
-    //  (v4)
+    //   v2                v3
     //
     //   side view
     //    ----------------- top
     //    ----------------- bottom
 
-
-    double         rmin;
-    double         rmax;
-    //double         xmin;
-    //double         xmax;
-    //double         ymin;
-    //double         ymax;
-    double         zmin;
-    double         zmax;
-    //double         rminatzmin;
-    //double         rmaxatzmax;
-    std::vector<XYZVector> vertex; 
-
-
-
     double width = area() / length();
     double expandedModWidth = width + 2 * serviceHybridWidth();
     double expandedModLength = length() + outerSensorExtraLength() + 2 * frontEndHybridWidth();
     double expandedModThickness;
-    if (!isPixelModule()) { expandedModThickness = dsDistance() + 2.0 * (supportPlateThickness() + sensorThickness()); }
-    //double expandedModThickness = dsDistance() + supportPlateThickness()+sensorThickness(); SHOULD BE THIS !!!!
-    else { expandedModThickness = sensorThickness() + 2.0 * MAX(chipThickness(), hybridThickness()); }
+    if (!isPixelModule())
+      expandedModThickness = dsDistance() + sensorThickness() + supportPlateThickness();
+    else
+      expandedModThickness = sensorThickness() + chipThickness() + hybridThickness();
 
-    
-    vector<double> xv; // x list (in global frame of reference) from which we will find min/max.
-    vector<double> yv; // y list (in global frame of reference) from which we will find min/max.
-    vector<double> zv; // z (in global frame of reference) list from which we will find min/max.
-    vector<double> rv; // radius list (in global frame of reference) from which we will find min/max.
-    vector<double> ratzminv; // radius list (in global frame of reference) at zmin from which we will find min/max.
-    vector<double> ratzmaxv; // radius list (in global frame of reference) at zmax from which we will find min/max.
+    const ROOT::Math::XYZVector& modCenter = center();
+    const ROOT::Math::XYZVector modX(getLocalX() * expandedModWidth * 0.5);
+    const ROOT::Math::XYZVector modY(getLocalY() * expandedModLength * 0.5);
+    const ROOT::Math::XYZVector modZ(normal() * expandedModThickness * 0.5);
 
-    // mx: (v2+v3)/2 - center(), my: (v1+v2)/2 - center()
-    XYZVector mx = (0.5*( basePoly().getVertex(2) + basePoly().getVertex(3) ) - center()).Unit() ;
-    XYZVector my = (0.5*( basePoly().getVertex(1) + basePoly().getVertex(2) ) - center()).Unit() ;
-
-    // new vertexes after expansion due to hybrid volumes
-    const int npoints = 5; // v0,v1,v2,v3,v4(=v0)
-    XYZVector v[npoints-1];
-    v[0] = center() - expandedModWidth/2. * mx - expandedModLength/2. * my;
-    v[1] = center() - expandedModWidth/2. * mx + expandedModLength/2. * my;
-    v[2] = center() + expandedModWidth/2. * mx + expandedModLength/2. * my;
-    v[3] = center() + expandedModWidth/2. * mx - expandedModLength/2. * my;
-
-    // Calculate all vertex candidates (8 points)
-    XYZVector v_top[npoints];    // module's top surface
-    XYZVector v_bottom[npoints]; // module's bottom surface
-
-    for (int ip = 0; ip < npoints-1; ip++) {
-      v_top[ip]    = v[ip] + 0.5*expandedModThickness * normal();
-      v_bottom[ip] = v[ip] - 0.5*expandedModThickness * normal();
-
-      // for debuging
-      vertex.push_back(v_top[ip]);
-      vertex.push_back(v_bottom[ip]);
-
-      // Calculate xmin, xmax, ymin, ymax, zmin, zmax
-      xv.push_back(v_top[ip].X());
-      xv.push_back(v_bottom[ip].X());
-      yv.push_back(v_top[ip].Y());
-      yv.push_back(v_bottom[ip].Y());
-      zv.push_back(v_top[ip].Z());
-      zv.push_back(v_bottom[ip].Z());
-    }
-    // Find min and max
-    //xmin = *std::min_element(xv.begin(), xv.end());
-    //xmax = *std::max_element(xv.begin(), xv.end());
-    //ymin = *std::min_element(yv.begin(), yv.end());
-    //ymax = *std::max_element(yv.begin(), yv.end());
-    zmin = *std::min_element(zv.begin(), zv.end());
-    zmax = *std::max_element(zv.begin(), zv.end());
-
-
-    // Calculate module's mid-points (8 points)
-    XYZVector v_mid_top[npoints]; // module's top surface mid-points
-    XYZVector v_mid_bottom[npoints]; // module's bottom surface mid-points
-
-    v_top[npoints-1] = v_top[0]; // copy v0 as v4 for convenience
-    v_bottom[npoints-1] = v_bottom[0]; // copy v0 as v4 for convenience
-
-    for (int ip = 0; ip < npoints-1; ip++) {
-      v_mid_top[ip] = (v_top[ip] + v_top[ip+1]) / 2.0;
-      v_mid_bottom[ip] = (v_bottom[ip] + v_bottom[ip+1]) / 2.0;
+    // Expanded module corners
+    std::array<ROOT::Math::XYZVector, 4> xyCorners;
+    for (std::size_t i = 0; i < 4; ++i) {
+      double signX = (i == 0 || i == 3) ? 1. : -1;
+      double signY = (i == 0 || i == 1) ? 1. : -1;
+      xyCorners[i] = modCenter + signX * modX + signY * modY;
     }
 
-    // Calculate rmin, rmax, rminatzmin, rmaxatzmax...
-    for (int ip = 0; ip < npoints-1; ip++) {
+    // Calculate all vertex candidates (corners + mid points)
+    std::array<ROOT::Math::XYZVector, 16> allPoints;
+    for (std::size_t i = 0; i < 4; ++i) {
+      std::size_t nextIdx = (i + 1) % 4;
 
-      // module's bottom surface
-      if (fabs(v_bottom[ip].Z() - zmin) < 0.001) {
-	v_bottom[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_bottom[ip].R());
-      }
-      if (fabs(v_bottom[ip].Z() - zmax) < 0.001) {
-	v_bottom[ip].SetZ(0.); // projection to xy plan.
-	ratzmaxv.push_back(v_bottom[ip].R());
-      }
-      v_bottom[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_bottom[ip].R());
+      // Top and bottom corners
+      auto botVtx = xyCorners[i] - modZ;
+      auto topVtx = xyCorners[i] + modZ;
+      allPoints[i*4]     = topVtx;
+      allPoints[i*4 + 1] = botVtx;
 
-      // module's top surface
-      if (fabs(v_top[ip].Z() - zmin) < 0.001) {
-	v_top[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_top[ip].R());
-      }
-      if (fabs(v_top[ip].Z() - zmax) < 0.001) {
-	v_top[ip].SetZ(0.); // projection to xy plan.
-	ratzmaxv.push_back(v_top[ip].R());
-      }
-      v_top[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_top[ip].R());
-    
-      // module's bottom surface mid-points
-      if (fabs(v_mid_bottom[ip].Z() - zmin) < 0.001) {
-	v_mid_bottom[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_mid_bottom[ip].R());
-      }
-      v_mid_bottom[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_mid_bottom[ip].R());
-    
-      // module's top surface mid-points
-      if (fabs(v_mid_top[ip].Z() - zmin) < 0.001) {
-	v_mid_top[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_mid_top[ip].R());
-      }
-      v_mid_top[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_mid_top[ip].R());
+      // Top and bottom midpoints between this corner and the next
+      allPoints[i*4 + 2] = (topVtx + (xyCorners[nextIdx] + modZ)) * 0.5;
+      allPoints[i*4 + 3] = (botVtx + (xyCorners[nextIdx] - modZ)) * 0.5;
     }
-    // Find min and max
-    rmin = *std::min_element(rv.begin(), rv.end());
-    rmax = *std::max_element(rv.begin(), rv.end());
-    //rminatzmin = *std::min_element(ratzminv.begin(), ratzminv.end());
-    //rmaxatzmax = *std::max_element(ratzmaxv.begin(), ratzmaxv.end());
 
+    // Find min and max Z and R
+    const auto [zMin, zMax] = std::minmax_element(allPoints.begin(), allPoints.end(),
+      [](const ROOT::Math::XYZVector& a, const ROOT::Math::XYZVector& b) { return a.Z() < b.Z(); });
+    const auto [rMin, rMax] = std::minmax_element(allPoints.begin(), allPoints.end(),
+      [](const ROOT::Math::XYZVector& a, const ROOT::Math::XYZVector& b) { return a.Rho() < b.Rho(); });
 
-    extrema["minZ"] = zmin;
-    extrema["maxZ"] = zmax;
-    extrema["minR"] = rmin;
-    extrema["maxR"] = rmax;
+    std::map<std::string, double> extrema {
+      {"minZ", zMin->Z()},
+      {"maxZ", zMax->Z()},
+      {"minR", rMin->Rho()},
+      {"maxR", rMax->Rho()}
+    };
 
     return extrema;
-
   }
-
 
 bool DetectorModule::couldHit(double trackPhi, double trackSlope, double zError) const {
   // Checking that hit within a module region works for barrel-type modules only!!!

--- a/src/DetectorModule.cc
+++ b/src/DetectorModule.cc
@@ -197,43 +197,17 @@ std::map<std::string, double> DetectorModule::extremaWithHybrids() const {
     //    ----------------- top
     //    ----------------- bottom
 
-    double width = area() / length();
-    double expandedModWidth = width + 2 * serviceHybridWidth();
-    double expandedModLength = length() + outerSensorExtraLength() + 2 * frontEndHybridWidth();
-    double expandedModThickness;
-    if (!isPixelModule())
-      expandedModThickness = dsDistance() + sensorThickness() + supportPlateThickness();
-    else
-      expandedModThickness = sensorThickness() + chipThickness() + hybridThickness();
+    const double width = area() / length();
+    const double expandedModWidth = computeExpandedModWidth(width, serviceHybridWidth(),
+        deadAreaExtraWidth(), chipNegativeXExtraWidth(), chipPositiveXExtraWidth());
+    const double expandedModLength = computeExpandedModLength(length() + outerSensorExtraLength(),
+        frontEndHybridWidth(), deadAreaExtraLength());
+    const double expandedModThickness = computeExpandedModThickness(isPixelModule(), isTimingModule(),
+        dsDistance(), sensorThickness(), supportPlateThickness(), chipThickness(), hybridThickness());
 
-    const ROOT::Math::XYZVector& modCenter = center();
-    const ROOT::Math::XYZVector modX(getLocalX() * expandedModWidth * 0.5);
-    const ROOT::Math::XYZVector modY(getLocalY() * expandedModLength * 0.5);
-    const ROOT::Math::XYZVector modZ(normal() * expandedModThickness * 0.5);
-
-    // Expanded module corners
-    std::array<ROOT::Math::XYZVector, 4> xyCorners;
-    for (std::size_t i = 0; i < 4; ++i) {
-      double signX = (i == 0 || i == 3) ? 1. : -1;
-      double signY = (i == 0 || i == 1) ? 1. : -1;
-      xyCorners[i] = modCenter + signX * modX + signY * modY;
-    }
-
-    // Calculate all vertex candidates (corners + mid points)
-    std::array<ROOT::Math::XYZVector, 16> allPoints;
-    for (std::size_t i = 0; i < 4; ++i) {
-      std::size_t nextIdx = (i + 1) % 4;
-
-      // Top and bottom corners
-      auto botVtx = xyCorners[i] - modZ;
-      auto topVtx = xyCorners[i] + modZ;
-      allPoints[i*4]     = topVtx;
-      allPoints[i*4 + 1] = botVtx;
-
-      // Top and bottom midpoints between this corner and the next
-      allPoints[i*4 + 2] = (topVtx + (xyCorners[nextIdx] + modZ)) * 0.5;
-      allPoints[i*4 + 3] = (botVtx + (xyCorners[nextIdx] - modZ)) * 0.5;
-    }
+    const auto allPoints = CoordinateOperations::boundingBoxCandidates(
+        center(), XYZVector(getLocalX() * expandedModWidth * 0.5),
+        XYZVector(getLocalY() * expandedModLength * 0.5), normal() * expandedModThickness * 0.5);
 
     // Find min and max Z and R
     const auto [zMin, zMax] = std::minmax_element(allPoints.begin(), allPoints.end(),

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -513,6 +513,11 @@ namespace insur {
     //std::vector<std::vector<ModuleCap> >& ec = lagg.getEndcapCap();
     
     for (oiter = ec.begin(); oiter != ec.end(); oiter++) {
+      if (lagg.getEndcapLayers()->at(layer - 1)->minZ() <= 0) {  // skip z- endcap layers
+		layer++;
+		continue;
+	  }
+
       std::set<int> ridx;
       double lrmin = std::numeric_limits<double>::max();
       double lrmax = 0;
@@ -2386,8 +2391,9 @@ namespace insur {
 	double diskZ = 0;
 	if (ringsIndexes.size() < 2) std::cout << "!!!!!!Disk with less than 2 rings, unexpected" << std::endl;
 	else {
-	  int firstRingIndex = *(ringsIndexes.begin());
-	  int secondRingIndex = *ringsIndexes.begin() + 1;
+	  auto it = ringsIndexes.begin();
+	  int firstRingIndex = *it;
+	  int secondRingIndex = (std::advance(it, 1), *it);
 	  diskZ = (ringzmin.at(firstRingIndex) + ringzmax.at(firstRingIndex) + ringzmin.at(secondRingIndex) + ringzmax.at(secondRingIndex)) / 4.;
 	}
 	
@@ -3111,8 +3117,9 @@ namespace insur {
 	double diskZ = 0;
 	if (ringsIndexes.size() < 2) std::cout << "!!!!!!Disk with less than 2 rings, unexpected" << std::endl;
 	else {
-	  int firstRingIndex = *(ringsIndexes.begin());
-	  int secondRingIndex = *ringsIndexes.begin() + 1;
+	  auto it = ringsIndexes.begin();
+	  int firstRingIndex = *it;
+	  int secondRingIndex = (std::advance(it, 1), *it);
 	  diskZ = (ringzmin.at(firstRingIndex) + ringzmax.at(firstRingIndex) + ringzmin.at(secondRingIndex) + ringzmax.at(secondRingIndex)) / 4.;
 	}
 	

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -9,9 +9,90 @@
 //#define __FLIPSENSORS_IN__
 
 #include <Extractor.hh>
+
 #include <cstdlib>
+#include <cmath>
+#include <algorithm>
+#include <sstream>
+#include <array>
+#include <map>
+#include <vector>
 
 namespace insur {
+
+  // Helper function to calculate and store the yaw-adjusted rotation for barrel modules
+  static std::string getBarrelModuleRotation(std::map<std::string, Rotation>& r, bool isPixelTracker, bool isFlipped, double yaw) {
+    // If there is no yaw, fallback to the standard static tags
+    if (std::abs(yaw) < 1e-5) {
+        return (!isPixelTracker) ?
+               (isFlipped ? xml_OT_places_flipped_mod_in_rod : xml_OT_places_unflipped_mod_in_rod) :
+               (isFlipped ? xml_PX_places_flipped_mod_in_rod : xml_PX_places_unflipped_mod_in_rod);
+    }
+
+    // Define base vectors before applying yaw
+    std::array<double, 3> x_dir, y_dir, z_dir;
+    if (!isPixelTracker) {
+        if (!isFlipped) {
+            x_dir[0] = 0.0; x_dir[1] = 1.0; x_dir[2] = 0.0;
+            y_dir[0] = 0.0; y_dir[1] = 0.0; y_dir[2] = 1.0;
+            z_dir[0] = 1.0; z_dir[1] = 0.0; z_dir[2] = 0.0;
+        } else {
+            x_dir[0] = 0.0; x_dir[1] = -1.0; x_dir[2] = 0.0;
+            y_dir[0] = 0.0; y_dir[1] = 0.0;  y_dir[2] = 1.0;
+            z_dir[0] = -1.0; z_dir[1] = 0.0; z_dir[2] = 0.0;
+        }
+    } else {
+        if (!isFlipped) {
+            x_dir[0] = 0.0; x_dir[1] = -1.0; x_dir[2] = 0.0;
+            y_dir[0] = 0.0; y_dir[1] = 0.0;  y_dir[2] = -1.0;
+            z_dir[0] = 1.0; z_dir[1] = 0.0;  z_dir[2] = 0.0;
+        } else {
+            x_dir[0] = 0.0; x_dir[1] = 1.0;  x_dir[2] = 0.0;
+            y_dir[0] = 0.0; y_dir[1] = 0.0;  y_dir[2] = -1.0;
+            z_dir[0] = -1.0; z_dir[1] = 0.0; z_dir[2] = 0.0;
+        }
+    }
+
+    // Apply the yaw around the local Z axis
+    double cosY = std::cos(yaw);
+    double sinY = std::sin(yaw);
+
+    std::array<double, 3> nx_dir, ny_dir;
+    for (int i = 0; i < 3; ++i) {
+        nx_dir[i] = cosY * x_dir[i] + sinY * y_dir[i];
+        ny_dir[i] = -sinY * x_dir[i] + cosY * y_dir[i];
+    }
+
+    // Lambdas to convert Cartesian vectors back into CMSSW spherical coordinates
+    auto getTheta = [](const std::array<double, 3>& v) {
+        double z = v[2];
+        if (z > 1.0) z = 1.0;
+        if (z < -1.0) z = -1.0;
+        return std::acos(z) * (180.0 / M_PI);
+    };
+    auto getPhi = [](const std::array<double, 3>& v) {
+        double p = std::atan2(v[1], v[0]) * (180.0 / M_PI);
+        return (p < 0.0) ? p + 360.0 : p;
+    };
+
+    // Construct a unique rotation name 
+    std::ostringstream rotName;
+    rotName << (isPixelTracker ? "PX" : "OT")
+            << (isFlipped ? "_Flipped" : "_Unflipped")
+            << "_Yaw" << std::round(yaw * (180.0 / M_PI));
+    std::string name = rotName.str();
+
+    // Register rotation if it hasn't been generated yet
+    if (r.find(name) == r.end()) {
+        Rotation rot;
+        rot.name = name;
+        rot.thetax = getTheta(nx_dir); rot.phix = getPhi(nx_dir);
+        rot.thetay = getTheta(ny_dir); rot.phiy = getPhi(ny_dir);
+        rot.thetaz = getTheta(z_dir);  rot.phiz = getPhi(z_dir);
+        r.insert(std::make_pair(name, rot));
+    }
+    return name;
+  }
 
   //public
   /**
@@ -840,9 +921,6 @@ namespace insur {
 	unflippedLadderName << trackerXmlTags.tracker << xml_layer << layer << xml_rod << xml_unflipped; // e.g. OTLayer1RodUnflipped
       }
 
-      std::string places_unflipped_mod_in_rod = (!isPixelTracker ? xml_OT_places_unflipped_mod_in_rod : xml_PX_places_unflipped_mod_in_rod);
-      std::string places_flipped_mod_in_rod = (!isPixelTracker ? xml_OT_places_flipped_mod_in_rod : xml_PX_places_flipped_mod_in_rod);
-
       double firstPhiRodMeanPhi = 0;
       double nextPhiRodMeanPhi = 0;
 
@@ -858,6 +936,33 @@ namespace insur {
       std::map<int, BTiltedRingInfo> rinfoplus; // positive-z side
       std::map<int, BTiltedRingInfo> rinfominus; // negative-z side
 
+	  // Collect the irregular ring parameter arrays
+      std::map<int, std::vector<double>> phi_plus_one, phi_minus_one, phi_plus_two, phi_minus_two;
+      std::map<int, std::vector<double>> radius_plus_one, radius_minus_one, radius_plus_two, radius_minus_two;
+      std::map<int, std::vector<double>> yaw_plus_one, yaw_minus_one, yaw_plus_two, yaw_minus_two;
+
+      for (auto tmp_iiter = oiter->begin(); tmp_iiter != oiter->end(); tmp_iiter++) {
+        if (isTilted && tmp_iiter->getModule().tiltAngle() != 0) {
+          int modRing = tmp_iiter->getModule().uniRef().ring;
+          double phi = tmp_iiter->getModule().center().Phi() * (180. / M_PI);
+          double radius = tmp_iiter->getModule().center().Rho();
+          double yaw = tmp_iiter->getModule().yawAngle() * (180. / M_PI);
+
+          if (tmp_iiter->getModule().uniRef().phi % 2 == 1) {
+            if (tmp_iiter->getModule().uniRef().side > 0) {
+                phi_plus_one[modRing].push_back(phi); radius_plus_one[modRing].push_back(radius); yaw_plus_one[modRing].push_back(yaw);
+            } else {
+                phi_minus_one[modRing].push_back(phi); radius_minus_one[modRing].push_back(radius); yaw_minus_one[modRing].push_back(yaw);
+            }
+          } else {
+            if (tmp_iiter->getModule().uniRef().side > 0) {
+                phi_plus_two[modRing].push_back(phi); radius_plus_two[modRing].push_back(radius); yaw_plus_two[modRing].push_back(yaw);
+            } else {
+                phi_minus_two[modRing].push_back(phi); radius_minus_two[modRing].push_back(radius); yaw_minus_two[modRing].push_back(yaw);
+            }
+          }
+        }
+      }
 
       // LOOP ON MODULE CAPS 
       for (iiter = oiter->begin(); iiter != oiter->end(); iiter++) {
@@ -1009,8 +1114,8 @@ namespace insur {
 	      pos.trans.dx = iiter->getModule().center().Rho() - firstPhiRodRadius;
 	      pos.trans.dz = iiter->getModule().center().Z();
 
-	      if (!iiter->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
-	      else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
+	      double yaw = iiter->getModule().yawAngle();
+		  pos.rotref = trackerXmlTags.nspace + ":" + getBarrelModuleRotation(r, isPixelTracker, iiter->getModule().flipped(), yaw);
 	      pos.copy = (!iiter->getModule().isTimingModule() ? 1 : timingModuleCopyNumber);
 	      if (iiter->getModule().isTimingModule()) pos.child_tag = childName + xml_positive_z;
 	      p.push_back(pos);
@@ -1020,8 +1125,8 @@ namespace insur {
 		pos.trans.dx = partner->getModule().center().Rho() - firstPhiRodRadius;
 		pos.trans.dz = partner->getModule().center().Z();
 
-		if (!partner->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
-		else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
+		double partnerYaw = partner->getModule().yawAngle();
+		pos.rotref = trackerXmlTags.nspace + ":" + getBarrelModuleRotation(r, isPixelTracker, partner->getModule().flipped(), partnerYaw);
 		pos.copy = (!iiter->getModule().isTimingModule() ? 2 : timingModuleCopyNumber);
 		if (iiter->getModule().isTimingModule()) pos.child_tag = childName + xml_negative_z;
 		p.push_back(pos);
@@ -1041,17 +1146,16 @@ namespace insur {
 		pos.child_tag = trackerXmlTags.nspace + ":" + mname.str();
 		pos.trans.dx = iiter->getModule().center().Rho() - nextPhiRodRadius;
 		pos.trans.dz = iiter->getModule().center().Z();
-		if (!iiter->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
-		else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
+		double yaw = iiter->getModule().yawAngle();
+		pos.rotref = trackerXmlTags.nspace + ":" + getBarrelModuleRotation(r, isPixelTracker, iiter->getModule().flipped(), yaw);
 		p.push_back(pos);
 	      
 		// This is a copy of the BModule on -Z side
 		if (partner != oiter->end()) {
 		  pos.trans.dx = partner->getModule().center().Rho() - nextPhiRodRadius;
 		  pos.trans.dz = partner->getModule().center().Z();
-		  if (!partner->getModule().flipped()) { pos.rotref = trackerXmlTags.nspace + ":" + places_unflipped_mod_in_rod; }
-		  else { pos.rotref = trackerXmlTags.nspace + ":" + places_flipped_mod_in_rod; }
-		  pos.copy = 2; 
+		  double partnerYaw = partner->getModule().yawAngle();
+		  pos.rotref = trackerXmlTags.nspace + ":" + getBarrelModuleRotation(r, isPixelTracker, partner->getModule().flipped(), partnerYaw);		  pos.copy = 2; 
 		  p.push_back(pos);
 		  pos.copy = 1;
 		}
@@ -2018,7 +2122,7 @@ namespace insur {
 	      //trspec.moduletypes.push_back(minfo_zero);
 	      
 	      // Tilted ring: first part to be stored
-	      alg.name = xml_trackerring_algo;
+	      alg.name = xml_trackerring_irregular_algo;
 	      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
 	      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
 	      pconverter << (rinfo.modules / 2);
@@ -2043,11 +2147,24 @@ namespace insur {
 	      pconverter << rinfo.bw_flipped;
 	      alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
 	      pconverter.str("");
+
+		  // Module position and yaw in tilted rings
+          int ringIndex = ringinfo.first;
+          if (rinfo.isZPlus && phi_plus_one[ringIndex].size() > 0) {
+            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_plus_one[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_plus_one[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_plus_one[ringIndex]));
+          } else if (!rinfo.isZPlus && phi_minus_one[ringIndex].size() > 0) {
+            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_minus_one[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_minus_one[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_minus_one[ringIndex]));
+          }
+
 	      a.push_back(alg);
 	      alg.parameters.clear();
 	      
 	      // Tilted ring: second part to be stored
-	      alg.name =  xml_trackerring_algo;
+	      alg.name = xml_trackerring_irregular_algo;
 	      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
 	      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
 	      pconverter << (rinfo.modules / 2);
@@ -2072,6 +2189,18 @@ namespace insur {
 	      pconverter << rinfo.fw_flipped;
 	      alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
 	      pconverter.str("");
+
+		  // Module position and yaw in tilted rings
+          if (rinfo.isZPlus && phi_plus_two[ringIndex].size() > 0) {
+            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_plus_two[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_plus_two[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_plus_two[ringIndex]));
+          } else if (!rinfo.isZPlus && phi_minus_two[ringIndex].size() > 0) {
+            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_minus_two[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_minus_two[ringIndex]));
+            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_minus_two[ringIndex]));
+          }
+
 	      a.push_back(alg);
 	      alg.parameters.clear();
 	    }

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -941,6 +941,78 @@ namespace insur {
       std::map<int, BTiltedRingInfo> rinfoplus; // positive-z side
       std::map<int, BTiltedRingInfo> rinfominus; // negative-z side
 
+      // OT BARREL: collect per-rod placement data (phi, radius, yaw) indexed by rod phi index.
+      // Used for both non-tilted layers and the flat-part rods of tilted layers.
+      // Replaces DDTrackerPhiAltAlgo with DDTrackerXYZPosAlgo so rods with different yaw angles
+      // (e.g. toggled by yawFlipRods in TiltedRodPair) can each be placed correctly.
+      struct OTRodPlacementData {
+        double centerPhi;    // rod center phi in radians
+        double centerRadius; // rod center radius in mm (avg of ring-1 and ring-2)
+        double yaw;          // representative yaw in radians
+      };
+      std::map<int, OTRodPlacementData> otRodPlacementByPhiIdx; // phi_index -> data
+
+      if (!isPixelTracker && !isTimingLayer) {
+        // Accumulate ring-1 and ring-2 Rho per phi index so that averaging cancels ±smallDelta.
+        // For tilted layers only flat-part modules (tiltAngle==0) are used; tilted-ring modules
+        // are handled separately by DDTrackerIrregularRingAlgo and are excluded here.
+        struct RodAccum {
+          double phi = 0.;
+          double yaw = 0.;
+          double sumRho = 0.;
+          int count=0;
+          bool hasRing1=false;
+        };
+        std::map<int, RodAccum> rodAccum;
+        for (auto& mod : *oiter) {
+          if (isTilted && mod.getModule().tiltAngle() != 0) continue; // skip tilted rings
+          const int phiIdx = mod.getModule().uniRef().phi;
+          const int ring   = mod.getModule().uniRef().ring;
+          if (mod.getModule().uniRef().side > 0 && (ring == 1 || ring == 2)) {
+            auto& acc = rodAccum[phiIdx];
+            acc.sumRho += mod.getModule().center().Rho();
+            acc.count++;
+            // Prefer ring-1 for phi/yaw; fall back to ring-2 if ring-1 not seen yet.
+            if (ring == 1) {
+              acc.phi = mod.getModule().center().Phi();
+              acc.yaw = mod.getModule().yawAngle();
+              acc.hasRing1 = true;
+            } else if (!acc.hasRing1) {
+              acc.phi = mod.getModule().center().Phi();
+              acc.yaw = mod.getModule().yawAngle();
+            }
+          }
+        }
+        for (const auto& [phiIdx, acc] : rodAccum) {
+          if (acc.count > 0) {
+            otRodPlacementByPhiIdx[phiIdx] = {
+              acc.phi,
+              acc.sumRho / acc.count,  // average of ring-1 and ring-2 cancels ±smallDelta
+              acc.yaw
+            };
+          }
+        }
+      }
+
+      // Determine the distinct yaw states across all rods (rounded to nearest degree).
+      // phi==1 rod is always the "base" template (ladderName). Any additional yaw state
+      // gets a secondary template named ladderName + "Yaw" + yaw_deg.
+      std::map<double, std::string> yawDegToTemplateName; // rounded_yaw_deg -> rod volume name
+      if (!otRodPlacementByPhiIdx.empty()) {
+        // The lowest phi index present is the primary template (normally phi==1).
+        const int primaryPhiIdx = otRodPlacementByPhiIdx.begin()->first;
+        const double phi1YawDeg = std::round(otRodPlacementByPhiIdx.at(primaryPhiIdx).yaw * 180.0 / M_PI);
+        yawDegToTemplateName[phi1YawDeg] = ladderName.str();
+        for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
+          const double yawDeg = std::round(data.yaw * 180.0 / M_PI);
+          if (yawDegToTemplateName.find(yawDeg) == yawDegToTemplateName.end()) {
+            std::ostringstream altName;
+            altName << ladderName.str() << "Yaw" << static_cast<int>(yawDeg);
+            yawDegToTemplateName[yawDeg] = altName.str();
+          }
+        }
+      }
+
 	  // Collect the irregular ring parameter arrays
       std::map<int, std::vector<double>> phi_plus_one, phi_minus_one, phi_plus_two, phi_minus_two;
       std::map<int, std::vector<double>> radius_plus_one, radius_minus_one, radius_plus_two, radius_minus_two;
@@ -1617,6 +1689,65 @@ namespace insur {
 	ri.push_back(ril);
       }
 
+      // OT STRAIGHT BARREL: build module placements for secondary rod templates (non-base yaw states).
+      // Each distinct yaw state beyond the primary (phi==1) needs a separate rod logical volume.
+      // All secondary templates share the same box shape as Template A but carry different module
+      // rotation references to correctly orient modules in rods that are yaw-rotated relative to
+      // the primary rod. Module positions (dx, dz) are the same since flat-barrel modules sit at
+      // the rod's centre radius (dx ≈ 0) and the same Z positions regardless of rod yaw.
+      if (!isPixelTracker && !isTimingLayer && yawDegToTemplateName.size() > 1) {
+        // For each additional yaw state, find its representative phi index (the lowest phi index
+        // with that yaw) and replay the module-placement pass for it.
+        for (const auto& [yawDeg, templateName] : yawDegToTemplateName) {
+          if (templateName == ladderName.str()) continue; // primary template already built
+
+          // Find the representative phi index for this yaw state
+          int repPhiIdx = -1;
+          for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
+            if (std::round(data.yaw * (180.0 / M_PI)) == yawDeg) {
+              if (repPhiIdx < 0 || phiIdx < repPhiIdx) repPhiIdx = phiIdx;
+            }
+          }
+          if (repPhiIdx < 0) continue;
+          const double repRodCenterRadius = otRodPlacementByPhiIdx.at(repPhiIdx).centerRadius;
+
+          // Replay PosParts for all modules in the representative rod
+          for (iiter = oiter->begin(); iiter != oiter->end(); iiter++) {
+            if (iiter->getModule().uniRef().side <= 0) continue;
+            if (iiter->getModule().uniRef().phi != repPhiIdx) continue;
+            if (isTilted && iiter->getModule().tiltAngle() != 0) continue;
+
+            const int modRing = iiter->getModule().uniRef().ring;
+            std::ostringstream mname;
+            mname << lname.str() << xml_R << modRing << xml_barrel_module;
+
+            pos.parent_tag = trackerXmlTags.nspace + ":" + templateName;
+            pos.child_tag  = trackerXmlTags.nspace + ":" + mname.str();
+            pos.trans.dx = iiter->getModule().center().Rho() - repRodCenterRadius;
+            pos.trans.dz = iiter->getModule().center().Z();
+            const double altYaw = iiter->getModule().yawAngle();
+            pos.rotref = trackerXmlTags.nspace + ":" +
+                         getBarrelModuleRotation(r, isPixelTracker, iiter->getModule().flipped(), altYaw);
+            pos.copy = 1;
+            p.push_back(pos);
+
+            // -Z side partner
+            std::vector<ModuleCap>::iterator partner = findPartnerModule(iiter, oiter->end(), modRing);
+            if (partner != oiter->end()) {
+              pos.trans.dx = partner->getModule().center().Rho() - repRodCenterRadius;
+              pos.trans.dz = partner->getModule().center().Z();
+              const double partnerAltYaw = partner->getModule().yawAngle();
+              pos.rotref = trackerXmlTags.nspace + ":" +
+                           getBarrelModuleRotation(r, isPixelTracker, partner->getModule().flipped(), partnerAltYaw);
+              pos.copy = 2;
+              p.push_back(pos);
+            }
+            pos.copy = 1;
+            pos.rotref = "";
+          }
+        }
+      }
+
 
       // rod(s)
       shape.name_tag = ladderName.str();
@@ -1680,6 +1811,20 @@ namespace insur {
       srspec.partselectors.push_back(ladderName.str());
       srspec.moduletypes.push_back(minfo_zero);
 
+      // OT BARREL: register secondary rod logical volumes (same shape, different name).
+      if (!isPixelTracker && !isTimingLayer && yawDegToTemplateName.size() > 1) {
+        for (const auto& [yawDeg, templateName] : yawDegToTemplateName) {
+          if (templateName == ladderName.str()) continue;
+          logic.name_tag   = templateName;
+          logic.shape_tag  = trackerXmlTags.nspace + ":" + ladderName.str(); // reuse primary shape
+          logic.material_tag = xml_material_air;
+          l.push_back(logic);
+          rspec.partselectors.push_back(templateName);
+          rspec.moduletypes.push_back(minfo_zero);
+          srspec.partselectors.push_back(templateName);
+          srspec.moduletypes.push_back(minfo_zero);
+        }
+      }
 
 
       // rods in layer algorithm(s)
@@ -1690,108 +1835,179 @@ namespace insur {
 
       // OUTER TRACKER
       if (!isPixelTracker) {
-	if (!hasPhiForbiddenRanges) {
-	  alg.name = xml_phialt_algo;
-	  alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-	  pconverter <<  trackerXmlTags.nspace + ":" + ladderName.str();
-	  alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
-	  alg.parameters.push_back(numericParam(xml_tilt, "90*deg")); // This "tilt" here has nothing to do with the tilt angle of a tilted TBPS.
-	  // It is an angle used internally by PhiAltAlgo to shift in Phi the startAngle ( in (X,Y) plane).
-	  // 90 deg corresponds to no shift. SHOULD NOT BE MODIFIED!!	  
-	  // Is firstPhiRod placed at inner radius?
-	  const bool isFirstPhiRodAtInnerRadius = (fabs(firstPhiRodRadius - innerLadderCenterRadius) < xml_epsilon);
-	  // The algo (as implemeted in CMSSW) starts by placing the inner radius rod, no matter what!
-	  // So need to start placing rods from the inner rod mean phi.
-	  const double algoStartPhi = (isFirstPhiRodAtInnerRadius ? firstPhiRodMeanPhi : nextPhiRodMeanPhi); 
-	  pconverter.str("");
-	  pconverter << algoStartPhi * 180. / M_PI << "*deg"; 
-	  alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-	  pconverter.str("");
-	  alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-	  pconverter << innerLadderCenterRadius << "*mm";
-	  alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << outerLadderCenterRadius << "*mm";
-	  alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
-	  pconverter.str("");
-	  alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
-	  pconverter << lagg.getBarrelLayers()->at(layer - 1)->numRods();
-	  alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
-	  pconverter.str("");
-	  alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-	  alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-	  a.push_back(alg);
-	  alg.parameters.clear();
-	}
-	else {
-	  int numRods = lagg.getBarrelLayers()->at(layer - 1)->numRods();
-	  int forbiddenPhiUpperAIndex = numRods / 2;
-	  int forbiddenPhiLowerBIndex = forbiddenPhiUpperAIndex + 1;
 
-	  alg.name = xml_phialt_algo;
-	  alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-	  pconverter <<  trackerXmlTags.nspace + ":" + ladderName.str();
-	  alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
-	  alg.parameters.push_back(numericParam(xml_tilt, "90*deg")); // This "tilt" here has nothing to do with the tilt angle of a tilted TBPS.
-	  // It is an angle used internally by PhiAltAlgo to shift in Phi the startAngle ( in (X,Y) plane).
-	  // 90 deg corresponds to no shift. SHOULD NOT BE MODIFIED!!
-	  pconverter.str("");
-	  pconverter << phiForbiddenRanges.at(1) * 180. / M_PI << "*deg";
-	  alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << (phiForbiddenRanges.at(forbiddenPhiUpperAIndex) - phiForbiddenRanges.at(1)) * 180. / M_PI << "*deg";
-	  alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
-	  // WARNING: Set RadisuIn parameter to the radius of the firstPhiRod.
-	  // The algorithm will indeed start by placing (in phi) that firstPhiRod, at radius whatever is assigned to radisuIn.
-	  // RadiusIn is just a name, and does not imply that the radius is low !!!!
-	  // Look at PhiAltAlgo implementation.
-	  pconverter.str("");
-	  pconverter << firstPhiRodRadius << "*mm";
-	  alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << nextPhiRodRadius << "*mm";
-	  alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
-	  pconverter.str("");
-	  alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
-	  pconverter << numRods / 2;
-	  alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
-	  alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-	  alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-	  a.push_back(alg);
-	  alg.parameters.clear();
+        // Register a per-rod phi placement rotation and return its name.
+        // Returns "NULL" when phi_rad ≈ 0 (identity; no rotation tag needed).
+        auto registerRodPhiRotation = [&](double phi_rad) -> std::string {
+          const double phi_deg = phi_rad * (180.0 / M_PI);
+          double norm_deg = std::fmod(phi_deg, 360.0);
+          if (norm_deg < 0.0) norm_deg += 360.0;
+          // CMSSW tolerance. TODO: Encapsulate it in a function.
+          if (std::fabs(norm_deg) < 1e-6 || std::fabs(norm_deg - 360.0) < 1e-6) return "NULL";
+          std::ostringstream rotName;
+          rotName << lname.str() << "_RodPhi" << static_cast<int>(std::round(norm_deg * 10.0));
+          const std::string name = rotName.str();
+          if (r.find(name) == r.end()) {
+            Rotation rot;
+            rot.name   = name;
+            rot.thetax = 90.0; rot.phix = norm_deg;
+            rot.thetay = 90.0; rot.phiy = norm_deg + 90.0;
+            rot.thetaz = 0.0;  rot.phiz = 0.0;
+            r.insert(std::make_pair(name, rot));
+          }
+          return name;
+        };
 
-	  alg.name = xml_phialt_algo;
-	  alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-	  pconverter.str("");
-	  pconverter <<  trackerXmlTags.nspace + ":" + ladderName.str();
-	  alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
-	  alg.parameters.push_back(numericParam(xml_tilt, "90*deg")); // This "tilt" here has nothing to do with the tilt angle of a tilted TBPS.
-	  // It is an angle used internally by PhiAltAlgo to shift in Phi the startAngle ( in (X,Y) plane).
-	  // 90 deg corresponds to no shift. SHOULD NOT BE MODIFIED!!
-	  pconverter.str("");
-	  pconverter << phiForbiddenRanges.at(forbiddenPhiLowerBIndex) * 180. / M_PI << "*deg";
-	  alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << (phiForbiddenRanges.at(numRods) - phiForbiddenRanges.at(forbiddenPhiLowerBIndex)) * 180. / M_PI << "*deg";
-	  alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << firstPhiRodRadius << "*mm";
-	  alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << nextPhiRodRadius << "*mm";
-	  alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
-	  pconverter.str("");
-	  alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
-	  pconverter << numRods / 2;
-	  alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
-	  pconverter.str("");
-	  pconverter << forbiddenPhiLowerBIndex;
-	  alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
-	  alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-	  a.push_back(alg);
-	  pconverter.str("");
-	  alg.parameters.clear();
-	}
+        // NON-TILTED OT LAYERS: one DDTrackerXYZPosAlgo block per rod.
+        // copy number = phi index, matching the PhiAltAlgo convention.
+        // One-block-per-yaw-group with IncrCopyNo=numGroups was wrong: yaw groups are
+        // NOT uniformly interleaved in the real geometry (e.g. L1 has AA-BB-AA-BB pairs),
+        // so the arithmetic copy-number sequence would overlap or skip phi indices.
+        if (!isTilted && !otRodPlacementByPhiIdx.empty()) {
+        for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
+          const double yawDeg = std::round(data.yaw * 180.0 / M_PI);
+          const std::string& templateName = yawDegToTemplateName.at(yawDeg);
+          const std::string rotName = registerRodPhiRotation(data.centerPhi);
+          const std::string rotEntry = (rotName == "NULL") ? "NULL"
+                                                           : trackerXmlTags.nspace + ":" + rotName;
+          alg.name   = xml_xyzpos_algo;
+          alg.parent = trackerXmlTags.nspace + ":" + lname.str();
+          alg.parameters.push_back(stringParam(xml_childparam,
+                                               trackerXmlTags.nspace + ":" + templateName));
+          pconverter.str(""); pconverter << phiIdx;
+          alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+          alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+          alg.parameters.push_back(arbitraryLengthVector("XPositions",
+              std::vector<double>{data.centerRadius * std::cos(data.centerPhi)}));
+          alg.parameters.push_back(arbitraryLengthVector("YPositions",
+              std::vector<double>{data.centerRadius * std::sin(data.centerPhi)}));
+          alg.parameters.push_back(arbitraryLengthVector("ZPositions",
+              std::vector<double>{0.0}));
+          alg.parameters.push_back(arbitraryLengthStringVector("Rotations",
+              std::vector<std::string>{rotEntry}));
+          a.push_back(alg);
+          alg.parameters.clear();
+        }
+        } // end !isTilted XYZPosAlgo path
+
+        // TILTED OT LAYERS: flat-part rods via DDTrackerXYZPosAlgo (per-rod blocks).
+        // Falls back to DDTrackerPhiAltAlgo only when no flat-part modules were found.
+        else if (isTilted) {
+          if (!otRodPlacementByPhiIdx.empty()) {
+          for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
+            const double yawDeg = std::round(data.yaw * 180.0 / M_PI);
+            const std::string& templateName = yawDegToTemplateName.at(yawDeg);
+            const std::string rotName = registerRodPhiRotation(data.centerPhi);
+            const std::string rotEntry = (rotName == "NULL") ? "NULL"
+                                                             : trackerXmlTags.nspace + ":" + rotName;
+            alg.name   = xml_xyzpos_algo;
+            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
+            alg.parameters.push_back(stringParam(xml_childparam,
+                                                 trackerXmlTags.nspace + ":" + templateName));
+            pconverter.str(""); pconverter << phiIdx;
+            alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+            alg.parameters.push_back(arbitraryLengthVector("XPositions",
+                std::vector<double>{data.centerRadius * std::cos(data.centerPhi)}));
+            alg.parameters.push_back(arbitraryLengthVector("YPositions",
+                std::vector<double>{data.centerRadius * std::sin(data.centerPhi)}));
+            alg.parameters.push_back(arbitraryLengthVector("ZPositions",
+                std::vector<double>{0.0}));
+            alg.parameters.push_back(arbitraryLengthStringVector("Rotations",
+                std::vector<std::string>{rotEntry}));
+            a.push_back(alg);
+            alg.parameters.clear();
+          }
+          } else { // fallback: no flat-part modules found, keep PhiAltAlgo
+          pconverter.str("");  // clear any residual state from prior loops
+          if (!hasPhiForbiddenRanges) {
+            alg.name = xml_phialt_algo;
+            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
+            pconverter.str(""); pconverter << trackerXmlTags.nspace + ":" + ladderName.str();
+            alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
+            alg.parameters.push_back(numericParam(xml_tilt, "90*deg"));
+            const bool isFirstPhiRodAtInnerRadius = (fabs(firstPhiRodRadius - innerLadderCenterRadius) < xml_epsilon);
+            const double algoStartPhi = (isFirstPhiRodAtInnerRadius ? firstPhiRodMeanPhi : nextPhiRodMeanPhi);
+            pconverter.str("");
+            pconverter << algoStartPhi * 180. / M_PI << "*deg";
+            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
+            pconverter.str("");
+            alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
+            pconverter.str(""); pconverter << innerLadderCenterRadius << "*mm";
+            alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
+            pconverter.str("");
+            pconverter << outerLadderCenterRadius << "*mm";
+            alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
+            pconverter.str("");
+            alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
+            pconverter.str(""); pconverter << lagg.getBarrelLayers()->at(layer - 1)->numRods();
+            alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
+            pconverter.str("");
+            alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
+            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+            a.push_back(alg);
+            alg.parameters.clear();
+          } else {
+            int numRods = lagg.getBarrelLayers()->at(layer - 1)->numRods();
+            int forbiddenPhiUpperAIndex = numRods / 2;
+            int forbiddenPhiLowerBIndex = forbiddenPhiUpperAIndex + 1;
+            alg.name = xml_phialt_algo;
+            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
+            pconverter.str(""); pconverter << trackerXmlTags.nspace + ":" + ladderName.str();
+            alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
+            alg.parameters.push_back(numericParam(xml_tilt, "90*deg"));
+            pconverter.str("");
+            pconverter << phiForbiddenRanges.at(1) * 180. / M_PI << "*deg";
+            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
+            pconverter.str("");
+            pconverter << (phiForbiddenRanges.at(forbiddenPhiUpperAIndex) - phiForbiddenRanges.at(1)) * 180. / M_PI << "*deg";
+            alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
+            pconverter.str("");
+            pconverter << firstPhiRodRadius << "*mm";
+            alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
+            pconverter.str("");
+            pconverter << nextPhiRodRadius << "*mm";
+            alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
+            pconverter.str("");
+            alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
+            pconverter.str(""); pconverter << numRods / 2;
+            alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
+            alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
+            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+            a.push_back(alg);
+            alg.parameters.clear();
+            alg.name = xml_phialt_algo;
+            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
+            pconverter.str("");
+            pconverter << trackerXmlTags.nspace + ":" + ladderName.str();
+            alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
+            alg.parameters.push_back(numericParam(xml_tilt, "90*deg"));
+            pconverter.str("");
+            pconverter << phiForbiddenRanges.at(forbiddenPhiLowerBIndex) * 180. / M_PI << "*deg";
+            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
+            pconverter.str("");
+            pconverter << (phiForbiddenRanges.at(numRods) - phiForbiddenRanges.at(forbiddenPhiLowerBIndex)) * 180. / M_PI << "*deg";
+            alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
+            pconverter.str("");
+            pconverter << firstPhiRodRadius << "*mm";
+            alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
+            pconverter.str("");
+            pconverter << nextPhiRodRadius << "*mm";
+            alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
+            pconverter.str("");
+            alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
+            pconverter.str(""); pconverter << numRods / 2;
+            alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
+            pconverter.str("");
+            pconverter << forbiddenPhiLowerBIndex;
+            alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+            a.push_back(alg);
+            pconverter.str("");
+            alg.parameters.clear();
+          }
+          } // end fallback PhiAltAlgo
+        }
       }
 
       // INNER TRACKER
@@ -2130,26 +2346,26 @@ namespace insur {
 	      alg.name = xml_trackerring_irregular_algo;
 	      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
 	      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
-	      pconverter << (rinfo.modules / 2);
+	      pconverter.str(""); pconverter << (rinfo.modules / 2);
 	      alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
 	      pconverter.str("");
 	      alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
 	      alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
 	      alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-	      pconverter << rinfo.startPhiAngle1 * 180. / M_PI << "*deg";
+	      pconverter.str(""); pconverter << rinfo.startPhiAngle1 * 180. / M_PI << "*deg";
 	      alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
 	      pconverter.str("");
 	      pconverter << rinfo.r1 << "*mm";
 	      alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
 	      pconverter.str("");
-	      alg.parameters.push_back(vectorParam(0, 0, (rinfo.z1 - rinfo.z2) / 2.0));	      
-	      pconverter << rinfo.isZPlus;
+	      alg.parameters.push_back(vectorParam(0, 0, (rinfo.z1 - rinfo.z2) / 2.0));
+	      pconverter.str(""); pconverter << rinfo.isZPlus;
 	      alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
 	      pconverter.str("");
-	      pconverter << rinfo.tiltAngle << "*deg";
+	      pconverter.str(""); pconverter << rinfo.tiltAngle << "*deg";
 	      alg.parameters.push_back(numericParam(xml_tiltangle, pconverter.str()));
 	      pconverter.str("");
-	      pconverter << rinfo.bw_flipped;
+	      pconverter.str(""); pconverter << rinfo.bw_flipped;
 	      alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
 	      pconverter.str("");
 
@@ -2172,26 +2388,26 @@ namespace insur {
 	      alg.name = xml_trackerring_irregular_algo;
 	      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
 	      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
-	      pconverter << (rinfo.modules / 2);
+	      pconverter.str(""); pconverter << (rinfo.modules / 2);
 	      alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
 	      pconverter.str("");
 	      alg.parameters.push_back(numericParam(xml_startcopyno, "2"));
 	      alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
 	      alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-	      pconverter << rinfo.startPhiAngle2 * 180. / M_PI << "*deg";
+	      pconverter.str(""); pconverter << rinfo.startPhiAngle2 * 180. / M_PI << "*deg";
 	      alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
 	      pconverter.str("");
 	      pconverter << rinfo.r2 << "*mm";
 	      alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
 	      pconverter.str("");
 	      alg.parameters.push_back(vectorParam(0, 0, (rinfo.z2 - rinfo.z1) / 2.0));
-	      pconverter << rinfo.isZPlus;
+	      pconverter.str(""); pconverter << rinfo.isZPlus;
 	      alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
 	      pconverter.str("");
-	      pconverter << rinfo.tiltAngle << "*deg";
+	      pconverter.str(""); pconverter << rinfo.tiltAngle << "*deg";
 	      alg.parameters.push_back(numericParam(xml_tiltangle, pconverter.str()));
 	      pconverter.str("");
-	      pconverter << rinfo.fw_flipped;
+	      pconverter.str(""); pconverter << rinfo.fw_flipped;
 	      alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
 	      pconverter.str("");
 
@@ -2847,13 +3063,13 @@ namespace insur {
             if(!myRingInfo.isRegularRing) alg.name=xml_trackerring_irregular_algo;
             alg.parent = logic.shape_tag;
             alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
-            pconverter << (myRingInfo.numModules / 2);
+            pconverter.str(""); pconverter << (myRingInfo.numModules / 2);
             alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
             pconverter.str("");
             alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
             alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
             alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-            pconverter << myRingInfo.surface1StartPhi * 180. / M_PI << "*deg";
+            pconverter.str(""); pconverter << myRingInfo.surface1StartPhi * 180. / M_PI << "*deg";
             alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
             pconverter.str("");
             pconverter << myRingInfo.radiusMid << "*mm";
@@ -2866,13 +3082,13 @@ namespace insur {
               pconverter.str("");
               alg.parameters.push_back(arbitraryLengthVector("radiusValues",radius_one[ringIndex]));
               pconverter.str("");
-            } 
+            }
 	    alg.parameters.push_back(vectorParam(0, 0, myRingInfo.surface1ZMid - myRingInfo.zMid));
-	    pconverter << myRingInfo.isDiskAtPlusZEnd;
+	    pconverter.str(""); pconverter << myRingInfo.isDiskAtPlusZEnd;
 	    alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
 	    pconverter.str("");
 	    alg.parameters.push_back(numericParam(xml_tiltangle, "90*deg"));
-	    pconverter << myRingInfo.surface1IsFlipped;
+	    pconverter.str(""); pconverter << myRingInfo.surface1IsFlipped;
 	    alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
 	    pconverter.str("");
             a.push_back(alg);
@@ -2882,13 +3098,13 @@ namespace insur {
 	    alg.name = xml_trackerring_algo;
             if(!myRingInfo.isRegularRing) alg.name=xml_trackerring_irregular_algo;
             alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
-            pconverter << (myRingInfo.numModules / 2);
+            pconverter.str(""); pconverter << (myRingInfo.numModules / 2);
             alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
             pconverter.str("");
             alg.parameters.push_back(numericParam(xml_startcopyno, "2"));
             alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
             alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-            pconverter << myRingInfo.surface2StartPhi * 180. / M_PI << "*deg";
+            pconverter.str(""); pconverter << myRingInfo.surface2StartPhi * 180. / M_PI << "*deg";
             alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
             pconverter.str("");
             pconverter << myRingInfo.radiusMid << "*mm";
@@ -2901,13 +3117,13 @@ namespace insur {
               pconverter.str("");
               alg.parameters.push_back(arbitraryLengthVector("radiusValues",radius_two[ringIndex]));
               pconverter.str("");
-            } 
+            }
 	    alg.parameters.push_back(vectorParam(0, 0, myRingInfo.surface2ZMid - myRingInfo.zMid));
-	    pconverter << myRingInfo.isDiskAtPlusZEnd;
+	    pconverter.str(""); pconverter << myRingInfo.isDiskAtPlusZEnd;
 	    alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
 	    pconverter.str("");
 	    alg.parameters.push_back(numericParam(xml_tiltangle, "90*deg"));
-	    pconverter << myRingInfo.surface2IsFlipped;
+	    pconverter.str(""); pconverter << myRingInfo.surface2IsFlipped;
 	    alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
 	    pconverter.str("");
             a.push_back(alg);
@@ -4390,6 +4606,19 @@ namespace insur {
     }
     return res.str();
  }
+
+  std::string Extractor::arbitraryLengthStringVector(std::string name, std::vector<std::string> invec){
+    std::ostringstream res;
+    std::string vector_opening = "<Vector name=\""+name+"\" type=\"string\" nEntries=\""+std::to_string(invec.size())+"\">";
+    if(invec.size() > 0){
+      res << vector_opening << invec.at(0);
+      for(unsigned int i=1; i<invec.size();i++){
+        res << "," << invec.at(i);
+      }
+      res << "</Vector>\n";  // no leading space — trailing space corrupts the last string token
+    }
+    return res.str();
+  }
     
 
   /**

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -994,6 +994,31 @@ namespace insur {
         }
       }
 
+      // IT BARREL: collect per-ladder placement data (phi, radius, flipped/skewed status), indexed by phi index.
+      // Used to replace DDTrackerAngularAlgorithm with explicit per-ladder DDTrackerXYZPosAlgo blocks.
+      struct ITLadderPlacementData {
+        double centerPhi;
+        double centerRadius;
+        bool isFlipped;
+        bool isSkewed;
+      };
+      std::map<int, ITLadderPlacementData> itLadderByPhiIdx;
+      if (isPixelTracker) {
+        for (auto& mod : *oiter) {
+          if (mod.getModule().uniRef().side > 0 && mod.getModule().uniRef().ring == 1) {
+            const int phiIdx = mod.getModule().uniRef().phi;
+            if (itLadderByPhiIdx.find(phiIdx) == itLadderByPhiIdx.end()) {
+              itLadderByPhiIdx[phiIdx] = {
+                mod.getModule().center().Phi(),
+                mod.getModule().center().Rho(),
+                mod.getModule().flipped(),
+                mod.getModule().isSkewed()
+              };
+            }
+          }
+        }
+      }
+
       // Determine the distinct yaw states across all rods (rounded to nearest degree).
       // phi==1 rod is always the "base" template (ladderName). Any additional yaw state
       // gets a secondary template named ladderName + "Yaw" + yaw_deg.
@@ -2010,207 +2035,79 @@ namespace insur {
         }
       }
 
-      // INNER TRACKER
+      // INNER TRACKER: replace DDTrackerAngularAlgorithm with explicit per-ladder DDTrackerXYZPosAlgo blocks.
       else {
 
-	// COMMON ALGORITHM PARAMETERS
 	const std::string nameSpace = trackerXmlTags.nspace;
 	const std::string parentName = lname.str();
-	const XYZVector center = XYZVector(0., 0., 0.);
-	const int copyNumberIncrement = 2;
 
+	// Register a per-ladder phi-rotation around Z and return its name ("NULL" for identity).
+	auto registerLadderPhiRotation = [&](double phi_rad) -> std::string {
+	  const double phi_deg = phi_rad * 180.0 / M_PI;
+	  double norm_deg = std::fmod(phi_deg, 360.0);
+	  if (norm_deg < 0.0) norm_deg += 360.0;
+	  if (std::fabs(norm_deg) < 1e-6 || std::fabs(norm_deg - 360.0) < 1e-6) return "NULL";
+	  std::ostringstream rotName;
+	  rotName << lname.str() << "_LadderPhi" << static_cast<int>(std::round(norm_deg * 10.0));
+	  const std::string name = rotName.str();
+	  if (r.find(name) == r.end()) {
+	    Rotation rot;
+	    rot.name   = name;
+	    rot.thetax = 90.0; rot.phix = norm_deg;
+	    rot.thetay = 90.0; rot.phiy = norm_deg + 90.0;
+	    rot.thetaz = 0.0;  rot.phiz = 0.0;
+	    r.insert(std::make_pair(name, rot));
+	  }
+	  return name;
+	};
 
-	// NON-SKEWED LAYER
+	// Emit one DDTrackerXYZPosAlgo block per ladder from the pre-pass map.
+	auto emitITLadderAlgo = [&](int phiIdx, const ITLadderPlacementData& data) {
+	  const std::string& templateName = data.isFlipped ? ladderName.str() : unflippedLadderName.str();
+	  const std::string rotName = registerLadderPhiRotation(data.centerPhi);
+	  const std::string rotEntry = (rotName == "NULL") ? "NULL" : nameSpace + ":" + rotName;
+	  alg.name   = xml_xyzpos_algo;
+	  alg.parent = nameSpace + ":" + parentName;
+	  alg.parameters.push_back(stringParam(xml_childparam, nameSpace + ":" + templateName));
+	  pconverter.str(""); pconverter << phiIdx;
+	  alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+	  alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+	  alg.parameters.push_back(arbitraryLengthVector("XPositions",
+	      std::vector<double>{data.centerRadius * std::cos(data.centerPhi)}));
+	  alg.parameters.push_back(arbitraryLengthVector("YPositions",
+	      std::vector<double>{data.centerRadius * std::sin(data.centerPhi)}));
+	  alg.parameters.push_back(arbitraryLengthVector("ZPositions",
+	      std::vector<double>{0.0}));
+	  alg.parameters.push_back(arbitraryLengthStringVector("Rotations",
+	      std::vector<std::string>{rotEntry}));
+	  a.push_back(alg);
+	  alg.parameters.clear();
+	};
+
+	// NON-SKEWED LAYER: one XYZPosAlgo block per ladder, copy number = phi index.
 	if (!isSkewedLayer) {
-	  
-	  // COMMON ALGORITHM PARAMETERS
-	  const double rangeAngle = 2. * M_PI;	  
-	  const int numberLadders = lagg.getBarrelLayers()->at(layer - 1)->numRods() / 2;	 
-
-	  // FIRST PHI LADDERS ALGORITHM
-	  const std::string firstPhiLadderName = ladderName.str();
-	  const double firstPhiLadderCenterPhi = firstPhiRodMeanPhi;
-	  const double firstPhiLadderRadius = firstPhiRodRadius;
-	  const int firstPhiLadderStartCopyNumber = 1;
-
-	  createAndStoreDDTrackerAngularAlgorithmBlock(a,
-						       nameSpace, 
-						       parentName,
-						       firstPhiLadderName,
-						       firstPhiLadderCenterPhi,
-						       rangeAngle,
-						       firstPhiLadderRadius,
-						       center,
-						       numberLadders,
-						       firstPhiLadderStartCopyNumber,
-						       copyNumberIncrement);
-
-	  // NEXT PHI LADDERS ALGORITHM
-	  const std::string nextPhiLadderName = unflippedLadderName.str();
-	  const double nextPhiLadderCenterPhi = nextPhiRodMeanPhi;
-	  const double nextPhiLadderRadius = nextPhiRodRadius;
-	  const int nextPhiLadderStartCopyNumber = 2;
-
-	  createAndStoreDDTrackerAngularAlgorithmBlock(a,
-						       nameSpace, 
-						       parentName,
-						       nextPhiLadderName,
-						       nextPhiLadderCenterPhi,						    
-						       rangeAngle,
-						       nextPhiLadderRadius,
-						       center,
-						       numberLadders,
-						       nextPhiLadderStartCopyNumber,
-						       copyNumberIncrement);
+	  for (const auto& [phiIdx, data] : itLadderByPhiIdx) {
+	    emitITLadderAlgo(phiIdx, data);
+	  }
 	}
 
-	// SKEWED LAYER
+	// SKEWED LAYER: unskewed ladders via per-ladder XYZPosAlgo; skewed ladders remain explicit.
 	// WARNING: This assumes that, per (X) side:
 	// - there is only 1 skewed ladder (placed at outer radius).
 	// - there is an odd number of non-skewed ladders (>=3).
-
-	// ALGO BLOCKS TO PLACE UNSKEWED LADDERS
 	else {
 
-	  // (-X) SIDE
-	  if (countUnskewedLaddersAtMinusXSide <= 2 || femod(countUnskewedLaddersAtMinusXSide, 2) == 0) { 
-	    logERROR("Skewed layer: It is expected to have an odd number (>=3) of non-skewed ladders per (X) side."); 
+	  if (countUnskewedLaddersAtMinusXSide <= 2 || femod(countUnskewedLaddersAtMinusXSide, 2) == 0) {
+	    logERROR("Skewed layer: It is expected to have an odd number (>=3) of non-skewed ladders per (X) side.");
 	  }
-	  else {
-
-	    // COMMON ALGORITHM PARAMETERS
-	    const double rangeAngleAtMinusXSide = femod(
-							femod(unskewedLaddersAtMinusXSideCentersMaxPhi, 2. * M_PI) 
-							- femod(unskewedLaddersAtMinusXSideCentersMinPhi, 2. * M_PI)
-							, 2. * M_PI);
-
-	    // FLIPPED LADDERS BLOCK (INNER RADIUS)
-	    // flipped ladders
-	    const std::string flippedLadderName = ladderName.str();
-	    // phi
-	    const double flippedLadderCenterPhi = unskewedLaddersAtMinusXSideCentersMinPhi; // WARNING: THIS ASSUMES
-	                                                                                    // that the non-skewed ladder placed at min phi 
-	                                                                                    // is placed at inner radius and flipped!!!
-	    // number of flipped ladders
-	    const int countFlippedLaddersAtMinusXSide = std::floor(countUnskewedLaddersAtMinusXSide / 2.) + 1; // WARNING: THIS ASSUMES
-	                                                                                                       // that there is an odd number of 
-                                                                                                               // non-skewed ladders: 
-	                                                                                                       // 1 more ladder at inner radius.
-	    // start copy number
-	    const int flippedLadderStartCopyNumber = 1;
-
-	    // algo block
-	    createAndStoreDDTrackerAngularAlgorithmBlock(a,
-							 nameSpace, 
-							 parentName,
-							 flippedLadderName,
-							 flippedLadderCenterPhi,
-							 rangeAngleAtMinusXSide,
-							 innerLadderCenterRadius,
-							 center,
-							 countFlippedLaddersAtMinusXSide,
-							 flippedLadderStartCopyNumber,
-							 copyNumberIncrement);	  
-
-	    // UNFLIPPED LADDERS BLOCK (OUTER RADIUS)
-	    // non-flipped ladders
-	    const std::string unFlippedLadderName = unflippedLadderName.str();
-	    // delta phi between 2 consecutive non-skewed ladders 
-	    const double deltaPhiAtMinusXSide = rangeAngleAtMinusXSide / (countUnskewedLaddersAtMinusXSide - 1);
-	    // phi
-	    const double unFlippedLadderCenterPhi = unskewedLaddersAtMinusXSideCentersMinPhi + deltaPhiAtMinusXSide;
-	    // number of non-flipped ladders
-	    const int countUnFlippedLaddersAtMinusXSide = std::floor(countUnskewedLaddersAtMinusXSide / 2.); // WARNING: THIS ASSUMES
-	                                                                                                     // that there is an odd number of 
-                                                                                                             // non-skewed ladders: 
-	                                                                                                     // 1 less ladder at outer radius.
-	    // start copy number
-	    const int unFlippedLadderStartCopyNumber = 2;
-
-	    // algo block
-	    createAndStoreDDTrackerAngularAlgorithmBlock(a,
-							 nameSpace, 
-							 parentName,
-							 unFlippedLadderName,
-							 unFlippedLadderCenterPhi,
-							 rangeAngleAtMinusXSide - 2. * deltaPhiAtMinusXSide,
-							 outerLadderCenterRadius,
-							 center,
-							 countUnFlippedLaddersAtMinusXSide,
-							 unFlippedLadderStartCopyNumber,
-							 copyNumberIncrement);
-	  }
-	  
-
-	  // (+X) side
-	  if (countUnskewedLaddersAtMinusXSide <= 2 || femod(countUnskewedLaddersAtMinusXSide, 2) == 0) { 
-	    logERROR("Skewed layer: It is expected to have an odd number (>=3) of non-skewed ladders per (X) side."); 
-	  }
-	  else {
-
-	    // COMMON ALGORITHM PARAMETERS 
-	    const double rangeAngleAtPlusXSide = femod(
-						       femod(unskewedLaddersAtPlusXSideCentersMaxPhi, 2. * M_PI) 
-						       - femod(unskewedLaddersAtPlusXSideCentersMinPhi, 2. * M_PI)
-						       , 2.*M_PI);
-
-	    // FLIPPED LADDERS BLOCK (INNER RADIUS)
-	    // flipped ladders
-	    const std::string flippedLadderName = ladderName.str();
-	    // phi	  
-	    const double flippedLadderCenterPhi = unskewedLaddersAtPlusXSideCentersMinPhi; // WARNING: THIS ASSUMES
-	                                                                                    // that the non-skewed ladder placed at min phi 
-	                                                                                    // is placed at inner radius and flipped!!!
-	    // number of flipped ladders
-	    const int countFlippedLaddersAtPlusXSide = std::floor(countUnskewedLaddersAtPlusXSide / 2.) + 1; // WARNING: THIS ASSUMES
-	                                                                                                     // that there is an odd number of 
-                                                                                                             // non-skewed ladders: 
-	                                                                                                     // 1 more ladder at inner radius.
-	    // start copy number
-	    const int flippedLadderStartCopyNumber = countUnskewedLaddersAtMinusXSide + 1;
-
-	    // algo block
-	    createAndStoreDDTrackerAngularAlgorithmBlock(a,
-							 nameSpace, 
-							 parentName,
-							 flippedLadderName,
-							 flippedLadderCenterPhi,
-							 rangeAngleAtPlusXSide,
-							 innerLadderCenterRadius,
-							 center,
-							 countFlippedLaddersAtPlusXSide,
-							 flippedLadderStartCopyNumber,
-							 copyNumberIncrement);	  
-
-	    // UNFLIPPED LADDERS BLOCK (OUTER RADIUS)
-	    // non-flipped ladders
-	    const std::string unFlippedLadderName = unflippedLadderName.str();
-	    // delta phi between 2 consecutive non-skewed ladders
-	    const double deltaPhiAtPlusXSide = rangeAngleAtPlusXSide / (countUnskewedLaddersAtPlusXSide - 1);
-	    // phi
-	    const double unFlippedLadderCenterPhi = unskewedLaddersAtPlusXSideCentersMinPhi + deltaPhiAtPlusXSide;
-	    // number of non-flipped ladders
-	    const int countUnFlippedLaddersAtPlusXSide = std::floor(countUnskewedLaddersAtPlusXSide / 2.); // WARNING: THIS ASSUMES
-	                                                                                                   // that there is an odd number of 
-                                                                                                           // non-skewed ladders: 
-	                                                                                                   // 1 less ladder at outer radius.
-	    // start copy number
-	    const int unFlippedLadderStartCopyNumber = countUnskewedLaddersAtMinusXSide + 2;
-
-	    // algo block
-	    createAndStoreDDTrackerAngularAlgorithmBlock(a,
-							 nameSpace, 
-							 parentName,
-							 unFlippedLadderName,
-							 unFlippedLadderCenterPhi,
-							 rangeAngleAtPlusXSide - 2. * deltaPhiAtPlusXSide,
-							 outerLadderCenterRadius,
-							 center,
-							 countUnFlippedLaddersAtPlusXSide,
-							 unFlippedLadderStartCopyNumber,
-							 copyNumberIncrement);
+	  if (countUnskewedLaddersAtPlusXSide <= 2 || femod(countUnskewedLaddersAtPlusXSide, 2) == 0) {
+	    logERROR("Skewed layer: It is expected to have an odd number (>=3) of non-skewed ladders per (X) side.");
 	  }
 
+	  // Unskewed ladders: one XYZPosAlgo block each, copy number = phi index from pre-pass.
+	  for (const auto& [phiIdx, data] : itLadderByPhiIdx) {
+	    if (!data.isSkewed) emitITLadderAlgo(phiIdx, data);
+	  }
 
 	  const int countTotalUnskewedLadders = countUnskewedLaddersAtMinusXSide + countUnskewedLaddersAtPlusXSide;
 
@@ -2223,10 +2120,10 @@ namespace insur {
 	  pos.trans.dy = skewedLadderAtMinusXSideCenterRadius * sin(skewedLadderAtMinusXSideCenterPhi);
 	  pos.trans.dz = 0;
 
-	  const double skewRotationAngleInRadAtMinusXSide = skewedLadderAtMinusXSideCenterPhi + skewedLadderAtMinusXSideSkewAngle;	    
+	  const double skewRotationAngleInRadAtMinusXSide = skewedLadderAtMinusXSideCenterPhi + skewedLadderAtMinusXSideSkewAngle;
 	  const std::string skewRotationNameAtMinusXSide = "Z" + any2str(skewRotationAngleInRadAtMinusXSide * 180. / M_PI, xml_angle_name_precision);
 	  addRotationAroundZAxis(r, skewRotationNameAtMinusXSide, skewRotationAngleInRadAtMinusXSide);
-	  
+
 	  pos.rotref = nameSpace + ":" + skewRotationNameAtMinusXSide;
 	  pos.copy = countTotalUnskewedLadders + 1;
 	  p.push_back(pos);
@@ -2244,7 +2141,7 @@ namespace insur {
 	  const double skewRotationAngleInRadAtPlusXSide = skewedLadderAtPlusXSideCenterPhi + skewedLadderAtPlusXSideSkewAngle;
 	  const std::string skewRotationNameAtPlusXSide = "Z" + any2str(skewRotationAngleInRadAtPlusXSide * 180. / M_PI, xml_angle_name_precision);
 	  addRotationAroundZAxis(r, skewRotationNameAtPlusXSide, skewRotationAngleInRadAtPlusXSide);
-	  
+
 	  pos.rotref = nameSpace + ":" + skewRotationNameAtPlusXSide;
 	  pos.copy = countTotalUnskewedLadders + 2;
 	  p.push_back(pos);
@@ -3431,42 +3328,19 @@ namespace insur {
         int nRings = ringsIndexes.size();
 
       
-        std::map<int, std::vector<double>> phi_one;
-        std::map<int, std::vector<double>> phi_two;
-        std::map<int, std::vector<double>> radius_one;
-        std::map<int, std::vector<double>> radius_two;
-        std::map<int, std::vector<double>> yaw_one;
-        std::map<int, std::vector<double>> yaw_two;
-
-        for (iiter = oiter->begin(); iiter != oiter->end(); iiter++){
-          if(!iiter->getModule().inRegularRing()){ //Don't need to check this for every endcap ring, only modules that are NOT in a regular ring
-            if(phi_one.count(iiter->getModule().uniRef().ring)==0){
-              phi_one[iiter->getModule().uniRef().ring] = std::vector<double>();
-            } 
-            if(radius_one.count(iiter->getModule().uniRef().ring)==0){
-              radius_one[iiter->getModule().uniRef().ring] = std::vector<double>();
-            } 
-            if(yaw_one.count(iiter->getModule().uniRef().ring)==0){
-              yaw_one[iiter->getModule().uniRef().ring] = std::vector<double>();
-            } 
-            if(phi_two.count(iiter->getModule().uniRef().ring)==0){
-              phi_two[iiter->getModule().uniRef().ring] = std::vector<double>();
-            }
-            if(radius_two.count(iiter->getModule().uniRef().ring)==0){
-              radius_two[iiter->getModule().uniRef().ring] = std::vector<double>();
-            }
-            if(yaw_two.count(iiter->getModule().uniRef().ring)==0){
-              yaw_two[iiter->getModule().uniRef().ring] = std::vector<double>();
-            }
-            if(iiter->getModule().uniRef().phi%2 == 1){
-              phi_one[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Phi()*180./M_PI);
-              radius_one[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Rho());
-              yaw_one[iiter->getModule().uniRef().ring].push_back(iiter->getModule().yawAngle()*180./M_PI);
-            } else {
-              phi_two[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Phi()*180./M_PI);
-              radius_two[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Rho());
-              yaw_two[iiter->getModule().uniRef().ring].push_back(iiter->getModule().yawAngle()*180./M_PI);
-            }
+        // Per-module placement data indexed by [ring][phi_index]. Replaces DDTrackerRingAlgo.
+        struct SDModuleData { double phi_deg; double radius; double yaw_deg; bool isFlipped; };
+        std::map<int, std::map<int, SDModuleData>> modulesByRingPhi;
+        for (iiter = oiter->begin(); iiter != oiter->end(); iiter++) {
+          const int ring   = iiter->getModule().uniRef().ring;
+          const int phiIdx = iiter->getModule().uniRef().phi;
+          if (modulesByRingPhi[ring].find(phiIdx) == modulesByRingPhi[ring].end()) {
+            modulesByRingPhi[ring][phiIdx] = {
+              iiter->getModule().center().Phi() * 180.0 / M_PI,
+              iiter->getModule().center().Rho(),
+              iiter->getModule().yawAngle() * 180.0 / M_PI,
+              iiter->getModule().flipped()
+            };
           }
         }
 
@@ -3797,81 +3671,60 @@ namespace insur {
               rspec.partselectors.push_back(logic.name_tag);
               rspec.moduletypes.push_back(minfo_zero);
 
-	      // Ring Surface 1 (half the modules - subdisk 1)
-	      if(sdIndex==1){
-                alg.name = xml_trackerring_algo;
-                if(!myRingInfo.isRegularRing) alg.name=xml_trackerring_irregular_algo;
-                alg.parent = logic.shape_tag;
-                alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
-                pconverter << (myRingInfo.numModules / 2);
-                alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
-                pconverter.str("");
-                alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-                alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
-                alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-                pconverter << myRingInfo.surface1StartPhi * 180. / M_PI << "*deg";
-                alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-                pconverter.str("");
-                pconverter << myRingInfo.radiusMid << "*mm";
-                alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
-                pconverter.str("");
-                if(!myRingInfo.isRegularRing && (phi_one[ringIndex]).size()>0){
-                  alg.parameters.push_back(arbitraryLengthVector("phiAngleValues",phi_one[ringIndex]));
-                  pconverter.str("");
-                  alg.parameters.push_back(arbitraryLengthVector("yawAngleValues",yaw_one[ringIndex]));
-                  pconverter.str("");
-                  alg.parameters.push_back(arbitraryLengthVector("radiusValues",radius_one[ringIndex]));
-                  pconverter.str("");
-                } 
-	        alg.parameters.push_back(vectorParam(0, 0, 0));
-	        pconverter << myRingInfo.isDiskAtPlusZEnd;
-	        alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
-	        pconverter.str("");
-	        alg.parameters.push_back(numericParam(xml_tiltangle, "90*deg"));
-	        pconverter << myRingInfo.surface1IsFlipped;
-                alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
-                pconverter.str("");
-                a.push_back(alg);
-                alg.parameters.clear();
-              }
+	      // Emit one DDTrackerXYZPosAlgo block per module for this subdisk's surface.
+	      // Rotation formula: exact algebraic expansion of R_phi * R_tilt(90) * R_flip * R_yaw.
+	      auto registerEndcapModuleRotation = [&](double phi_deg, double yaw_deg, bool isZPlus, bool isFlipped) -> std::string {
+	        double norm_phi = std::fmod(phi_deg, 360.0);
+	        if (norm_phi < 0.0) norm_phi += 360.0;
+	        std::ostringstream rotName;
+	        rotName << "EMod_Phi" << static_cast<int>(std::round(norm_phi * 10.0))
+	                << "_Yaw"    << static_cast<int>(std::round(yaw_deg * 10.0))
+	                << (isZPlus ? "_ZPlus" : "_ZMinus")
+	                << (isFlipped ? "_Flipped" : "");
+	        const std::string name = rotName.str();
+	        if (r.find(name) == r.end()) {
+	          double phix = 0.0, phiy = 0.0, thetaz = 0.0;
+	          if (isZPlus) {
+	            if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 0.0; }
+	            else            { phix = phi_deg - yaw_deg - 90.0; phiy = phi_deg - yaw_deg + 180.0; thetaz = 180.0; }
+	          } else {
+	            if (!isFlipped) { phix = phi_deg - yaw_deg + 90.0; phiy = phi_deg - yaw_deg;         thetaz = 180.0; }
+	            else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg;         thetaz = 0.0; }
+	          }
+	          Rotation rot;
+	          rot.name = name;
+	          rot.thetax = 90.0; rot.phix = std::fmod(phix + 3600.0, 360.0);
+	          rot.thetay = 90.0; rot.phiy = std::fmod(phiy + 3600.0, 360.0);
+	          rot.thetaz = thetaz; rot.phiz = 0.0;
+	          r.insert(std::make_pair(name, rot));
+	        }
+	        return name;
+	      };
 
-	      // Ring Surface 2 (half the modules - subdisk 2)
-	      if(sdIndex==2){
-                alg.name = xml_trackerring_algo;
-                if(!myRingInfo.isRegularRing) alg.name=xml_trackerring_irregular_algo;
-                alg.parent = logic.shape_tag;
-                alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
-                pconverter << (myRingInfo.numModules / 2);
-                alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
-                pconverter.str("");
-                alg.parameters.push_back(numericParam(xml_startcopyno, "2"));
-                alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
-                alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-                pconverter << myRingInfo.surface1StartPhi * 180. / M_PI << "*deg";
-                alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-                pconverter.str("");
-                pconverter << myRingInfo.radiusMid << "*mm";
-                alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
-                pconverter.str("");
-                if(!myRingInfo.isRegularRing && (phi_two[ringIndex]).size()>0 ){
-                  alg.parameters.push_back(arbitraryLengthVector("phiAngleValues",phi_two[ringIndex]));
-                  pconverter.str("");
-                  alg.parameters.push_back(arbitraryLengthVector("yawAngleValues",yaw_two[ringIndex]));
-                  pconverter.str("");
-                  alg.parameters.push_back(arbitraryLengthVector("radiusValues",radius_two[ringIndex]));
-                  pconverter.str("");
-                } 
-	        alg.parameters.push_back(vectorParam(0, 0, 0));
-	        pconverter << myRingInfo.isDiskAtPlusZEnd;
-	        alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
-	        pconverter.str("");
-	        alg.parameters.push_back(numericParam(xml_tiltangle, "90*deg"));
-	        pconverter << myRingInfo.surface1IsFlipped;
-	        alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
-	        pconverter.str("");
-                a.push_back(alg);
-                alg.parameters.clear();
-              }
+	      const int sdPhiParity = sdIndex % 2; // 1 = odd phi (SD1), 0 = even phi (SD2)
+	      const auto& ringModules = modulesByRingPhi[ringIndex];
+	      for (const auto& [phiIdx, modData] : ringModules) {
+	        if (phiIdx % 2 != sdPhiParity) continue;
+	        const double phi_rad = modData.phi_deg * M_PI / 180.0;
+	        const std::string rotName = registerEndcapModuleRotation(
+	          modData.phi_deg, modData.yaw_deg, myRingInfo.isDiskAtPlusZEnd, modData.isFlipped);
+	        alg.name = xml_xyzpos_algo;
+	        alg.parent = logic.shape_tag;
+	        alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
+	        pconverter.str(""); pconverter << phiIdx;
+	        alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+	        alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+	        alg.parameters.push_back(arbitraryLengthVector("XPositions",
+	            std::vector<double>{modData.radius * std::cos(phi_rad)}));
+	        alg.parameters.push_back(arbitraryLengthVector("YPositions",
+	            std::vector<double>{modData.radius * std::sin(phi_rad)}));
+	        alg.parameters.push_back(arbitraryLengthVector("ZPositions",
+	            std::vector<double>{0.0}));
+	        alg.parameters.push_back(arbitraryLengthStringVector("Rotations",
+	            std::vector<std::string>{trackerXmlTags.nspace + ":" + rotName}));
+	        a.push_back(alg);
+	        alg.parameters.clear();
+	      }
             }
           }
           //subdisc

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -2683,36 +2683,34 @@ namespace insur {
         std::map<int, std::vector<double>> yaw_one;
         std::map<int, std::vector<double>> yaw_two;
 
-        for (iiter = oiter->begin(); iiter != oiter->end(); iiter++){
-          if(!iiter->getModule().inRegularRing()){ //Don't need to check this for every endcap ring, only modules that are NOT in a regular ring
-            if(phi_one.count(iiter->getModule().uniRef().ring)==0){
-              phi_one[iiter->getModule().uniRef().ring] = std::vector<double>();
+        // PRE-PASS: Unconditionally collect X, Y, Z, and Yaw for all modules.
+        for (iiter = oiter->begin(); iiter != oiter->end(); iiter++) {
+            int modRing = iiter->getModule().uniRef().ring;
+            
+            if (phi_one.count(modRing) == 0) {
+                phi_one[modRing]    = std::vector<double>();
+                radius_one[modRing] = std::vector<double>();
+                yaw_one[modRing]    = std::vector<double>();
             } 
-            if(radius_one.count(iiter->getModule().uniRef().ring)==0){
-              radius_one[iiter->getModule().uniRef().ring] = std::vector<double>();
-            } 
-            if(yaw_one.count(iiter->getModule().uniRef().ring)==0){
-              yaw_one[iiter->getModule().uniRef().ring] = std::vector<double>();
-            } 
-            if(phi_two.count(iiter->getModule().uniRef().ring)==0){
-              phi_two[iiter->getModule().uniRef().ring] = std::vector<double>();
+            if (phi_two.count(modRing) == 0) {
+                phi_two[modRing]    = std::vector<double>();
+                radius_two[modRing] = std::vector<double>();
+                yaw_two[modRing]    = std::vector<double>();
             }
-            if(radius_two.count(iiter->getModule().uniRef().ring)==0){
-              radius_two[iiter->getModule().uniRef().ring] = std::vector<double>();
-            }
-            if(yaw_two.count(iiter->getModule().uniRef().ring)==0){
-              yaw_two[iiter->getModule().uniRef().ring] = std::vector<double>();
-            }
-            if(iiter->getModule().uniRef().phi%2 == 1){
-              phi_one[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Phi()*180./M_PI);
-              radius_one[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Rho());
-              yaw_one[iiter->getModule().uniRef().ring].push_back(iiter->getModule().yawAngle()*180./M_PI);
+
+            double phi_deg = iiter->getModule().center().Phi() * 180. / M_PI;
+            double radius  = iiter->getModule().center().Rho();
+            double yaw_deg = iiter->getModule().yawAngle() * 180. / M_PI;
+
+            if (iiter->getModule().uniRef().phi % 2 == 1) {
+                phi_one[modRing].push_back(phi_deg);
+                radius_one[modRing].push_back(radius);
+                yaw_one[modRing].push_back(yaw_deg);
             } else {
-              phi_two[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Phi()*180./M_PI);
-              radius_two[iiter->getModule().uniRef().ring].push_back(iiter->getModule().center().Rho());
-              yaw_two[iiter->getModule().uniRef().ring].push_back(iiter->getModule().yawAngle()*180./M_PI);
+                phi_two[modRing].push_back(phi_deg);
+                radius_two[modRing].push_back(radius);
+                yaw_two[modRing].push_back(yaw_deg);
             }
-          }
         }
 
         // LOOP ON MODULE CAPS
@@ -3097,76 +3095,106 @@ namespace insur {
             rspec.partselectors.push_back(logic.name_tag);
             rspec.moduletypes.push_back(minfo_zero);
 
-	    // Ring Surface 1 (half the modules)
-	    alg.name = xml_trackerring_algo;
-            if(!myRingInfo.isRegularRing) alg.name=xml_trackerring_irregular_algo;
-            alg.parent = logic.shape_tag;
-            alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
-            pconverter.str(""); pconverter << (myRingInfo.numModules / 2);
-            alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-            alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
-            alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-            pconverter.str(""); pconverter << myRingInfo.surface1StartPhi * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-            pconverter.str("");
-            pconverter << myRingInfo.radiusMid << "*mm";
-            alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
-            pconverter.str("");
-            if(!myRingInfo.isRegularRing && (phi_one[ringIndex]).size()>0){
-              alg.parameters.push_back(arbitraryLengthVector("phiAngleValues",phi_one[ringIndex]));
-              pconverter.str("");
-              alg.parameters.push_back(arbitraryLengthVector("yawAngleValues",yaw_one[ringIndex]));
-              pconverter.str("");
-              alg.parameters.push_back(arbitraryLengthVector("radiusValues",radius_one[ringIndex]));
-              pconverter.str("");
-            }
-	    alg.parameters.push_back(vectorParam(0, 0, myRingInfo.surface1ZMid - myRingInfo.zMid));
-	    pconverter.str(""); pconverter << myRingInfo.isDiskAtPlusZEnd;
-	    alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
-	    pconverter.str("");
-	    alg.parameters.push_back(numericParam(xml_tiltangle, "90*deg"));
-	    pconverter.str(""); pconverter << myRingInfo.surface1IsFlipped;
-	    alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
-	    pconverter.str("");
-            a.push_back(alg);
-            alg.parameters.clear();
+	    // Lambda to generate and cache explicit endcap module rotations matching DDTrackerRingAlgo math
+            auto registerEndcapModuleRotation = [&](double phi_deg, double yaw_deg, bool isZPlus, bool isFlipped) -> std::string {
+                // Normalize phi to 0-360 for consistent naming
+                double norm_phi = std::fmod(phi_deg, 360.0);
+                if (norm_phi < 0.0) norm_phi += 360.0;
+                
+                std::ostringstream rotName;
+                rotName << "EMod_Phi" << static_cast<int>(std::round(norm_phi * 10.0))
+                        << "_Yaw"   << static_cast<int>(std::round(yaw_deg * 10.0))
+                        << (isZPlus ? "_ZPlus" : "_ZMinus")
+                        << (isFlipped ? "_Flipped" : "");
+                
+                const std::string name = rotName.str();
+                if (r.find(name) == r.end()) {
+                    Rotation rot;
+                    rot.name = name;
+                    
+                    // Exact algebraic expansion of CMSSW's R_global = R_phi * R_tilt * R_flip * R_yaw
+                    // where tilt is 90 degrees for endcap rings.
+                    double phix = 0.0, phiy = 0.0, thetaz = 0.0;
+                    
+                    if (isZPlus) {
+                        if (!isFlipped) {
+                            phix = phi_deg + yaw_deg + 90.0;
+                            phiy = phi_deg + yaw_deg + 180.0;
+                            thetaz = 0.0;
+                        } else {
+                            phix = phi_deg - yaw_deg - 90.0;
+                            phiy = phi_deg - yaw_deg + 180.0;
+                            thetaz = 180.0;
+                        }
+                    } else { // isZMinus
+                        if (!isFlipped) {
+                            phix = phi_deg - yaw_deg + 90.0;
+                            phiy = phi_deg - yaw_deg;
+                            thetaz = 180.0;
+                        } else {
+                            phix = phi_deg + yaw_deg - 90.0;
+                            phiy = phi_deg + yaw_deg;
+                            thetaz = 0.0;
+                        }
+                    }
 
-	    // Ring Surface 2 (half the modules)
-	    alg.name = xml_trackerring_algo;
-            if(!myRingInfo.isRegularRing) alg.name=xml_trackerring_irregular_algo;
-            alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
-            pconverter.str(""); pconverter << (myRingInfo.numModules / 2);
-            alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_startcopyno, "2"));
-            alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
-            alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-            pconverter.str(""); pconverter << myRingInfo.surface2StartPhi * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-            pconverter.str("");
-            pconverter << myRingInfo.radiusMid << "*mm";
-            alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
-            pconverter.str("");
-            if(!myRingInfo.isRegularRing && (phi_two[ringIndex]).size()>0 ){
-              alg.parameters.push_back(arbitraryLengthVector("phiAngleValues",phi_two[ringIndex]));
-              pconverter.str("");
-              alg.parameters.push_back(arbitraryLengthVector("yawAngleValues",yaw_two[ringIndex]));
-              pconverter.str("");
-              alg.parameters.push_back(arbitraryLengthVector("radiusValues",radius_two[ringIndex]));
-              pconverter.str("");
+                    // Keep values cleanly within 0-360 range
+                    rot.thetax = 90.0; rot.phix = std::fmod(phix + 3600.0, 360.0);
+                    rot.thetay = 90.0; rot.phiy = std::fmod(phiy + 3600.0, 360.0);
+                    rot.thetaz = thetaz; rot.phiz = 0.0;
+                    
+                    r.insert(std::make_pair(name, rot));
+                }
+                return name;
+            };
+
+            // Lambda to emit 1-entry XYZPosAlgo blocks for a surface
+            auto emitModulePlacement = [&](int startCopyNo, double surfaceZMid, bool isZPlus, bool isFlipped,
+                                           const std::vector<double>& phis,
+                                           const std::vector<double>& radiuses,
+                                           const std::vector<double>& yaws) {
+                for (size_t i = 0; i < phis.size(); ++i) {
+                    double phi_rad = phis[i] * (M_PI / 180.0);
+                    double rad = radiuses[i];
+                    double x = rad * std::cos(phi_rad);
+                    double y = rad * std::sin(phi_rad);
+                    double z = surfaceZMid - myRingInfo.zMid; 
+
+                    std::string rotName = registerEndcapModuleRotation(phis[i], yaws[i], isZPlus, isFlipped);
+                    // Endcap modules are never at identity orientation (always tilted 90 degrees), 
+                    // so we do not need the "NULL" fallback check used in the barrel.
+                    std::string rotEntry = trackerXmlTags.nspace + ":" + rotName;
+
+                    alg.name = xml_xyzpos_algo;
+                    alg.parent = logic.shape_tag;
+                    alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));
+
+                    pconverter.str(""); pconverter << (startCopyNo + i * 2);
+                    alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+                    pconverter.str(""); // Crucial system-wide reset
+                    alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+
+                    alg.parameters.push_back(arbitraryLengthVector("XPositions", std::vector<double>{x}));
+                    alg.parameters.push_back(arbitraryLengthVector("YPositions", std::vector<double>{y}));
+                    alg.parameters.push_back(arbitraryLengthVector("ZPositions", std::vector<double>{z}));
+                    alg.parameters.push_back(arbitraryLengthStringVector("Rotations", std::vector<std::string>{rotEntry}));
+
+                    a.push_back(alg);
+                    alg.parameters.clear();
+                }
+            };
+
+            // Emit Surface 1
+            if (phi_one[ringIndex].size() > 0) {
+                emitModulePlacement(1, myRingInfo.surface1ZMid, myRingInfo.isDiskAtPlusZEnd, myRingInfo.surface1IsFlipped,
+                                    phi_one[ringIndex], radius_one[ringIndex], yaw_one[ringIndex]);
             }
-	    alg.parameters.push_back(vectorParam(0, 0, myRingInfo.surface2ZMid - myRingInfo.zMid));
-	    pconverter.str(""); pconverter << myRingInfo.isDiskAtPlusZEnd;
-	    alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
-	    pconverter.str("");
-	    alg.parameters.push_back(numericParam(xml_tiltangle, "90*deg"));
-	    pconverter.str(""); pconverter << myRingInfo.surface2IsFlipped;
-	    alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
-	    pconverter.str("");
-            a.push_back(alg);
-            alg.parameters.clear();
+            
+            // Emit Surface 2
+            if (phi_two[ringIndex].size() > 0) {
+                emitModulePlacement(2, myRingInfo.surface2ZMid, myRingInfo.isDiskAtPlusZEnd, myRingInfo.surface2IsFlipped,
+                                    phi_two[ringIndex], radius_two[ringIndex], yaw_two[ringIndex]);
+            }
           }
         }
 

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -3019,14 +3019,14 @@ namespace insur {
                             phiy = phi_deg + yaw_deg + 180.0;
                             thetaz = 0.0;
                         } else {
-                            phix = phi_deg - yaw_deg - 90.0;
-                            phiy = phi_deg - yaw_deg + 180.0;
+                            phix = phi_deg + yaw_deg - 90.0;
+                            phiy = phi_deg + yaw_deg + 180.0;
                             thetaz = 180.0;
                         }
                     } else { // isZMinus
                         if (!isFlipped) {
-                            phix = phi_deg - yaw_deg + 90.0;
-                            phiy = phi_deg - yaw_deg;
+                            phix = phi_deg + yaw_deg + 90.0;
+                            phiy = phi_deg + yaw_deg;
                             thetaz = 180.0;
                         } else {
                             phix = phi_deg + yaw_deg - 90.0;
@@ -3686,9 +3686,9 @@ namespace insur {
 	          double phix = 0.0, phiy = 0.0, thetaz = 0.0;
 	          if (isZPlus) {
 	            if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 0.0; }
-	            else            { phix = phi_deg - yaw_deg - 90.0; phiy = phi_deg - yaw_deg + 180.0; thetaz = 180.0; }
+	            else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 180.0; }
 	          } else {
-	            if (!isFlipped) { phix = phi_deg - yaw_deg + 90.0; phiy = phi_deg - yaw_deg;         thetaz = 180.0; }
+	            if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg;         thetaz = 180.0; }
 	            else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg;         thetaz = 0.0; }
 	          }
 	          Rotation rot;

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -2342,88 +2342,127 @@ namespace insur {
 	      trspec.partselectors.push_back(rinfo.name);
 	      //trspec.moduletypes.push_back(minfo_zero);
 	      
-	      // Tilted ring: first part to be stored
-	      alg.name = xml_trackerring_irregular_algo;
-	      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
-	      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
-	      pconverter.str(""); pconverter << (rinfo.modules / 2);
-	      alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
-	      pconverter.str("");
-	      alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-	      alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
-	      alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-	      pconverter.str(""); pconverter << rinfo.startPhiAngle1 * 180. / M_PI << "*deg";
-	      alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-	      pconverter.str("");
-	      pconverter << rinfo.r1 << "*mm";
-	      alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
-	      pconverter.str("");
-	      alg.parameters.push_back(vectorParam(0, 0, (rinfo.z1 - rinfo.z2) / 2.0));
-	      pconverter.str(""); pconverter << rinfo.isZPlus;
-	      alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
-	      pconverter.str("");
-	      pconverter.str(""); pconverter << rinfo.tiltAngle << "*deg";
-	      alg.parameters.push_back(numericParam(xml_tiltangle, pconverter.str()));
-	      pconverter.str("");
-	      pconverter.str(""); pconverter << rinfo.bw_flipped;
-	      alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
-	      pconverter.str("");
+	      // Lambda to generate and cache explicit tilted module rotations
+              auto registerTiltedModuleRotation = [&](double phi_deg, double yaw_deg, double tilt_deg, bool isZPlus, bool isFlipped) -> std::string {
+                  double norm_phi = std::fmod(phi_deg, 360.0);
+                  if (norm_phi < 0.0) norm_phi += 360.0;
+                  
+                  std::ostringstream rotName;
+                  rotName << "TMod_Phi" << static_cast<int>(std::round(norm_phi * 10.0))
+                          << "_Yaw"   << static_cast<int>(std::round(yaw_deg * 10.0))
+                          << "_Tilt"  << static_cast<int>(std::round(tilt_deg * 10.0))
+                          << (isZPlus ? "_ZPlus" : "_ZMinus")
+                          << (isFlipped ? "_Flipped" : "");
+                  
+                  const std::string name = rotName.str();
+                  if (r.find(name) == r.end()) {
+                      double phi = norm_phi * M_PI / 180.0;
+                      double yaw = yaw_deg * M_PI / 180.0;
+                      double tilt = tilt_deg * M_PI / 180.0;
 
-		  // Module position and yaw in tilted rings
-          int ringIndex = ringinfo.first;
-          if (rinfo.isZPlus && phi_plus_one[ringIndex].size() > 0) {
-            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_plus_one[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_plus_one[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_plus_one[ringIndex]));
-          } else if (!rinfo.isZPlus && phi_minus_one[ringIndex].size() > 0) {
-            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_minus_one[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_minus_one[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_minus_one[ringIndex]));
-          }
+                      // Matrix representation: columns as {x, y, z}
+                      using Mat3 = std::array<std::array<double, 3>, 3>;
+                      auto mult = [](const Mat3& A, const Mat3& B) -> Mat3 {
+                          Mat3 C = {};
+                          for(int col = 0; col < 3; ++col) {
+                              for(int row = 0; row < 3; ++row) {
+                                  C[col][row] = A[0][row]*B[col][0] + A[1][row]*B[col][1] + A[2][row]*B[col][2];
+                              }
+                          }
+                          return C;
+                      };
 
-	      a.push_back(alg);
-	      alg.parameters.clear();
-	      
-	      // Tilted ring: second part to be stored
-	      alg.name = xml_trackerring_irregular_algo;
-	      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
-	      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
-	      pconverter.str(""); pconverter << (rinfo.modules / 2);
-	      alg.parameters.push_back(numericParam(xml_nmods, pconverter.str()));
-	      pconverter.str("");
-	      alg.parameters.push_back(numericParam(xml_startcopyno, "2"));
-	      alg.parameters.push_back(numericParam(xml_incrcopyno, "2"));
-	      alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-	      pconverter.str(""); pconverter << rinfo.startPhiAngle2 * 180. / M_PI << "*deg";
-	      alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-	      pconverter.str("");
-	      pconverter << rinfo.r2 << "*mm";
-	      alg.parameters.push_back(numericParam(xml_radius, pconverter.str()));
-	      pconverter.str("");
-	      alg.parameters.push_back(vectorParam(0, 0, (rinfo.z2 - rinfo.z1) / 2.0));
-	      pconverter.str(""); pconverter << rinfo.isZPlus;
-	      alg.parameters.push_back(numericParam(xml_iszplus, pconverter.str()));
-	      pconverter.str("");
-	      pconverter.str(""); pconverter << rinfo.tiltAngle << "*deg";
-	      alg.parameters.push_back(numericParam(xml_tiltangle, pconverter.str()));
-	      pconverter.str("");
-	      pconverter.str(""); pconverter << rinfo.fw_flipped;
-	      alg.parameters.push_back(numericParam(xml_isflipped, pconverter.str()));
-	      pconverter.str("");
+                      Mat3 rYaw = {{{std::cos(yaw), std::sin(yaw), 0}, {-std::sin(yaw), std::cos(yaw), 0}, {0, 0, 1}}};
+                      Mat3 rFlip = {{{-1, 0, 0}, {0, 1, 0}, {0, 0, -1}}};
+                      
+                      Mat3 rTilt = {};
+                      if (isZPlus) {
+                          rTilt = {{{0, 1, 0}, {-std::sin(tilt), 0, std::cos(tilt)}, {std::cos(tilt), 0, std::sin(tilt)}}};
+                      } else {
+                          rTilt = {{{0, 1, 0}, {std::sin(tilt), 0, std::cos(tilt)}, {std::cos(tilt), 0, -std::sin(tilt)}}};
+                      }
+                      
+                      Mat3 rPhi = {{{std::cos(phi), std::sin(phi), 0}, {-std::sin(phi), std::cos(phi), 0}, {0, 0, 1}}};
 
-		  // Module position and yaw in tilted rings
-          if (rinfo.isZPlus && phi_plus_two[ringIndex].size() > 0) {
-            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_plus_two[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_plus_two[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_plus_two[ringIndex]));
-          } else if (!rinfo.isZPlus && phi_minus_two[ringIndex].size() > 0) {
-            alg.parameters.push_back(arbitraryLengthVector("phiAngleValues", phi_minus_two[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("yawAngleValues", yaw_minus_two[ringIndex]));
-            alg.parameters.push_back(arbitraryLengthVector("radiusValues", radius_minus_two[ringIndex]));
-          }
+                      // Compute exact CMSSW rotation: globalRot = R_phi * R_tilt * (isFlipped ? R_flip : I) * R_yaw
+                      Mat3 tiltCombined = isFlipped ? mult(rTilt, rFlip) : rTilt;
+                      Mat3 globalRotMat = mult(mult(rPhi, tiltCombined), rYaw);
 
-	      a.push_back(alg);
-	      alg.parameters.clear();
+                      auto getTheta = [](const std::array<double, 3>& v) {
+                          double z = v[2];
+                          if (z > 1.0) z = 1.;
+						  if (z < -1.0) z = -1.0;
+                          return std::acos(z) * 180.0 / M_PI;
+                      };
+                      auto getPhi = [](const std::array<double, 3>& v) {
+                          double p = std::atan2(v[1], v[0]) * 180.0 / M_PI;
+                          return (p < 0.0) ? p + 360.0 : p;
+                      };
+
+                      Rotation rot;
+                      rot.name = name;
+                      rot.thetax = getTheta(globalRotMat[0]); rot.phix = getPhi(globalRotMat[0]);
+                      rot.thetay = getTheta(globalRotMat[1]); rot.phiy = getPhi(globalRotMat[1]);
+                      rot.thetaz = getTheta(globalRotMat[2]); rot.phiz = getPhi(globalRotMat[2]);
+                      
+                      r.insert(std::make_pair(name, rot));
+                  }
+                  return name;
+              };
+
+              // Lambda to emit 1-entry XYZPosAlgo blocks for a tilted ring surface
+              auto emitTiltedModulePlacement = [&](int startCopyNo, double localZOffset, bool isZPlus, bool isFlipped,
+                                                   const std::vector<double>& phis,
+                                                   const std::vector<double>& radiuses,
+                                                   const std::vector<double>& yaws) {
+                  for (size_t i = 0; i < phis.size(); ++i) {
+                      double phi_rad = phis[i] * M_PI / 180.0;
+                      double rad = radiuses[i];
+                      double x = rad * std::cos(phi_rad);
+                      double y = rad * std::sin(phi_rad);
+                      double z = localZOffset;
+
+                      std::string rotName = registerTiltedModuleRotation(phis[i], yaws[i], rinfo.tiltAngle, isZPlus, isFlipped);
+                      std::string rotEntry = trackerXmlTags.nspace + ":" + rotName;
+
+                      alg.name = xml_xyzpos_algo;
+                      alg.parent = trackerXmlTags.nspace + ":" + rinfo.name;
+                      alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + rinfo.childname));
+
+                      pconverter.str(""); pconverter << (startCopyNo + i * 2);
+                      alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
+                      pconverter.str(""); // System-wide reset
+                      alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
+
+                      alg.parameters.push_back(arbitraryLengthVector("XPositions", std::vector<double>{x}));
+                      alg.parameters.push_back(arbitraryLengthVector("YPositions", std::vector<double>{y}));
+                      alg.parameters.push_back(arbitraryLengthVector("ZPositions", std::vector<double>{z}));
+                      alg.parameters.push_back(arbitraryLengthStringVector("Rotations", std::vector<std::string>{rotEntry}));
+
+                      a.push_back(alg);
+                      alg.parameters.clear();
+                  }
+              };
+
+              int ringIndex = ringinfo.first;
+              
+              // Tilted ring: first part (Surface 1)
+              if (rinfo.isZPlus && phi_plus_one[ringIndex].size() > 0) {
+                  emitTiltedModulePlacement(1, (rinfo.z1 - rinfo.z2) / 2.0, rinfo.isZPlus, rinfo.bw_flipped,
+                                            phi_plus_one[ringIndex], radius_plus_one[ringIndex], yaw_plus_one[ringIndex]);
+              } else if (!rinfo.isZPlus && phi_minus_one[ringIndex].size() > 0) {
+                  emitTiltedModulePlacement(1, (rinfo.z1 - rinfo.z2) / 2.0, rinfo.isZPlus, rinfo.bw_flipped,
+                                            phi_minus_one[ringIndex], radius_minus_one[ringIndex], yaw_minus_one[ringIndex]);
+              }
+
+              // Tilted ring: second part (Surface 2)
+              if (rinfo.isZPlus && phi_plus_two[ringIndex].size() > 0) {
+                  emitTiltedModulePlacement(2, (rinfo.z2 - rinfo.z1) / 2.0, rinfo.isZPlus, rinfo.fw_flipped,
+                                            phi_plus_two[ringIndex], radius_plus_two[ringIndex], yaw_plus_two[ringIndex]);
+              } else if (!rinfo.isZPlus && phi_minus_two[ringIndex].size() > 0) {
+                  emitTiltedModulePlacement(2, (rinfo.z2 - rinfo.z1) / 2.0, rinfo.isZPlus, rinfo.fw_flipped,
+                                            phi_minus_two[ringIndex], radius_minus_two[ringIndex], yaw_minus_two[ringIndex]);
+              }
 	    }
 	  }
 	}

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -926,9 +926,6 @@ namespace insur {
 	unflippedLadderName << trackerXmlTags.tracker << xml_layer << layer << xml_rod << xml_unflipped; // e.g. OTLayer1RodUnflipped
       }
 
-      double firstPhiRodMeanPhi = 0;
-      double nextPhiRodMeanPhi = 0;
-
       std::map<std::tuple<int, int, int, int >, std::string > timingModuleNames;
       bool newTimingModuleType = true;
       int timingModuleCopyNumber = 0;
@@ -1129,9 +1126,6 @@ namespace insur {
 
 	  // ROD 1 (STRAIGHT LAYER), OR ROD 1 + MODULES WITH UNIREF PHI == 1 OF THE TILTED RINGS (TILTED LAYER)
 	  if (iiter->getModule().uniRef().phi == 1) {
-
-	    firstPhiRodMeanPhi = iiter->getModule().center().Phi();
-
             std::ostringstream ringname;
 	    ringname << lname.str() << xml_ring << modRing;
 
@@ -1242,7 +1236,6 @@ namespace insur {
 
 	  if (iiter->getModule().uniRef().phi == 2) {
 	    if (!isTilted || (isTilted && (tiltAngle == 0))) {
-	      nextPhiRodMeanPhi = iiter->getModule().center().Phi();
 	      if (isPixelTracker) {
 		pos.parent_tag = trackerXmlTags.nspace + ":" + unflippedLadderName.str();
 		pos.child_tag = trackerXmlTags.nspace + ":" + mname.str();
@@ -1854,10 +1847,6 @@ namespace insur {
 
       // rods in layer algorithm(s)
 
-      // Get inner / outer ladders radii
-      const double innerLadderCenterRadius = MIN(firstPhiRodRadius, nextPhiRodRadius);  // inner radius
-      const double outerLadderCenterRadius = MAX(firstPhiRodRadius, nextPhiRodRadius); // outer radius
-
       // OUTER TRACKER
       if (!isPixelTracker) {
 
@@ -1916,7 +1905,6 @@ namespace insur {
         } // end !isTilted XYZPosAlgo path
 
         // TILTED OT LAYERS: flat-part rods via DDTrackerXYZPosAlgo (per-rod blocks).
-        // Falls back to DDTrackerPhiAltAlgo only when no flat-part modules were found.
         else if (isTilted) {
           if (!otRodPlacementByPhiIdx.empty()) {
           for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
@@ -1943,95 +1931,7 @@ namespace insur {
             a.push_back(alg);
             alg.parameters.clear();
           }
-          } else { // fallback: no flat-part modules found, keep PhiAltAlgo
-          pconverter.str("");  // clear any residual state from prior loops
-          if (!hasPhiForbiddenRanges) {
-            alg.name = xml_phialt_algo;
-            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-            pconverter.str(""); pconverter << trackerXmlTags.nspace + ":" + ladderName.str();
-            alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
-            alg.parameters.push_back(numericParam(xml_tilt, "90*deg"));
-            const bool isFirstPhiRodAtInnerRadius = (fabs(firstPhiRodRadius - innerLadderCenterRadius) < xml_epsilon);
-            const double algoStartPhi = (isFirstPhiRodAtInnerRadius ? firstPhiRodMeanPhi : nextPhiRodMeanPhi);
-            pconverter.str("");
-            pconverter << algoStartPhi * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_rangeangle, "360*deg"));
-            pconverter.str(""); pconverter << innerLadderCenterRadius << "*mm";
-            alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
-            pconverter.str("");
-            pconverter << outerLadderCenterRadius << "*mm";
-            alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
-            pconverter.str(""); pconverter << lagg.getBarrelLayers()->at(layer - 1)->numRods();
-            alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-            a.push_back(alg);
-            alg.parameters.clear();
-          } else {
-            int numRods = lagg.getBarrelLayers()->at(layer - 1)->numRods();
-            int forbiddenPhiUpperAIndex = numRods / 2;
-            int forbiddenPhiLowerBIndex = forbiddenPhiUpperAIndex + 1;
-            alg.name = xml_phialt_algo;
-            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-            pconverter.str(""); pconverter << trackerXmlTags.nspace + ":" + ladderName.str();
-            alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
-            alg.parameters.push_back(numericParam(xml_tilt, "90*deg"));
-            pconverter.str("");
-            pconverter << phiForbiddenRanges.at(1) * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-            pconverter.str("");
-            pconverter << (phiForbiddenRanges.at(forbiddenPhiUpperAIndex) - phiForbiddenRanges.at(1)) * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
-            pconverter.str("");
-            pconverter << firstPhiRodRadius << "*mm";
-            alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
-            pconverter.str("");
-            pconverter << nextPhiRodRadius << "*mm";
-            alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
-            pconverter.str(""); pconverter << numRods / 2;
-            alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
-            alg.parameters.push_back(numericParam(xml_startcopyno, "1"));
-            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-            a.push_back(alg);
-            alg.parameters.clear();
-            alg.name = xml_phialt_algo;
-            alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-            pconverter.str("");
-            pconverter << trackerXmlTags.nspace + ":" + ladderName.str();
-            alg.parameters.push_back(stringParam(xml_childparam, pconverter.str()));
-            alg.parameters.push_back(numericParam(xml_tilt, "90*deg"));
-            pconverter.str("");
-            pconverter << phiForbiddenRanges.at(forbiddenPhiLowerBIndex) * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_startangle, pconverter.str()));
-            pconverter.str("");
-            pconverter << (phiForbiddenRanges.at(numRods) - phiForbiddenRanges.at(forbiddenPhiLowerBIndex)) * 180. / M_PI << "*deg";
-            alg.parameters.push_back(numericParam(xml_rangeangle, pconverter.str()));
-            pconverter.str("");
-            pconverter << firstPhiRodRadius << "*mm";
-            alg.parameters.push_back(numericParam(xml_radiusin, pconverter.str()));
-            pconverter.str("");
-            pconverter << nextPhiRodRadius << "*mm";
-            alg.parameters.push_back(numericParam(xml_radiusout, pconverter.str()));
-            pconverter.str("");
-            alg.parameters.push_back(numericParam(xml_zposition, "0.0*mm"));
-            pconverter.str(""); pconverter << numRods / 2;
-            alg.parameters.push_back(numericParam(xml_number, pconverter.str()));
-            pconverter.str("");
-            pconverter << forbiddenPhiLowerBIndex;
-            alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
-            alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-            a.push_back(alg);
-            pconverter.str("");
-            alg.parameters.clear();
           }
-          } // end fallback PhiAltAlgo
         }
       }
 
@@ -4247,55 +4147,6 @@ namespace insur {
       rot.phiz = 0.;
       storedRotations.insert(std::pair<std::string, Rotation>(rotationName, rot));
     }
-  } 
-
-
-
-  void Extractor::createAndStoreDDTrackerAngularAlgorithmBlock(std::vector<AlgoInfo>& storedAlgorithmBlocks,
-							       const std::string nameSpace, 
-							       const std::string parentName,
-							       const std::string childName,
-							       const double startAngleInRad,
-							       const double rangeAngleInRad,
-							       const double radius,
-							       const XYZVector& center,
-							       const int numCopies,
-							       const int startCopyNumber,
-							       const int copyNumberIncrement) {
-    AlgoInfo myAlgo; // would obviously be better to build the algo directly here instead of having a constructor with no argument!
-
-    // Algo name
-    myAlgo.name = xml_angular_algo;
-
-    // Parent volume name
-    myAlgo.parent = nameSpace + ":" + parentName;
-
-    // Child volume name
-    myAlgo.parameters.push_back(stringParam(xml_childparam, nameSpace + ":" + childName));
-	 
-    // Volume with copy number 1, center phi angle
-    myAlgo.parameters.push_back(numericParam(xml_startangle, any2str(startAngleInRad * 180. / M_PI, xml_angle_precision) + "*deg"));
-	 
-    // Difference between first and last volumes' centers phi angles
-    myAlgo.parameters.push_back(numericParam(xml_rangeangle, any2str(rangeAngleInRad * 180. / M_PI, xml_angle_precision) + "*deg"));
-
-    // All volumes are assumed to be placed at same radius in that algorithm
-    myAlgo.parameters.push_back(numericParam(xml_radius, any2str(radius) + "*mm"));
-
-    // Shift of children with respect to parent, AFTER rotation is done
-    myAlgo.parameters.push_back(vectorParam(center.X(), center.Y(), center.Z()));
-
-    // Number of children copies
-    myAlgo.parameters.push_back(numericParam(xml_nmods, any2str(numCopies)));
-	  
-    // Start copy number
-    myAlgo.parameters.push_back(numericParam(xml_startcopyno, any2str(startCopyNumber)));
-
-    // Copy number increment
-    myAlgo.parameters.push_back(numericParam(xml_incrcopyno, any2str(copyNumberIncrement)));
-
-    // Store algo
-    storedAlgorithmBlocks.push_back(myAlgo);
   }
 
 

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -20,6 +20,15 @@
 
 namespace insur {
 
+  static double vecTheta(const std::array<double, 3>& v) {
+    double z = std::max(-1.0, std::min(1.0, v[2]));
+    return std::acos(z) * (180.0 / M_PI);
+  }
+  static double vecPhi(const std::array<double, 3>& v) {
+    double p = std::atan2(v[1], v[0]) * (180.0 / M_PI);
+    return (p < 0.0) ? p + 360.0 : p;
+  }
+
   // Helper function to calculate and store the yaw-adjusted rotation for barrel modules
   static std::string getBarrelModuleRotation(std::map<std::string, Rotation>& r, bool isPixelTracker, bool isFlipped, double yaw) {
     // If there is no yaw, fallback to the standard static tags
@@ -63,18 +72,6 @@ namespace insur {
         ny_dir[i] = -sinY * x_dir[i] + cosY * y_dir[i];
     }
 
-    // Lambdas to convert Cartesian vectors back into CMSSW spherical coordinates
-    auto getTheta = [](const std::array<double, 3>& v) {
-        double z = v[2];
-        if (z > 1.0) z = 1.0;
-        if (z < -1.0) z = -1.0;
-        return std::acos(z) * (180.0 / M_PI);
-    };
-    auto getPhi = [](const std::array<double, 3>& v) {
-        double p = std::atan2(v[1], v[0]) * (180.0 / M_PI);
-        return (p < 0.0) ? p + 360.0 : p;
-    };
-
     // Construct a unique rotation name 
     std::ostringstream rotName;
     rotName << (isPixelTracker ? "PX" : "OT")
@@ -86,9 +83,9 @@ namespace insur {
     if (r.find(name) == r.end()) {
         Rotation rot;
         rot.name = name;
-        rot.thetax = getTheta(nx_dir); rot.phix = getPhi(nx_dir);
-        rot.thetay = getTheta(ny_dir); rot.phiy = getPhi(ny_dir);
-        rot.thetaz = getTheta(z_dir);  rot.phiz = getPhi(z_dir);
+        rot.thetax = vecTheta(nx_dir); rot.phix = vecPhi(nx_dir);
+        rot.thetay = vecTheta(ny_dir); rot.phiy = vecPhi(ny_dir);
+        rot.thetaz = vecTheta(z_dir);  rot.phiz = vecPhi(z_dir);
         r.insert(std::make_pair(name, rot));
     }
     return name;
@@ -1872,41 +1869,9 @@ namespace insur {
           return name;
         };
 
-        // NON-TILTED OT LAYERS: one DDTrackerXYZPosAlgo block per rod.
+        // One DDTrackerXYZPosAlgo block per rod (straight and tilted flat-part share the same loop).
         // copy number = phi index, matching the PhiAltAlgo convention.
-        // One-block-per-yaw-group with IncrCopyNo=numGroups was wrong: yaw groups are
-        // NOT uniformly interleaved in the real geometry (e.g. L1 has AA-BB-AA-BB pairs),
-        // so the arithmetic copy-number sequence would overlap or skip phi indices.
-        if (!isTilted && !otRodPlacementByPhiIdx.empty()) {
-        for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
-          const double yawDeg = std::round(data.yaw * 180.0 / M_PI);
-          const std::string& templateName = yawDegToTemplateName.at(yawDeg);
-          const std::string rotName = registerRodPhiRotation(data.centerPhi);
-          const std::string rotEntry = (rotName == "NULL") ? "NULL"
-                                                           : trackerXmlTags.nspace + ":" + rotName;
-          alg.name   = xml_xyzpos_algo;
-          alg.parent = trackerXmlTags.nspace + ":" + lname.str();
-          alg.parameters.push_back(stringParam(xml_childparam,
-                                               trackerXmlTags.nspace + ":" + templateName));
-          pconverter.str(""); pconverter << phiIdx;
-          alg.parameters.push_back(numericParam(xml_startcopyno, pconverter.str()));
-          alg.parameters.push_back(numericParam(xml_incrcopyno, "1"));
-          alg.parameters.push_back(arbitraryLengthVector("XPositions",
-              std::vector<double>{data.centerRadius * std::cos(data.centerPhi)}));
-          alg.parameters.push_back(arbitraryLengthVector("YPositions",
-              std::vector<double>{data.centerRadius * std::sin(data.centerPhi)}));
-          alg.parameters.push_back(arbitraryLengthVector("ZPositions",
-              std::vector<double>{0.0}));
-          alg.parameters.push_back(arbitraryLengthStringVector("Rotations",
-              std::vector<std::string>{rotEntry}));
-          a.push_back(alg);
-          alg.parameters.clear();
-        }
-        } // end !isTilted XYZPosAlgo path
-
-        // TILTED OT LAYERS: flat-part rods via DDTrackerXYZPosAlgo (per-rod blocks).
-        else if (isTilted) {
-          if (!otRodPlacementByPhiIdx.empty()) {
+        if (!otRodPlacementByPhiIdx.empty()) {
           for (const auto& [phiIdx, data] : otRodPlacementByPhiIdx) {
             const double yawDeg = std::round(data.yaw * 180.0 / M_PI);
             const std::string& templateName = yawDegToTemplateName.at(yawDeg);
@@ -1930,7 +1895,6 @@ namespace insur {
                 std::vector<std::string>{rotEntry}));
             a.push_back(alg);
             alg.parameters.clear();
-          }
           }
         }
       }
@@ -2185,22 +2149,11 @@ namespace insur {
                       Mat3 tiltCombined = isFlipped ? mult(rTilt, rFlip) : rTilt;
                       Mat3 globalRotMat = mult(mult(rPhi, tiltCombined), rYaw);
 
-                      auto getTheta = [](const std::array<double, 3>& v) {
-                          double z = v[2];
-                          if (z > 1.0) z = 1.;
-						  if (z < -1.0) z = -1.0;
-                          return std::acos(z) * 180.0 / M_PI;
-                      };
-                      auto getPhi = [](const std::array<double, 3>& v) {
-                          double p = std::atan2(v[1], v[0]) * 180.0 / M_PI;
-                          return (p < 0.0) ? p + 360.0 : p;
-                      };
-
                       Rotation rot;
                       rot.name = name;
-                      rot.thetax = getTheta(globalRotMat[0]); rot.phix = getPhi(globalRotMat[0]);
-                      rot.thetay = getTheta(globalRotMat[1]); rot.phiy = getPhi(globalRotMat[1]);
-                      rot.thetaz = getTheta(globalRotMat[2]); rot.phiz = getPhi(globalRotMat[2]);
+                      rot.thetax = vecTheta(globalRotMat[0]); rot.phix = vecPhi(globalRotMat[0]);
+                      rot.thetay = vecTheta(globalRotMat[1]); rot.phiy = vecPhi(globalRotMat[1]);
+                      rot.thetaz = vecTheta(globalRotMat[2]); rot.phiz = vecPhi(globalRotMat[2]);
                       
                       r.insert(std::make_pair(name, rot));
                   }
@@ -2317,6 +2270,38 @@ namespace insur {
    * @param t A reference to the collection of topology information; used for output
    * @param ri A reference to the collection of overall radiation and interaction lengths per layer or disc; used for output
    */
+  // Compute and cache an explicit endcap module rotation matching DDTrackerRingAlgo math.
+  // Captures only the rotation map; shared by analyseDiscs and analyseDiscsAndSubDiscs.
+  static std::string registerEndcapModuleRotation(std::map<std::string, Rotation>& r,
+                                                  double phi_deg, double yaw_deg,
+                                                  bool isZPlus, bool isFlipped) {
+    double norm_phi = std::fmod(phi_deg, 360.0);
+    if (norm_phi < 0.0) norm_phi += 360.0;
+    std::ostringstream rotName;
+    rotName << "EMod_Phi" << static_cast<int>(std::round(norm_phi * 10.0))
+            << "_Yaw"    << static_cast<int>(std::round(yaw_deg * 10.0))
+            << (isZPlus ? "_ZPlus" : "_ZMinus")
+            << (isFlipped ? "_Flipped" : "");
+    const std::string name = rotName.str();
+    if (r.find(name) == r.end()) {
+      double phix = 0.0, phiy = 0.0, thetaz = 0.0;
+      if (isZPlus) {
+        if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 0.0;   }
+        else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 180.0; }
+      } else {
+        if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg;         thetaz = 180.0; }
+        else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg;         thetaz = 0.0;   }
+      }
+      Rotation rot;
+      rot.name = name;
+      rot.thetax = 90.0; rot.phix = std::fmod(phix + 3600.0, 360.0);
+      rot.thetay = 90.0; rot.phiy = std::fmod(phiy + 3600.0, 360.0);
+      rot.thetaz = thetaz; rot.phiz = 0.0;
+      r.emplace(name, rot);
+    }
+    return name;
+  }
+
   void Extractor::analyseDiscs(MaterialTable& mt, std::vector<std::vector<ModuleCap> >& ec, Tracker& tr, XmlTags& trackerXmlTags,
                                std::vector<Composite>& c, std::vector<LogicalInfo>& l, std::vector<ShapeInfo>& s, std::vector<ShapeOperationInfo>& so,
 			       std::vector<PosInfo>& p, std::vector<AlgoInfo>& a, std::map<std::string,Rotation>& r, std::vector<SpecParInfo>& t, std::vector<RILengthInfo>& ri, bool wt) {
@@ -2892,58 +2877,6 @@ namespace insur {
             rspec.partselectors.push_back(logic.name_tag);
             rspec.moduletypes.push_back(minfo_zero);
 
-	    // Lambda to generate and cache explicit endcap module rotations matching DDTrackerRingAlgo math
-            auto registerEndcapModuleRotation = [&](double phi_deg, double yaw_deg, bool isZPlus, bool isFlipped) -> std::string {
-                // Normalize phi to 0-360 for consistent naming
-                double norm_phi = std::fmod(phi_deg, 360.0);
-                if (norm_phi < 0.0) norm_phi += 360.0;
-                
-                std::ostringstream rotName;
-                rotName << "EMod_Phi" << static_cast<int>(std::round(norm_phi * 10.0))
-                        << "_Yaw"   << static_cast<int>(std::round(yaw_deg * 10.0))
-                        << (isZPlus ? "_ZPlus" : "_ZMinus")
-                        << (isFlipped ? "_Flipped" : "");
-                
-                const std::string name = rotName.str();
-                if (r.find(name) == r.end()) {
-                    Rotation rot;
-                    rot.name = name;
-                    
-                    // Exact algebraic expansion of CMSSW's R_global = R_phi * R_tilt * R_flip * R_yaw
-                    // where tilt is 90 degrees for endcap rings.
-                    double phix = 0.0, phiy = 0.0, thetaz = 0.0;
-                    
-                    if (isZPlus) {
-                        if (!isFlipped) {
-                            phix = phi_deg + yaw_deg + 90.0;
-                            phiy = phi_deg + yaw_deg + 180.0;
-                            thetaz = 0.0;
-                        } else {
-                            phix = phi_deg + yaw_deg - 90.0;
-                            phiy = phi_deg + yaw_deg + 180.0;
-                            thetaz = 180.0;
-                        }
-                    } else { // isZMinus
-                        if (!isFlipped) {
-                            phix = phi_deg + yaw_deg + 90.0;
-                            phiy = phi_deg + yaw_deg;
-                            thetaz = 180.0;
-                        } else {
-                            phix = phi_deg + yaw_deg - 90.0;
-                            phiy = phi_deg + yaw_deg;
-                            thetaz = 0.0;
-                        }
-                    }
-
-                    // Keep values cleanly within 0-360 range
-                    rot.thetax = 90.0; rot.phix = std::fmod(phix + 3600.0, 360.0);
-                    rot.thetay = 90.0; rot.phiy = std::fmod(phiy + 3600.0, 360.0);
-                    rot.thetaz = thetaz; rot.phiz = 0.0;
-                    
-                    r.insert(std::make_pair(name, rot));
-                }
-                return name;
-            };
 
             // Lambda to emit 1-entry XYZPosAlgo blocks for a surface
             auto emitModulePlacement = [&](int startCopyNo, double surfaceZMid, bool isZPlus, bool isFlipped,
@@ -2957,9 +2890,7 @@ namespace insur {
                     double y = rad * std::sin(phi_rad);
                     double z = surfaceZMid - myRingInfo.zMid; 
 
-                    std::string rotName = registerEndcapModuleRotation(phis[i], yaws[i], isZPlus, isFlipped);
-                    // Endcap modules are never at identity orientation (always tilted 90 degrees), 
-                    // so we do not need the "NULL" fallback check used in the barrel.
+                    std::string rotName = registerEndcapModuleRotation(r, phis[i], yaws[i], isZPlus, isFlipped);
                     std::string rotEntry = trackerXmlTags.nspace + ":" + rotName;
 
                     alg.name = xml_xyzpos_algo;
@@ -3571,43 +3502,13 @@ namespace insur {
               rspec.partselectors.push_back(logic.name_tag);
               rspec.moduletypes.push_back(minfo_zero);
 
-	      // Emit one DDTrackerXYZPosAlgo block per module for this subdisk's surface.
-	      // Rotation formula: exact algebraic expansion of R_phi * R_tilt(90) * R_flip * R_yaw.
-	      auto registerEndcapModuleRotation = [&](double phi_deg, double yaw_deg, bool isZPlus, bool isFlipped) -> std::string {
-	        double norm_phi = std::fmod(phi_deg, 360.0);
-	        if (norm_phi < 0.0) norm_phi += 360.0;
-	        std::ostringstream rotName;
-	        rotName << "EMod_Phi" << static_cast<int>(std::round(norm_phi * 10.0))
-	                << "_Yaw"    << static_cast<int>(std::round(yaw_deg * 10.0))
-	                << (isZPlus ? "_ZPlus" : "_ZMinus")
-	                << (isFlipped ? "_Flipped" : "");
-	        const std::string name = rotName.str();
-	        if (r.find(name) == r.end()) {
-	          double phix = 0.0, phiy = 0.0, thetaz = 0.0;
-	          if (isZPlus) {
-	            if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 0.0; }
-	            else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg + 180.0; thetaz = 180.0; }
-	          } else {
-	            if (!isFlipped) { phix = phi_deg + yaw_deg + 90.0; phiy = phi_deg + yaw_deg;         thetaz = 180.0; }
-	            else            { phix = phi_deg + yaw_deg - 90.0; phiy = phi_deg + yaw_deg;         thetaz = 0.0; }
-	          }
-	          Rotation rot;
-	          rot.name = name;
-	          rot.thetax = 90.0; rot.phix = std::fmod(phix + 3600.0, 360.0);
-	          rot.thetay = 90.0; rot.phiy = std::fmod(phiy + 3600.0, 360.0);
-	          rot.thetaz = thetaz; rot.phiz = 0.0;
-	          r.insert(std::make_pair(name, rot));
-	        }
-	        return name;
-	      };
-
 	      const int sdPhiParity = sdIndex % 2; // 1 = odd phi (SD1), 0 = even phi (SD2)
 	      const auto& ringModules = modulesByRingPhi[ringIndex];
 	      for (const auto& [phiIdx, modData] : ringModules) {
 	        if (phiIdx % 2 != sdPhiParity) continue;
 	        const double phi_rad = modData.phi_deg * M_PI / 180.0;
 	        const std::string rotName = registerEndcapModuleRotation(
-	          modData.phi_deg, modData.yaw_deg, myRingInfo.isDiskAtPlusZEnd, modData.isFlipped);
+	          r, modData.phi_deg, modData.yaw_deg, myRingInfo.isDiskAtPlusZEnd, modData.isFlipped);
 	        alg.name = xml_xyzpos_algo;
 	        alg.parent = logic.shape_tag;
 	        alg.parameters.push_back(stringParam(xml_childparam, trackerXmlTags.nspace + ":" + myRingInfo.childname));

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -3738,6 +3738,13 @@ namespace insur {
       matname << xml_base_serfcomp << "R" << (int)(iter->getInnerRadius()) << "Z" << (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0));
       shapename << xml_base_serf << "R" << (int)(iter->getInnerRadius()) << "Z" << (int)(fabs(iter->getZOffset() + iter->getZLength() / 2.0));
       if ((iter->getZOffset() + iter->getZLength()) > 0 ) {
+        if (iter->getRWidth() <= 0) {
+          std::stringstream msg;
+          msg << shapename.str() << " has non-positive rWidth=" << iter->getRWidth()
+	      << ". Skipping (problem upstream in Materialway section building)." << std::ends;
+          logWARNING(msg.str());
+          continue;
+        }
         if ( iter->getLocalMasses().size() ) {
           c.push_back(createComposite(matname.str(), compositeDensity(*iter), *iter));
 

--- a/src/Extractor.cc
+++ b/src/Extractor.cc
@@ -4438,27 +4438,6 @@ namespace insur {
 
   
 
-  const double ModuleComplexHelpers::computeExpandedModWidth(const double moduleWidth, 
-							     const double serviceHybridWidth, 
-							     const double deadAreaExtraWidth,
-							     const double chipNegativeXExtraWidth,
-							     const double chipPositiveXExtraWidth) {
-    const double totalServiceHybridWidth = 2. * serviceHybridWidth; // OT case
-    const double totalDeadAreaExtraWidth = 2. * deadAreaExtraWidth; // IT case: around sensor
-    const double totalChipExtraWidth = 2. * MAX(chipNegativeXExtraWidth, chipPositiveXExtraWidth); // IT case: around chip
-    const double expandedModWidth = moduleWidth + totalServiceHybridWidth + MAX(totalDeadAreaExtraWidth, totalChipExtraWidth);
-    return expandedModWidth;
-  }
-
-  const double ModuleComplexHelpers::computeExpandedModLength(const double moduleLength, 
-							      const double frontEndHybridWidth, 
-							      const double deadAreaExtraLength) {
-    const double totalFrontEndHybridWidth = 2. * frontEndHybridWidth; // OT case
-    const double totalDeadAreaExtraLength = 2.* deadAreaExtraLength;  // IT case
-    const double expandedModLength = moduleLength + totalFrontEndHybridWidth + totalDeadAreaExtraLength;
-    return expandedModLength;
-  }
-
 
 
 
@@ -4491,32 +4470,32 @@ namespace insur {
                                                              hybridLeftAndRightVolume_mm3(-1.),
 							     deadAreaTotalVolume_mm3(-1.),
                                                              moduleMassWithoutSensors_expected(0.),
-                                                             expandedModWidth(ModuleComplexHelpers::computeExpandedModWidth(modWidth, 
+                                                             expandedModWidth(DetectorModule::computeExpandedModWidth(modWidth,
 															    serviceHybridWidth, 
 															    deadAreaExtraWidth,
 															    chipNegativeXExtraWidth,
 															    chipPositiveXExtraWidth)
 									      ),
 		      
-                                                             expandedModLength(ModuleComplexHelpers::computeExpandedModLength(modLength,
+                                                             expandedModLength(DetectorModule::computeExpandedModLength(modLength,
 															      frontEndHybridWidth,
 															      deadAreaExtraLength)
 									       ),
-                                                             expandedModLengthPixDoubleSens(ModuleComplexHelpers::computeExpandedModLength(modLengthDoubleSens,
+                                                             expandedModLengthPixDoubleSens(DetectorModule::computeExpandedModLength(modLengthDoubleSens,
 															      frontEndHybridWidth,
 															      deadAreaExtraLength)
 									       ),
 							     center(module.center()),
                                                              normal(module.normal()),
                                                              prefix_material(xml_hybrid_comp) {
+    expandedModThickness = DetectorModule::computeExpandedModThickness(module.isPixelModule(),
+        module.isTimingModule(), sensorDistance, sensorThickness, supportPlateThickness,
+        chipThickness, hybridThickness);
     if (!module.isPixelModule()) {
-      if (!module.isTimingModule()) expandedModThickness = sensorDistance + 2.0 * (supportPlateThickness + sensorThickness);
-      else expandedModThickness = sensorThickness + 2.0 * MAX(supportPlateThickness, hybridThickness);
       prefix_xmlfile = xml_fileident + ":";
       nTypes = 9;
     }
     else {
-      expandedModThickness = sensorThickness + 2.0 * MAX(chipThickness, hybridThickness);
       prefix_xmlfile = xml_PX_fileident + ":";
       nTypes = 11;
     }
@@ -4856,7 +4835,7 @@ namespace insur {
     //
     // Module polygon
     //   top view
-    //   v1                v2
+    //   v1                v0
     //    *---------------*
     //    |       ^ my    |
     //    |       |   mx  |
@@ -4864,8 +4843,7 @@ namespace insur {
     //    |     center    |
     //    |               |
     //    *---------------*
-    //   v0                v3
-    //  (v4)
+    //   v2                v3
     //
     //   side view
     //    ----------------- top
@@ -4878,43 +4856,20 @@ namespace insur {
     vector<double> ratzminv; // radius list (in global frame of reference) at zmin from which we will find min/max.
     vector<double> ratzmaxv; // radius list (in global frame of reference) at zmax from which we will find min/max.
 
-    // mx: (v2+v3)/2 - center, my: (v1+v2)/2 - center
-    XYZVector mx = (0.5*( module.basePoly().getVertex(2) + module.basePoly().getVertex(3) ) - center).Unit() ;
-    XYZVector my = (0.5*( module.basePoly().getVertex(1) + module.basePoly().getVertex(2) ) - center).Unit() ;
+    const auto allPoints = CoordinateOperations::boundingBoxCandidates(
+        center, XYZVector(module.getLocalX() * expandedModWidth * 0.5),
+        XYZVector(module.getLocalY() * expandedModLength * 0.5), normal * expandedModThickness * 0.5);
 
-    // new vertexes after expansion due to hybrid volumes
-    const int npoints = 5; // v0,v1,v2,v3,v4(=v0)
-    XYZVector v[npoints-1];
-    v[0] = module.center() - expandedModWidth/2. * mx - expandedModLength/2. * my;
-    v[1] = module.center() - expandedModWidth/2. * mx + expandedModLength/2. * my;
-    v[2] = module.center() + expandedModWidth/2. * mx + expandedModLength/2. * my;
-    v[3] = module.center() + expandedModWidth/2. * mx - expandedModLength/2. * my;
-    /*if(module.numSensors()==2){
-        v[0] = module.center() - expandedModWidth/2. * mx - expandedModLengthPixDoubleSens/2. * my;
-        v[1] = module.center() - expandedModWidth/2. * mx + expandedModLengthPixDoubleSens/2. * my;
-        v[2] = module.center() + expandedModWidth/2. * mx + expandedModLengthPixDoubleSens/2. * my;
-        v[3] = module.center() + expandedModWidth/2. * mx - expandedModLengthPixDoubleSens/2. * my;
-    }*/
+    // Keep the top/bottom corner points (indices i*4 and i*4+1) for the debug vertex dump.
+    for (std::size_t i = 0; i < 4; ++i) {
+      vertex.push_back(allPoints[i*4]);
+      vertex.push_back(allPoints[i*4 + 1]);
+    }
 
-    // Calculate all vertex candidates (8 points)
-    XYZVector v_top[npoints];    // module's top surface
-    XYZVector v_bottom[npoints]; // module's bottom surface
-
-    for (int ip = 0; ip < npoints-1; ip++) {
-      v_top[ip]    = v[ip] + 0.5*expandedModThickness*normal;
-      v_bottom[ip] = v[ip] - 0.5*expandedModThickness*normal;
-
-      // for debuging
-      vertex.push_back(v_top[ip]);
-      vertex.push_back(v_bottom[ip]);
-
-      // Calculate xmin, xmax, ymin, ymax, zmin, zmax
-      xv.push_back(v_top[ip].X());
-      xv.push_back(v_bottom[ip].X());
-      yv.push_back(v_top[ip].Y());
-      yv.push_back(v_bottom[ip].Y());
-      zv.push_back(v_top[ip].Z());
-      zv.push_back(v_bottom[ip].Z());
+    for (const auto& pt : allPoints) {
+      xv.push_back(pt.X());
+      yv.push_back(pt.Y());
+      zv.push_back(pt.Z());
     }
     // Find min and max
     xmin = *std::min_element(xv.begin(), xv.end());
@@ -4924,61 +4879,10 @@ namespace insur {
     zmin = *std::min_element(zv.begin(), zv.end());
     zmax = *std::max_element(zv.begin(), zv.end());
 
-
-    // Calculate module's mid-points (8 points)
-    XYZVector v_mid_top[npoints]; // module's top surface mid-points
-    XYZVector v_mid_bottom[npoints]; // module's bottom surface mid-points
-
-    v_top[npoints-1] = v_top[0]; // copy v0 as v4 for convenience
-    v_bottom[npoints-1] = v_bottom[0]; // copy v0 as v4 for convenience
-
-    for (int ip = 0; ip < npoints-1; ip++) {
-      v_mid_top[ip] = (v_top[ip] + v_top[ip+1]) / 2.0;
-      v_mid_bottom[ip] = (v_bottom[ip] + v_bottom[ip+1]) / 2.0;
-    }
-
-    // Calculate rmin, rmax, rminatzmin, rmaxatzmax...
-    for (int ip = 0; ip < npoints-1; ip++) {
-
-      // module's bottom surface
-      if (fabs(v_bottom[ip].Z() - zmin) < 0.001) {
-	v_bottom[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_bottom[ip].R());
-      }
-      if (fabs(v_bottom[ip].Z() - zmax) < 0.001) {
-	v_bottom[ip].SetZ(0.); // projection to xy plan.
-	ratzmaxv.push_back(v_bottom[ip].R());
-      }
-      v_bottom[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_bottom[ip].R());
-
-      // module's top surface
-      if (fabs(v_top[ip].Z() - zmin) < 0.001) {
-	v_top[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_top[ip].R());
-      }
-      if (fabs(v_top[ip].Z() - zmax) < 0.001) {
-	v_top[ip].SetZ(0.); // projection to xy plan.
-	ratzmaxv.push_back(v_top[ip].R());
-      }
-      v_top[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_top[ip].R());
-    
-      // module's bottom surface mid-points
-      if (fabs(v_mid_bottom[ip].Z() - zmin) < 0.001) {
-	v_mid_bottom[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_mid_bottom[ip].R());
-      }
-      v_mid_bottom[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_mid_bottom[ip].R());
-    
-      // module's top surface mid-points
-      if (fabs(v_mid_top[ip].Z() - zmin) < 0.001) {
-	v_mid_top[ip].SetZ(0.); // projection to xy plan.
-	ratzminv.push_back(v_mid_top[ip].R());
-      }
-      v_mid_top[ip].SetZ(0.); // projection to xy plan.
-      rv.push_back(v_mid_top[ip].R());
+    for (const auto& pt : allPoints) {
+      rv.push_back(pt.Rho());
+      if (std::fabs(pt.Z() - zmin) < 0.001) ratzminv.push_back(pt.Rho());
+      if (std::fabs(pt.Z() - zmax) < 0.001) ratzmaxv.push_back(pt.Rho());
     }
     // Find min and max
     rmin = *std::min_element(rv.begin(), rv.end());

--- a/src/GeometricModule.cc
+++ b/src/GeometricModule.cc
@@ -153,11 +153,13 @@ void RectangularModule::build() {
       iContourPoint++;
     }
 
-    float l = length(), w = width();
-    basePoly_ << XYZVector( l/2, w/2, 0)
-              << XYZVector(-l/2, w/2, 0)
-              << XYZVector(-l/2,-w/2, 0)
-              << XYZVector( l/2,-w/2, 0);
+    double w_2 = 0.5 * width();
+    double l_2 = 0.5 * length();
+    basePoly_ << XYZVector( w_2,  l_2, 0.)
+              << XYZVector(-w_2,  l_2, 0.)
+              << XYZVector(-w_2, -l_2, 0.)
+              << XYZVector( w_2, -l_2, 0.);
+
     cleanup();
     builtok(true);
   }

--- a/src/Materialway.cc
+++ b/src/Materialway.cc
@@ -945,6 +945,15 @@ namespace material {
           int sectionMaxZ = sectionMinZ + sectionWidth;
           //int sectionMaxR = discretize(disk.maxRwithHybrids()) + diskSectionUpMargin;
           int sectionMaxR = section->minR() - safetySpace - layerStationLenght;
+	  if (sectionMaxR <= sectionMinR) {
+	    logERROR(Form("Disk service routing: sectionMaxR (%d) <= sectionMinR (%d) "
+			 "(disk minR=%.1f mm, horizontal rail minR=%.1f mm). "
+			 "Not enough radial clearance for the conversion station. "
+			 "sectionMaxR clamped to sectionMinR.",
+			 sectionMaxR, sectionMinR,
+			 undiscretize(sectionMinR), undiscretize(section->minR())));
+	    sectionMaxR = sectionMinR;
+	  }
 
 	  // DEE VOLUMES (1 disk = 2 dees)
 	  // TO DO: move this to tuneable disk properties.

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -107,6 +107,9 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
     auto center = mod->center();
     mod->translate(-center);
 
+    // Initial global position
+    mod->rotateZ(M_PI_2);
+
     const bool shouldFlip = (!isRingOn4Dees() 
                              ? (parity < 0)                // Two-sided Dees: modules on small |Z| side are flipped
                              : isSmallerAbsZRingInDisk()); // Four Dees: all modules in the inner ring are flipped

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -104,7 +104,7 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
     mod->myid(i+1);
 
     // Execute transformations around the module's local axes
-    const auto& center = mod->center();
+    auto center = mod->center();
     mod->translate(-center);
 
     const bool shouldFlip = (!isRingOn4Dees() 
@@ -127,13 +127,12 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
     }
 
     // Restore original position and move away from the beamline
-    if ((yawAngle != 0.) && (mod->manualRhoCentre() > 0.)) {
-      mod->translateR(mod->manualRhoCentre());
+    center += XYZVector(modTranslateX, 0., 0.);
+    // For irregular rings, the module centre is shifted
+    if (mod->manualRhoCentre() > 0.) {
+      center += center.Unit() * (mod->manualRhoCentre() - center.Rho());
     }
-    else {
-      mod->translate(center);
-      mod->translate(XYZVector(modTranslateX, 0., 0.));
-    }
+    mod->translate(center);
 
     if (mod->manualPhiCenter.state() && mod->manualPhiCenterDeg.state())
       logWARNING("A module was set both manualPhiCenter and manualPhiCenterDeg. Only the former will be considered");

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -101,36 +101,44 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
 
     EndcapModule* mod = GeometryFactory::clone(*templ);
     mod->build();
-    mod->translate(XYZVector(modTranslateX, 0, 0));
     mod->myid(i+1);
 
-    double yawAngle = 0;
-    bool doYaw = false;
+    // Execute transformations around the module's local axes
+    const auto& center = mod->center();
+    mod->translate(-center);
+
+    const bool shouldFlip = (!isRingOn4Dees() 
+                             ? (parity < 0)                // Two-sided Dees: modules on small |Z| side are flipped
+                             : isSmallerAbsZRingInDisk()); // Four Dees: all modules in the inner ring are flipped
+    mod->flipped(shouldFlip);
+
+    // Calculate yaw angle
+    double yawAngle = 0.;
     if (mod->yawAngleFromConfig.state()) {
-      doYaw = true;
       mod->notInRegularRing();
       yawAngle = mod->yawAngleFromConfig();
     }
     if (mod->yawFlip()) {
-      doYaw = true;
       yawAngle += M_PI;
     }
-
-    if (doYaw) {
-      double rho_center = mod->center().Rho();
-
-      mod->translateR(-rho_center);
+    // Apply yaw
+    if (yawAngle != 0.) {
       mod->yaw(yawAngle);
+    }
 
-      if (mod->manualRhoCentre() > 0)
-        mod->translateR(mod->manualRhoCentre());
-      else
-        mod->translateR(rho_center);
+    // Restore original position and move away from the beamline
+    if ((yawAngle != 0.) && (mod->manualRhoCentre() > 0.)) {
+      mod->translateR(mod->manualRhoCentre());
+    }
+    else {
+      mod->translate(center);
+      mod->translate(XYZVector(modTranslateX, 0., 0.));
     }
 
     if (mod->manualPhiCenter.state() && mod->manualPhiCenterDeg.state())
       logWARNING("A module was set both manualPhiCenter and manualPhiCenterDeg. Only the former will be considered");
 
+    // Shift around phi (global Z)
     double nominalZRot = 0.;
     if (mod->manualPhiCenter.state()) {
       nominalZRot = mod->manualPhiCenter();
@@ -152,16 +160,11 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
       if (nominalZRot >= M_PI)
         nominalZRot += diffPhi;
     }
-
     mod->rotateZ(nominalZRot + zRotation());
+
     mod->translateZ(parity * smallDelta);
     mod->setIsSmallerAbsZModuleInRing(parity < 0);
 
-    const bool isFlipped = (!isRingOn4Dees() 
-                            ? (parity < 0)                // Two-sided Dees: modules on small |Z| side are flipped
-                            : isSmallerAbsZRingInDisk()); // Four Dees: all modules in the inner ring are flipped
-
-    mod->flipped(isFlipped);
     modules_.push_back(mod);
   }
 

--- a/src/Ring.cc
+++ b/src/Ring.cc
@@ -170,6 +170,10 @@ void Ring::buildModules(EndcapModule* templ, int numMods, double smallDelta, dou
     modules_.push_back(mod);
   }
 
+  sortModulesByIncreasingPhi();
+}
+
+void Ring::sortModulesByIncreasingPhi() {
   // Sort the modules in increasing phi and set their IDs
   modules_.sort([](const EndcapModule& mod_a, const EndcapModule& mod_b) {
     // femod handles small differences in phi in module placement
@@ -300,6 +304,8 @@ void Ring::rotateToNegativeZSide() {
   for (auto& m : modules_) {
     m.rotateToNegativeZSide();
   }
+
+  sortModulesByIncreasingPhi();
 }
 
 /** This computes the actual coverage in Phi of a disk (after it is built).

--- a/src/RodPair.cc
+++ b/src/RodPair.cc
@@ -358,11 +358,23 @@ void StraightRodPair::buildModules(Container& modules, const RodTemplate& rodTem
       mod->myid(i+1);
     }
     mod->side(side);
-    mod->translateR(parity > 0 ? smallDelta() : -smallDelta());
-    if (smallDelta() != 0) { mod->flipped(parity != 1); } // When smallDelta() != 0, the flip is alternated.
-    else { mod->flipped(!isPlusBigDeltaRod); } // When smallDelta() == 0, the flip only depends whether the rod is located at + BigDelta or at - BigDelta.
-    mod->translateZ(posList[i] + (direction == BuildDir::RIGHT ? mod->length()/2 : -mod->length()/2));
-    // mod->translate(XYZVector(parity > 0 ? smallDelta() : -smallDelta(), 0, posList[i])); // CUIDADO: we are now translating the center instead of an edge as before
+
+    // Execute transformations around the module's local axes
+    const auto& center = mod->center();
+    mod->translate(-center);
+
+    const bool shouldFlip = (smallDelta() != 0)
+                             ? (parity != 1)        // When smallDelta() != 0, the flip is alternated
+                             : !isPlusBigDeltaRod;  // Otherwise, the flip depends whether the rod is located at + or - BigDelta
+    mod->flipped(shouldFlip);
+    mod->rotateX(mod->isPixelModule() ? -M_PI_2 : M_PI_2);
+
+    const double rOffset = (parity > 0) ? smallDelta() : -smallDelta();
+    mod->translateR(rOffset);
+
+    const double zOffset = (direction == BuildDir::RIGHT) ? (mod->length() * 0.5) : (-mod->length() * 0.5);
+    mod->translateZ(posList[i] + zOffset);
+
     modules.push_back(mod);
   }
 }
@@ -471,15 +483,13 @@ void TiltedRodPair::buildModules(Container& modules, const RodTemplate& rodTempl
   if (direction == BuildDir::LEFT && fabs(tmspecs[0].z) < 0.5) { i = 1; it++; } // this skips the first module if we're going left (i.e. neg rod) and z=0 because it means the pos rod has already got a module there
   for (; i < (int)tmspecs.size(); i++, ++it) {
     bool isTiltedModule = (tmspecs[i].gamma == 0);
-    //std::cout << "i = " << i << std::endl;
-    //std::cout << "tmspecs[i].r = " << tmspecs[i].r << std::endl;
-    //std::cout << "tmspecs[i].z = " << tmspecs[i].z << std::endl;
     BarrelModule* mod = GeometryFactory::make<BarrelModule>(**it);
     mod->myid(i+1);
     mod->side(side);
     mod->store(propertyTree());
     if (mod->yawFlip() && (side==1)) mod->rotateXModCentre(M_PI);
     if (mod->yawFlipNeg() && (side==-1)) mod->rotateXModCentre(M_PI);
+    mod->rotateXModCentre(M_PI_2);
     // Use the yawFlipRods only for the tilted part
     if (isTiltedModule)
       for (auto& iRod : mod->yawFlipRods)

--- a/src/RodPair.cc
+++ b/src/RodPair.cc
@@ -360,14 +360,25 @@ void StraightRodPair::buildModules(Container& modules, const RodTemplate& rodTem
     mod->side(side);
 
     // Execute transformations around the module's local axes
-    const auto& center = mod->center();
+    const auto center = mod->center();
     mod->translate(-center);
 
     const bool shouldFlip = (smallDelta() != 0)
                              ? (parity != 1)        // When smallDelta() != 0, the flip is alternated
                              : !isPlusBigDeltaRod;  // Otherwise, the flip depends whether the rod is located at + or - BigDelta
-    mod->flipped(shouldFlip);
+
+    const bool shouldYaw = (mod->yawFlip() && (side == 1)) || (mod->yawFlipNeg() && (side == -1));
+
+    // Initial global orientation with skew
+    if (shouldYaw)
+      mod->yaw(M_PI);
+    mod->rotateY(M_PI_2 - mod->skewAngle());
     mod->rotateX(mod->isPixelModule() ? -M_PI_2 : M_PI_2);
+
+    mod->flipped(shouldFlip);
+
+    // Restore the original position
+    mod->translate(center);
 
     const double rOffset = (parity > 0) ? smallDelta() : -smallDelta();
     mod->translateR(rOffset);
@@ -428,12 +439,6 @@ void StraightRodPair::buildFull(const RodTemplate& rodTemplate, bool isPlusBigDe
     }
   }
 
-  // yawFlipping as last thing
-  for (auto& it : zPlusModules_)
-    if (it.yawFlip()) it.rotateXModCentre(M_PI);
-  for (auto& it : zMinusModules_)
-    if (it.yawFlipNeg()) it.rotateXModCentre(M_PI);
-
   currMaxZ = zPlusModules_.size() > 1 ? MAX(zPlusModules_.rbegin()->planarMaxZ(), (zPlusModules_.rbegin()+1)->planarMaxZ()) : (!zPlusModules_.empty() ? zPlusModules_.rbegin()->planarMaxZ() : 0.);
   maxZ(currMaxZ);
 }
@@ -482,27 +487,42 @@ void TiltedRodPair::buildModules(Container& modules, const RodTemplate& rodTempl
   int i = 0;
   if (direction == BuildDir::LEFT && fabs(tmspecs[0].z) < 0.5) { i = 1; it++; } // this skips the first module if we're going left (i.e. neg rod) and z=0 because it means the pos rod has already got a module there
   for (; i < (int)tmspecs.size(); i++, ++it) {
-    bool isTiltedModule = (tmspecs[i].gamma == 0);
     BarrelModule* mod = GeometryFactory::make<BarrelModule>(**it);
     mod->myid(i+1);
     mod->side(side);
     mod->store(propertyTree());
-    if (mod->yawFlip() && (side==1)) mod->rotateXModCentre(M_PI);
-    if (mod->yawFlipNeg() && (side==-1)) mod->rotateXModCentre(M_PI);
-    mod->rotateXModCentre(M_PI_2);
-    // Use the yawFlipRods only for the tilted part
-    if (isTiltedModule)
-      for (auto& iRod : mod->yawFlipRods)
-        if (iRod == myid()) mod->rotateXModCentre(M_PI);
-    mod->tilt(side * tmspecs[i].gamma);
-    mod->translateR(tmspecs[i].r);
-    if (isTiltedModule) { // FLAT PART OF THE TILTED ROD
+
+    // Execute transformations around the module's local axes
+    const auto center = mod->center();
+    mod->translate(-center);
+
+    const double tiltAngle = side * tmspecs[i].gamma;
+    const bool isTiltedModule = tiltAngle != 0.;
+
+    bool shouldYaw = (mod->yawFlip() && (side == 1)) || (mod->yawFlipNeg() && (side == -1));
+    for (const auto& iRod : mod->yawFlipRods)
+      shouldYaw = (iRod == myid()) ? !shouldYaw : shouldYaw;
+
+    // Initial global orientation with skew
+    if (shouldYaw)
+      mod->yaw(M_PI);
+    mod->rotateY(M_PI_2 - mod->skewAngle());
+    mod->rotateX(M_PI_2);
+
+    if (isTiltedModule) {
+      mod->tilt(tiltAngle);
+      mod->flipped(flip);
+    }
+    else { // FLAT PART OF THE TILTED ROD
       if (!mod->isPixelModule()) mod->flipped(i%2);         // Rod in Outer Tracker: alternates flip along z. i is the ring number.
       else mod->flipped(flip);                              // Rod in Inner Tracker: all modules of a given rod have same flip. 
                                                             // (Modules of the lower radius rods are all flipped).
-    } 
-    else { mod->flipped(flip); } // TILTED PART OF THE TILTED ROD
+    }
+
+    mod->translate(center);
+    mod->translateR(tmspecs[i].r);
     mod->translateZ(side * tmspecs[i].z);
+
     modules.push_back(mod);
   }
 }

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -1,6 +1,9 @@
 #include "Sensor.hh"
 #include "DetectorModule.hh"
 
+#include <memory>
+#include <Math/Vector3Dfwd.h>
+
 void Sensor::check() {
   PropertyObject::check();
   
@@ -10,50 +13,70 @@ void Sensor::check() {
   if (numSegments.state() && stripLengthEstimate.state()) throw PathfulException("Only one between numSegments and stripLengthEstimate can be specified");
 }
 
-double Sensor::sensorNormalOffset() const {
-  double offset;
-  if (parent_->numSensors() <= 1) offset = 0.;
-  else {
-    if (myid() == 1) offset = -parent_->dsDistance()/2.;
-    else offset = parent_->dsDistance()/2.;
-  }
-  return offset;
-}
-
-double Sensor::sensorXOffset() const {
-  double offset;
-  if (parent_->numSensors() <= 1) offset = 0.;
-  else {
-    if (myid() == 1) offset = -parent_->offsetForSensors();
-    else offset = parent_->offsetForSensors();
-  }
-  return offset;
-}
-
-
 const Polygon3d<4>& Sensor::hitPoly() const {
   if (hitPoly_) return *hitPoly_;
-  double offset = sensorNormalOffset();
-  hitPoly_ = CoordinateOperations::computeTranslatedPolygon(parent_->basePoly(), offset);
-  // Special case for split-sensor modules: sensor's polygon is reduced and shifted along local Y
-  if (parent_->numSensors() == 2 && parent_->sensorLayout() == SensorLayout::MONO) {
-    const XYZVector unitY(parent_->getLocalY());
 
-    // Resizing the sensor polygon wrt the module polygon, accounting for the dead space between sensors
-    double moduleLength = parent_->length();
-    double deadLength = parent_->centralDeadAreaLength();
-    double sensorLength = moduleLength / parent_->numSensors() - deadLength / 2.;
-    Polygon3d<4> *poly = CoordinateOperations::computeResizedPolygon(*hitPoly_, unitY, sensorLength/moduleLength);
+  const int numSensors = parent_->numSensors();
 
-    // UPPER sensor is shifted up in the *local* Y direction
+  const Polygon3d<4>& basePoly = parent_->basePoly();
+
+  // Single-sensor module, no offset and/or polygon resizing required
+  if (numSensors <= 1) {
+    if (numSensors <= 0)
+      logWARNING("Sensor::hitPoly Warning: DetectorModule::numSensors() <= 0");
+    hitPoly_ = new Polygon3d<4>(basePoly);
+  }
+
+  // Special case for split-sensor modules
+  else if (numSensors == 2 && parent_->sensorLayout() == SensorLayout::MONO) {
+    // Account for the dead space between sensors when resizing the module polygon
+    const double moduleLength = parent_->length();
+    const double deadLength   = parent_->centralDeadAreaLength();
+    const double sensorLength = moduleLength / numSensors - 0.5 * deadLength;
+    const double scaleFactor  = sensorLength / moduleLength;
+
+    // Module center and unit local Y
+    const ROOT::Math::XYZVector moduleCenter = parent_->center();
+    const ROOT::Math::XYZVector localY = (basePoly.getVertex(0) - basePoly.getVertex(3)).Unit();
+
+    // Translate the sensor along the local Y
     double offsetY = (moduleLength - sensorLength) * 0.5;
     offsetY = (innerOuter() == SensorPosition::UPPER) ? offsetY : -offsetY;
+    ROOT::Math::XYZVector sensorCenter = moduleCenter + offsetY * localY;
 
-    // Apply the shift along the local Y direction and update the polygon
-    poly->translate(unitY*offsetY);
-    delete hitPoly_;
-    hitPoly_ = poly;
+    // Resize the Y-length of the module polygon
+    std::unique_ptr<Polygon3d<4>> newPoly = std::make_unique<Polygon3d<4>>();
+    for (const ROOT::Math::XYZVector* vtx = basePoly.begin(); vtx != basePoly.end(); ++vtx) {
+      // Distance vector from the module center to the vertex
+      ROOT::Math::XYZVector d = *vtx - moduleCenter;
+
+      // Projection of "d" along the local Y
+      ROOT::Math::XYZVector projY = d.Dot(localY) * localY;
+
+      // Start with original "d", subtract the original Y, and add the scaled Y
+      ROOT::Math::XYZVector scaledVtx = d + projY * (scaleFactor - 1.0);
+
+      // Update the vertex position and add it to the new polygon
+      *newPoly << (sensorCenter + scaledVtx);
+    }
+
+    hitPoly_ = newPoly.release();
   }
+
+  // General 3D module case
+  else {
+    // Calculate the translation along the local Z
+    double offsetZ = 0.5 * parent_->dsDistance();
+    offsetZ = (innerOuter() == SensorPosition::UPPER) ? offsetZ : -offsetZ;
+    ROOT::Math::XYZVector extentZ = offsetZ * parent_->normal();
+
+    // Apply the translation
+    std::unique_ptr<Polygon3d<4>> newPoly = std::make_unique<Polygon3d<4>>(basePoly);
+    newPoly->translate(extentZ);
+
+    hitPoly_ = newPoly.release();
+  }
+
   return *hitPoly_;
 }
 

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7387,6 +7387,8 @@ void Vizard::drawArrowCross(double x, double y,const TVector3& locX,const TVecto
 
 
   void Vizard::drawAxesAndNameXY(const Module* aModule, double yScale, bool endcap=true) {
+    constexpr double vizEpsilon = 1e-12; // Floating-point rounding guard
+
     const auto& locX = aModule->getLocalX();
     const auto& locY = aModule->getLocalY();
     // Z axis
@@ -7402,12 +7404,8 @@ void Vizard::drawArrowCross(double x, double y,const TVector3& locX,const TVecto
     TArrow* xArrow = new TArrow(center.X(), center.Y(),
                                 center.X() + arrow_length_x * locX.X(), center.Y() + arrow_length_x * locX.Y(),
                                 arrow_size, arrow_option);
-    TArrow* yArrow = new TArrow(center.X(), center.Y(),
-                                center.X() + arrow_length_y * locY.X(), center.Y() + arrow_length_y * locY.Y(),
-                                arrow_size, arrow_option);
-    TArrow* zArrow = new TArrow(center.X(), center.Y(),
-                                center.X() + arrow_length_x * locZ.X(), center.Y() + arrow_length_x * locZ.Y(),
-                                arrow_size, arrow_option);
+    TArrow* yArrow = nullptr;
+    TArrow* zArrow = nullptr;
 
 #ifdef only_plot_plank_modules_facing_outwards
     TVector3 startZ(center.X(), center.Y(), center.Z());
@@ -7421,10 +7419,16 @@ void Vizard::drawArrowCross(double x, double y,const TVector3& locX,const TVecto
     xArrow->SetFillColor(kRed);
     xArrow->Draw();
     if (endcap) {
+      yArrow = new TArrow(center.X(), center.Y(),
+                          center.X() + arrow_length_y * locY.X(), center.Y() + arrow_length_y * locY.Y(),
+                          arrow_size, arrow_option);
       yArrow->SetLineColor(kBlue);
       yArrow->SetFillColor(kBlue);
       yArrow->Draw();
     } else {
+      zArrow = new TArrow(center.X(), center.Y(),
+                          center.X() + arrow_length_x * locZ.X(), center.Y() + arrow_length_x * locZ.Y(),
+                          arrow_size, arrow_option);
       zArrow->SetLineColor(kGreen+2);
       zArrow->SetFillColor(kGreen+2);
       zArrow->Draw();
@@ -7432,9 +7436,9 @@ void Vizard::drawArrowCross(double x, double y,const TVector3& locX,const TVecto
 
     // Z axis symbol
     const double zSymbolSize = std::max(arrow_length_x, arrow_length_y) / 5;
-    if (locZ.Z() > 0) {
+    if (locZ.Z() > vizEpsilon) {
       drawArrowDot(center.X(), center.Y(), zSymbolSize, kGreen + 2);
-    } else if (locZ.Z() < 0) {
+    } else if (locZ.Z() < -vizEpsilon) {
       drawArrowCross(center.X(), center.Y(), locX, locY, zSymbolSize, kGreen + 2);
     }
 


### PR DESCRIPTION
This PR introduces refactorings to the underlying module placement logic, improves code safety, simplifies orientation calculations, and updates the TBPS v8.0.7 configuration file layout.

The main goal of these changes is to align polygon local-to-global coordinate operations, as well as align the orientation of the exported XMLs with the internal tkLayout geometry descriptions.

This fixes #666.

---

# Core Geometry & Rotations

* **Local Axes Alignment**: Reordered module transformations so that rotations around local axes are executed first. Derived local axes directly from the vertex winding sequence in `RectangularModule::build`.
* **Yaw and Orientation Fixes**: Adjusted yawed barrel modules to rotate about the local $Z$ axis instead of the local $X$ axis. Reordered local $X$ and $Y$ rotations, and isolated initial global orientation logic outside of `Barrel/EndcapModule::build`.
* **ROOT Rotations**: Replaced custom `RotateX/Y/Z` template structures inside `AbstractPolygon` with standard `ROOT::Math::Rotation3D` components (`RotationX/Y/Z`).
* **Data Types**: Converted member variables tracking tilt and skew angles in `GeometricModule` from `int` to `double`.

# Sensor Logic & Memory Safety

* **`Sensor::hitPoly` Refactor**: Simplified 3D module geometry tracking by projecting, scaling, and translating vertices along local axes, eliminating polygon math helpers. Safer memory management using `std::unique_ptr`.
* **Extrema Calculations**: Re-factored `DetectorModule::extremaWithHybrids()` to use the new orientation logic. Replaced direct base polygon access with explicit `getLocalX()`, `getLocalY()`, and `normal()` abstraction calls.
* **Shared Bounding-Box Geometry**: Extracted the hybrid-expanded bounding-box candidate-point construction into `CoordinateOperations::boundingBoxCandidates()`, shared by `extremaWithHybrids()` and `ModuleComplex`. Moved the expanded width/length/thickness formulas onto `DetectorModule` as static helpers consumed by both call sites; removed the duplicated `ModuleComplexHelpers`.
* **Line Intersections**: Updated the filter within `Polygon3d<NumSides>::isLineIntersecting` to properly register hits regardless of the polygon's normal vector's direction.

# Extractor & XML Export

## DDTrackerXYZPosAlgo Migration

All subdetectors now use per-module `DDTrackerXYZPosAlgo` placement blocks, replacing the phi-based (`DDTrackerPhiAltAlgo`) and ring-based (`DDTrackerRingAlgo`, `DDTrackerIrregularRingAlgo`) algorithms that could not represent per-module yaw variation.

* **OT Straight Barrel**: Each rod gets its own one-entry `XYZPosAlgo` block with explicit X/Y/Z positions and a registered rotation matrix. Rod center radius is computed as the average of ring-1 and ring-2 module $\rho$ per $\phi$ index, cancelling the ±`smallDelta` stagger offset. Secondary rod logical volumes are created for each distinct yaw state.
* **OT Tilted Barrel Rings**: Each module gets a one-entry `XYZPosAlgo` block; the rotation matrix is computed using an embedded 3×3 matrix engine and mapped back to spherical (`thetax`/`phix`) angles for the `DDrot` convention.
* **OT Endcap**: The pre-pass unconditionally collects X, Y, Z, and yaw for all modules. The rotation matrix is an exact algebraic expansion of $R_\phi \cdot R_\text{tilt} \cdot R_\text{flip} \cdot R_\text{yaw}$ at a fixed 90° tilt, correctly handling the local Z/Y axis sign inversions for $-Z$ and flipped modules.
* **IT Barrel**: Emits one `XYZPosAlgo` block per ladder; rotations registered via `getBarrelModuleRotation()`.
* **IT Endcap**: A pre-pass indexed by `[ring][phi]` collects position and yaw for each module; subdisk loops emit one block per module with rotations registered via `registerEndcapModuleRotation()`.

Legacy placement algorithms and their associated constants and helper functions have been removed.

## Extractor Refactoring

* **Dynamic Barrel Module Rotation**: Added the `getBarrelModuleRotation` function, which calculates a barrel module's Euler angles based on Z-axis yaw and dynamically registers uniquely named rotation tags into the XML export map.
* **Duplicated Code**: Merged duplicate OT straight-rod and flat-part rod placement loops into a single block.
* **Degenerate Service Volume Guard**: Service components with non-positive `rWidth` are now skipped with a warning instead of emitting an invalid shape; in disk service routing, `sectionMaxR` is clamped to `sectionMinR` (with an error log) when radial clearance is insufficient for the conversion station.

# Bug Fixes

* **Endcap Module Placement**: Fixed a bug where `manualRhoCentre` was ignored based on a module's yaw angle.
* **Endcap DetId ($-Z$ side)**: The $-Z$ endcap is cloned from $+Z$ by rotating each module 180° in yaw, mapping $\phi \to \pi - \phi$. `phiIdentifier` was not recalculated after this rotation, producing wrong DetId assignments in TEPX disks. Added `Ring::sortModulesByIncreasingPhi()` called from `rotateToNegativeZSide()` to re-order $-Z$ modules by their updated $\phi$ values before identifiers are assigned. Removed the incomplete $1 + ((3N/2 - \text{phiRef}) \;\%\; N)$ compensation formula from `EndcapDetIdBuilder`.
* **IT Endcap Yaw Sign**: In `Ring::buildModules`, `yaw()` and the phi-placement `rotateZ` are adjacent rotations about the global $Z$ axis, composing as $R_z(\phi + \text{yaw})$ regardless of flip state. The previous code applied $-\text{yaw}$ in the `ZPlus/Flipped` and `ZMinus/!Flipped` cases, introducing up to ~0.3 rad of yaw error for some IT Endcap modules. All four cases in `registerEndcapModuleRotation` now use $+\text{yaw}$.

# Visualization

* **Vizard**: Added floating-point rounding guards (`vizEpsilon`) to `Vizard::drawAxesAndNameXY` to suppress precision loss layout glitches.

# Configuration Files

* **TBPS v8.0.7**: Correctly mapped `yawFlipRods` parameters to flat module sections inside `TBPS_V807.cfg`. Moved `smallDelta` and `placeRadiusHint` options under the `FULL LAYER` block.
